### PR TITLE
Try Vercel analytics for Next.js app

### DIFF
--- a/apps/bestofjs-nextjs/package.json
+++ b/apps/bestofjs-nextjs/package.json
@@ -30,6 +30,7 @@
     "@types/fs-extra": "^11.0.1",
     "@types/lodash": "^4.14.195",
     "@types/numeral": "^2.0.2",
+    "@vercel/analytics": "^1.0.1",
     "class-variance-authority": "^0.4.0",
     "clsx": "^1.2.1",
     "cmdk": "^0.2.0",

--- a/apps/bestofjs-nextjs/src/app/layout.tsx
+++ b/apps/bestofjs-nextjs/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import "@/app/globals.css";
 import { Metadata } from "next";
+import { Analytics } from "@vercel/analytics/react";
 
 import { APP_DISPLAY_NAME } from "@/config/site";
 import { fontSans } from "@/lib/fonts";
@@ -52,6 +53,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
             </div>
             <TailwindIndicator />
           </ThemeProvider>
+          <Analytics />
         </body>
       </html>
     </>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,7 @@ importers:
       '@types/react': ^18.2.7
       '@types/react-dom': ^18.2.4
       '@typescript-eslint/parser': ^5.59.7
+      '@vercel/analytics': ^1.0.1
       autoprefixer: ^10.4.14
       class-variance-authority: ^0.4.0
       clsx: ^1.2.1
@@ -67,6 +68,7 @@ importers:
       '@types/fs-extra': 11.0.1
       '@types/lodash': 4.14.196
       '@types/numeral': 2.0.2
+      '@vercel/analytics': 1.0.1
       class-variance-authority: 0.4.0_typescript@4.9.5
       clsx: 1.2.1
       cmdk: 0.2.0_ea5oonu4gon5qt6dhkzotww2vm
@@ -3685,6 +3687,10 @@ packages:
       '@typescript-eslint/types': 5.62.0
       eslint-visitor-keys: 3.4.2
     dev: true
+
+  /@vercel/analytics/1.0.1:
+    resolution: {integrity: sha512-Ux0c9qUfkcPqng3vrR0GTrlQdqNJ2JREn/2ydrVuKwM3RtMfF2mWX31Ijqo1opSjNAq6rK76PwtANw6kl6TAow==}
+    dev: false
 
   /@vitejs/plugin-react/2.2.0_vite@3.2.7:
     resolution: {integrity: sha512-FFpefhvExd1toVRlokZgxgy2JtnBOdp4ZDsq7ldCWaqGSGn9UhWMAVm/1lxPL14JfNS5yGz+s9yFrQY6shoStA==}


### PR DESCRIPTION
## Goal

It would be nice to get data about the traffic and the pages visited by users, without compromising user's privacy and without introducing heavy scripts in the client.

Now that we have more server-centric application, it should run on the server, ideally.

Let's try Vercel Analytics: https://vercel.com/docs/concepts/analytics/quickstart

Unfortunately it's not a server-side only solution:

> If everything is set up properly, you should be able to see a Fetch/XHR request in your browser's Network tab from /_vercel/insights/view when you visit any page

Related: #105 
