### PR TITLE
fix: When no results are found, do not render useless headings

### DIFF
--- a/apps/bestofjs-nextjs/src/components/search-palette/search-palette.tsx
+++ b/apps/bestofjs-nextjs/src/components/search-palette/search-palette.tsx
@@ -149,9 +149,9 @@ export function SearchPalette({ allProjects, allTags }: SearchProps) {
     });
   };
 
-  const isEmptyProjects = filteredProjects.length == 0,
-    isEmptyTags = filteredTags.length == 0,
-    isEmptySearchResults = isEmptyProjects && isEmptyTags;
+  const isEmptyProjects = filteredProjects.length == 0;
+  const isEmptyTags = filteredTags.length == 0;
+  const isEmptySearchResults = isEmptyProjects && isEmptyTags;
 
   return (
     <>

--- a/apps/bestofjs-nextjs/src/components/search-palette/search-palette.tsx
+++ b/apps/bestofjs-nextjs/src/components/search-palette/search-palette.tsx
@@ -149,6 +149,10 @@ export function SearchPalette({ allProjects, allTags }: SearchProps) {
     });
   };
 
+  const isEmptyProjects = filteredProjects.length == 0,
+    isEmptyTags = filteredTags.length == 0,
+    isEmptySearchResults = isEmptyProjects && isEmptyTags;
+
   return (
     <>
       <Button
@@ -192,8 +196,10 @@ export function SearchPalette({ allProjects, allTags }: SearchProps) {
               </div>
             )}
             <CommandList>
-              <CommandEmpty>No results found.</CommandEmpty>
-              {searchQuery.length > 0 && (
+              {isEmptySearchResults && (
+                <CommandEmpty>No results found.</CommandEmpty>
+              )}
+              {searchQuery.length > 0 && !isEmptyProjects && (
                 <CommandGroup heading="Projects">
                   {filteredProjects.slice(0, 10).map((project) => (
                     <div
@@ -272,9 +278,9 @@ export function SearchPalette({ allProjects, allTags }: SearchProps) {
                   )}
                 </CommandGroup>
               )}
-              <CommandGroup heading="Tags">
-                {filteredTags.length > 0 ? (
-                  filteredTags.slice(0, 20).map((tag) => (
+              {!isEmptyTags && (
+                <CommandGroup heading="Tags">
+                  {filteredTags.slice(0, 20).map((tag) => (
                     <CommandItem
                       key={tag.code}
                       value={"tag/" + tag.code}
@@ -290,11 +296,9 @@ export function SearchPalette({ allProjects, allTags }: SearchProps) {
                         </div>
                       </div>
                     </CommandItem>
-                  ))
-                ) : (
-                  <div className="py-6 text-center text-sm">No tag found</div>
-                )}
-              </CommandGroup>
+                  ))}
+                </CommandGroup>
+              )}
             </CommandList>
           </>
         )}


### PR DESCRIPTION

# Fix 1:
## Goal
When I search for something that doesn't exist in projects and tags, I should not see the `Tags` and `Projects` headers.

## How to test

1. Open the search menu
2. Search for something that doesn't exist.
3. Confirm only `''No results found.''` renders in the results area.

## Screenshots

Error case:
![image](https://github.com/bestofjs/bestofjs/assets/2955134/79171227-d2cd-496b-a908-cb1bd51624a5)

Fixed:

![image](https://github.com/bestofjs/bestofjs/assets/2955134/9450efe2-b273-4c49-90d8-affd8f91e06d)


![image](https://github.com/bestofjs/bestofjs/assets/2955134/3c2ddb08-e097-404b-ba82-ab66c8477c15)
