### PR TITLE
Handle `isFeatured` flag to select "Featured projects"

### DIFF
--- a/apps/bestofjs-webui/src/global.d.ts
+++ b/apps/bestofjs-webui/src/global.d.ts
@@ -22,6 +22,7 @@ declare namespace BestOfJS {
     npm: string;
     downloads: number;
     icon: string;
+    isFeatured: boolean;
   }
 
   // Project handled in the state container

--- a/apps/bestofjs-webui/src/selectors/projects-selectors.ts
+++ b/apps/bestofjs-webui/src/selectors/projects-selectors.ts
@@ -112,8 +112,7 @@ export const getFeaturedProjects = (criteria) =>
     [allProjects, (state) => state.entities.tags, (state) => state.auth],
     (projects, tags, auth) => {
       const featured = projects
-        .filter((project) => !!project.icon)
-        .filter((project) => project.stars > 1000)
+        .filter((project) => project.isFeatured)
         .map(getFullProject(tags, auth));
       const projectSelector = getProjectSelectorByKey(criteria);
       return sortProjects(projectSelector)(featured);


### PR DESCRIPTION
## Goal

In the backend, a status option "featured" was added to be able to detect the projects considered as "Featured":
 https://github.com/bestofjs/bestofjs-backend/commit/21ed1533e9048d3284d1a57dffcfbe9f96684a9d
 
Before we were only relying on the existence of a specific icon for the project, which was not great as we want the ability to setup a custom icon without making the project "Featured".

Note: there is no specific criteria to make a project "Featured" we only want highlight a subset of important projects.
There are currently 237 projects showing up, I'm cleaning up up to try to make this  number close to 200.

Related PR for the beta version: https://github.com/bestofjs/bestofjs/pull/184


## Screenshots

### Before

![image](https://github.com/bestofjs/bestofjs/assets/5546996/36b04b7e-ad69-43a8-8287-ff3ec8e8a988)


### After

![image](https://github.com/bestofjs/bestofjs/assets/5546996/8fcab2a1-8e4b-4e01-81a1-54672e94304f)
