### PR TITLE
Improve dark mode design on beta

### DIFF
--- a/apps/bestofjs-nextjs/src/app/globals.css
+++ b/apps/bestofjs-nextjs/src/app/globals.css
@@ -51,7 +51,8 @@
     --popover: 240 10% 3.9%;
     --popover-foreground: 0 0% 98%;
 
-    --primary: 0 0% 98%;
+    /* --primary: 0 0% 98%; */
+    --primary: 25 100% 70%;
     --primary-foreground: 240 5.9% 10%;
 
     --secondary: 240 3.7% 15.9%;

--- a/apps/bestofjs-nextjs/src/app/globals.css
+++ b/apps/bestofjs-nextjs/src/app/globals.css
@@ -45,13 +45,14 @@
     --background: 240 10% 3.9%;
     --foreground: 0 0% 98%;
 
-    --card: 240 10% 3.9%;
+    /* Less dark cards to make them stand up from the black bg (original: 240 10% 3.9%) */
+    --card: 240 10% 15%;
     --card-foreground: 0 0% 98%;
 
     --popover: 240 10% 3.9%;
     --popover-foreground: 0 0% 98%;
 
-    /* --primary: 0 0% 98%; */
+    /* Setup orange as the primary color instead of 0 0% 98% */
     --primary: 25 100% 70%;
     --primary-foreground: 240 5.9% 10%;
 
@@ -61,13 +62,15 @@
     --muted: 240 3.7% 15.9%;
     --muted-foreground: 240 5% 64.9%;
 
-    --accent: 240 3.7% 15.9%;
+    /* Increase contrast when tags are hovered (original L=15.9%) */
+    --accent: 240 3.7% 20%;
     --accent-foreground: 0 0% 98%;
 
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 85.7% 97.3%;
 
-    --border: 240 3.7% 15.9%;
+    /* Increase the contrast of border as we use a less dark bg for cards (original L=15.9%) */
+    --border: 240 3.7% 25%;
     --input: 240 3.7% 15.9%;
     --ring: 240 4.9% 83.9%;
 

--- a/apps/bestofjs-nextjs/src/app/globals.css
+++ b/apps/bestofjs-nextjs/src/app/globals.css
@@ -42,38 +42,33 @@
   }
 
   .dark {
-    --background: 224 71% 4%;
-    --foreground: 213 31% 91%;
+    --background: 240 10% 3.9%;
+    --foreground: 0 0% 98%;
 
-    --muted: 223 47% 11%;
-    --muted-foreground: 215.4 16.3% 56.9%;
+    --card: 240 10% 3.9%;
+    --card-foreground: 0 0% 98%;
 
-    --accent: 216 34% 17%;
-    --accent-foreground: 210 40% 98%;
+    --popover: 240 10% 3.9%;
+    --popover-foreground: 0 0% 98%;
 
-    --popover: 224 71% 4%;
-    --popover-foreground: 215 20.2% 65.1%;
+    --primary: 0 0% 98%;
+    --primary-foreground: 240 5.9% 10%;
 
-    --border: 216 34% 27%;
-    --input: 216 34% 17%;
+    --secondary: 240 3.7% 15.9%;
+    --secondary-foreground: 0 0% 98%;
 
-    --card: 224 71% 4%;
-    --card-foreground: 213 31% 91%;
+    --muted: 240 3.7% 15.9%;
+    --muted-foreground: 240 5% 64.9%;
 
-    /* --primary: 210 40% 98%; */
-    /* orange6 from Radix instead of "SeaSalt" light gray */
-    --primary: 25 100% 82.8%;
-    --primary-foreground: 222.2 47.4% 1.2%;
+    --accent: 240 3.7% 15.9%;
+    --accent-foreground: 0 0% 98%;
 
-    --secondary: 222.2 47.4% 11.2%;
-    --secondary-foreground: 210 40% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 0 85.7% 97.3%;
 
-    --destructive: 0 63% 31%;
-    --destructive-foreground: 210 40% 98%;
-
-    --ring: 216 34% 17%;
-
-    --radius: 0.5rem;
+    --border: 240 3.7% 15.9%;
+    --input: 240 3.7% 15.9%;
+    --ring: 240 4.9% 83.9%;
 
     --graphBackgroundColor1: #9c4221;
     --graphBackgroundColor2: #7b341e;

--- a/apps/bestofjs-nextjs/src/app/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/page.tsx
@@ -51,7 +51,7 @@ export default async function IndexPage() {
       </div>
 
       <div className="flex flex-col gap-8 lg:flex-row">
-        <div className="grow space-y-6">
+        <div className="grow space-y-8">
           <HotProjectList projects={hotProjects} />
 
           <NewestProjectList projects={newestProjects} />

--- a/apps/bestofjs-nextjs/src/components/core/section.tsx
+++ b/apps/bestofjs-nextjs/src/components/core/section.tsx
@@ -10,12 +10,12 @@ type Props = {
 };
 export const SectionHeading = ({ className, icon, title, subtitle }: Props) => {
   return (
-    <div className={cn("flex items-center font-mono", className)}>
+    <div className={cn("flex items-center", className)}>
       {icon && (
         <div className="pr-2 text-yellow-500 dark:text-yellow-600">{icon}</div>
       )}
       <div className="grow">
-        <h2 className="text-2xl">{title}</h2>
+        <h2 className="text-2xl font-mono">{title}</h2>
         {subtitle && (
           <div className="uppercase text-muted-foreground">{subtitle}</div>
         )}

--- a/apps/bestofjs-nextjs/src/components/core/section.tsx
+++ b/apps/bestofjs-nextjs/src/components/core/section.tsx
@@ -10,9 +10,9 @@ type Props = {
 };
 export const SectionHeading = ({ className, icon, title, subtitle }: Props) => {
   return (
-    <div className={cn("flex items-center", className)}>
+    <div className={cn("flex items-center font-mono", className)}>
       {icon && (
-        <div className="pr-2 text-yellow-500 dark:text-yellow-400">{icon}</div>
+        <div className="pr-2 text-yellow-500 dark:text-yellow-600">{icon}</div>
       )}
       <div className="grow">
         <h2 className="text-2xl">{title}</h2>

--- a/apps/bestofjs-nextjs/src/components/header/desktop-nav.tsx
+++ b/apps/bestofjs-nextjs/src/components/header/desktop-nav.tsx
@@ -29,7 +29,7 @@ export function MainNav() {
           <Icons.logo
             width={130}
             height={37.15}
-            className="h-[37.15px] w-[130px] text-orange-600 dark:text-yellow-400"
+            className="h-[37.15px] w-[130px] text-primary"
           />
         </Link>
         <nav className="flex gap-6">

--- a/apps/bestofjs-nextjs/src/components/project-list/project-table.tsx
+++ b/apps/bestofjs-nextjs/src/components/project-list/project-table.tsx
@@ -75,7 +75,7 @@ const ProjectTableRow = ({
 
       <Cell className="w-auto py-4 pl-4 md:pl-2">
         <div className="relative flex items-center space-x-2">
-          <NextLink href={path} className="hover:underline">
+          <NextLink href={path} className="hover:underline font-mono">
             {project.name}
           </NextLink>
           <div className="flex space-x-1">
@@ -114,7 +114,7 @@ const ProjectTableRow = ({
           </div>
         </div>
 
-        <div className="mb-3 mt-2 space-y-2 text-sm">
+        <div className="mb-4 mt-2 space-y-2 text-sm">
           <div>{project.description}</div>
           {showDetails && (
             <>

--- a/apps/bestofjs-nextjs/src/components/project-list/project-table.tsx
+++ b/apps/bestofjs-nextjs/src/components/project-list/project-table.tsx
@@ -75,7 +75,10 @@ const ProjectTableRow = ({
 
       <Cell className="w-auto py-4 pl-4 md:pl-2">
         <div className="relative flex items-center space-x-2">
-          <NextLink href={path} className="hover:underline font-mono">
+          <NextLink
+            href={path}
+            className="hover:underline font-mono text-primary"
+          >
             {project.name}
           </NextLink>
           <div className="flex space-x-1">

--- a/apps/bestofjs-nextjs/src/components/tags/project-tag.tsx
+++ b/apps/bestofjs-nextjs/src/components/tags/project-tag.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import NextLink from "next/link";
 
+import { cn } from "@/lib/utils";
 import { badgeVariants } from "@/components/ui/badge";
 // import { MdAdd } from "react-icons/md";
 import { ProjectSearchQuery, SearchUrlBuilder } from "@/app/projects/types";
@@ -40,7 +41,10 @@ export const ProjectTag = ({
     : `/projects?tags=${tag.code}`;
 
   return (
-    <NextLink href={url} className={badgeVariants({ variant: "secondary" })}>
+    <NextLink
+      href={url}
+      className={cn(badgeVariants({ variant: "secondary" }), "text-sm")}
+    >
       {tag.name}
     </NextLink>
   );

--- a/apps/bestofjs-nextjs/src/components/tags/project-tag.tsx
+++ b/apps/bestofjs-nextjs/src/components/tags/project-tag.tsx
@@ -43,7 +43,10 @@ export const ProjectTag = ({
   return (
     <NextLink
       href={url}
-      className={cn(badgeVariants({ variant: "secondary" }), "text-sm")}
+      className={cn(
+        badgeVariants({ variant: "outline" }),
+        "px-3 py-1 text-sm rounded-sm font-normal hover:bg-accent"
+      )}
     >
       {tag.name}
     </NextLink>

--- a/apps/bestofjs-nextjs/src/components/ui/badge.tsx
+++ b/apps/bestofjs-nextjs/src/components/ui/badge.tsx
@@ -1,7 +1,7 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
   "inline-flex items-center border rounded-full px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
@@ -21,7 +21,7 @@ const badgeVariants = cva(
       variant: "default",
     },
   }
-)
+);
 
 export interface BadgeProps
   extends React.HTMLAttributes<HTMLDivElement>,
@@ -30,7 +30,7 @@ export interface BadgeProps
 function Badge({ className, variant, ...props }: BadgeProps) {
   return (
     <div className={cn(badgeVariants({ variant }), className)} {...props} />
-  )
+  );
 }
 
-export { Badge, badgeVariants }
+export { Badge, badgeVariants };

--- a/apps/bestofjs-nextjs/src/components/ui/card.tsx
+++ b/apps/bestofjs-nextjs/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "-mx-4 border-y bg-card text-card-foreground shadow-sm sm:mx-0 sm:rounded-lg sm:border",
+      "-mx-4 border-y bg-card text-card-foreground shadow-sm sm:mx-0 sm:rounded-md sm:border",
       className
     )}
     {...props}

--- a/apps/bestofjs-nextjs/tailwind.config.js
+++ b/apps/bestofjs-nextjs/tailwind.config.js
@@ -9,7 +9,7 @@ module.exports = {
       center: true,
       padding: "2rem",
       screens: {
-        "2xl": "1064px", // set 1000px as the mas content width (taking into account the spacing 2 x 32px)
+        "2xl": "1064px", // set 1000px as the max content width (taking into account the spacing 2 x 32px)
       },
     },
     extend: {

--- a/apps/bestofjs-nextjs/tailwind.config.js
+++ b/apps/bestofjs-nextjs/tailwind.config.js
@@ -9,7 +9,7 @@ module.exports = {
       center: true,
       padding: "2rem",
       screens: {
-        "2xl": "1200px",
+        "2xl": "1064px", // set 1000px as the mas content width (taking into account the spacing 2 x 32px)
       },
     },
     extend: {


### PR DESCRIPTION
## Goal

Following the great [feedback](https://github.com/bestofjs/bestofjs/issues/176#issuecomment-1668896120) we got on GitHub, it's time to spend some time improving the design of the dark mode!

- Black background instead of the blueish one
- Make cards less dark to make them more and decrease the high contrast between dark background and white text
- More visible links inside project tables (orange + mono font)
- More visible tags inside the project tables
- Decrease max page width to match the current version (`1000px`)
- Make the logo orange for consistency
- Use more the mono font for some links and titles, to get a more "high tech" touch

## Screenshots

It's only the 1st iteration, to be continued...

![image](https://github.com/bestofjs/bestofjs/assets/5546996/6c09ca40-7470-4247-a671-221e69d127d0)


