### PR TITLE
Add Hall of Fame page to beta version

### DIFF
--- a/apps/bestofjs-nextjs/src/app/backend.ts
+++ b/apps/bestofjs-nextjs/src/app/backend.ts
@@ -267,7 +267,7 @@ export function createSearchClient() {
       const populateMemberProjects = (member: BestOfJS.RawHallOfFameMember) => {
         const projects: BestOfJS.Project[] = member.projects
           .map((projectSlug) => projectsBySlug[projectSlug])
-          .filter(Boolean) // needed as some members are linked to deprecated projects. TODO fix Hall fo fame data?
+          .filter(Boolean) // needed as some members are linked to deprecated projects. TODO fix Hall of fame data?
           .map(populate);
         return {
           ...member,

--- a/apps/bestofjs-nextjs/src/app/hall-of-fame/hall-of-member-list.tsx
+++ b/apps/bestofjs-nextjs/src/app/hall-of-fame/hall-of-member-list.tsx
@@ -51,7 +51,8 @@ function HallOfFameMember({ member }: { member: BestOfJS.HallOfFameMember }) {
                   badgeVariants({ variant: "outline" }),
                   "text-md",
                   "rounded-sm",
-                  "hover:bg-accent"
+                  "hover:bg-accent",
+                  "font-normal"
                 )}
               >
                 {project.name}

--- a/apps/bestofjs-nextjs/src/app/hall-of-fame/hall-of-member-list.tsx
+++ b/apps/bestofjs-nextjs/src/app/hall-of-fame/hall-of-member-list.tsx
@@ -1,0 +1,70 @@
+import Image from "next/image";
+import NextLink from "next/link";
+import numeral from "numeral";
+
+import { cn } from "@/lib/utils";
+import { badgeVariants } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+
+type Props = {
+  members: BestOfJS.HallOfFameMember[];
+};
+export function HallOfFameMemberList({ members }: Props) {
+  return (
+    <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
+      {members.map((member) => (
+        <HallOfFameMember key={member.username} member={member} />
+      ))}
+    </div>
+  );
+}
+
+function HallOfFameMember({ member }: { member: BestOfJS.HallOfFameMember }) {
+  return (
+    <Card className="sm:rounded-none">
+      <div className="flex border-b">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={`${member.avatar}&s=150`}
+          width="100"
+          height="100"
+          alt={member.username}
+          className="display-block"
+        />
+        <div className="flex flex-1 flex-col justify-center p-4">
+          <div className="text-xl">{member.name}</div>
+          <div className="text-muted-foreground">{member.username}</div>
+          <div className="text-secondary-foreground">
+            {formatNumber(member.followers)} followers
+          </div>
+        </div>
+      </div>
+      <div className="divide-y">
+        {member.bio && <div className="p-4">{member.bio}</div>}
+        {member.projects.length > 0 && (
+          <div className="flex flex-wrap gap-2 p-4">
+            {member.projects.map((project) => (
+              <NextLink
+                key={project.slug}
+                href={`/projects/${project.slug}`}
+                className={cn(
+                  badgeVariants({ variant: "outline" }),
+                  "text-md",
+                  "rounded-sm",
+                  "hover:bg-accent"
+                )}
+              >
+                {project.name}
+              </NextLink>
+            ))}
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+function formatNumber(value: number) {
+  const digitsFormat = value > 1000 ? "0.0 a" : "0 a";
+  return numeral(value).format(digitsFormat);
+}

--- a/apps/bestofjs-nextjs/src/app/hall-of-fame/hall-of-member-list.tsx
+++ b/apps/bestofjs-nextjs/src/app/hall-of-fame/hall-of-member-list.tsx
@@ -1,9 +1,11 @@
 import Image from "next/image";
 import NextLink from "next/link";
 import numeral from "numeral";
+import { GoMarkGithub } from "react-icons/go";
 
 import { cn } from "@/lib/utils";
 import { badgeVariants } from "@/components/ui/badge";
+import { buttonVariants } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 
 type Props = {
@@ -25,14 +27,31 @@ function HallOfFameMember({ member }: { member: BestOfJS.HallOfFameMember }) {
       <div className="flex border-b">
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
-          src={`${member.avatar}&s=150`}
+          src={`${member.avatar}&s=100`}
           width="100"
           height="100"
           alt={member.username}
-          className="display-block"
+          className="display-block h-[100px] w-[100px]"
         />
-        <div className="flex flex-1 flex-col justify-center p-4">
-          <div className="text-xl">{member.name}</div>
+        <div className="flex flex-1 flex-col justify-center px-4">
+          <div className="flex items-center gap-2">
+            <span className="text-xl">{member.name}</span>
+            <a
+              href={`https://github.com/${member.username}`}
+              aria-label="GitHub repository"
+              rel="noopener noreferrer"
+              target="_blank"
+              className={cn(
+                buttonVariants({ variant: "ghost" }),
+                "rounded-full",
+                "w-10",
+                "h-10",
+                "p-0"
+              )}
+            >
+              <GoMarkGithub size={24} />
+            </a>
+          </div>
           <div className="text-muted-foreground">{member.username}</div>
           <div className="text-secondary-foreground">
             {formatNumber(member.followers)} followers

--- a/apps/bestofjs-nextjs/src/app/hall-of-fame/hall-of-member-list.tsx
+++ b/apps/bestofjs-nextjs/src/app/hall-of-fame/hall-of-member-list.tsx
@@ -1,12 +1,10 @@
-import Image from "next/image";
 import NextLink from "next/link";
 import numeral from "numeral";
-import { GoMarkGithub } from "react-icons/go";
 
 import { cn } from "@/lib/utils";
 import { badgeVariants } from "@/components/ui/badge";
-import { buttonVariants } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { ProjectAvatar } from "@/components/core";
 
 type Props = {
   members: BestOfJS.HallOfFameMember[];
@@ -24,7 +22,7 @@ export function HallOfFameMemberList({ members }: Props) {
 function HallOfFameMember({ member }: { member: BestOfJS.HallOfFameMember }) {
   return (
     <Card className="sm:rounded-none">
-      <div className="flex border-b">
+      <div className="flex items-center border-b">
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           src={`${member.avatar}&s=100`}
@@ -33,28 +31,18 @@ function HallOfFameMember({ member }: { member: BestOfJS.HallOfFameMember }) {
           alt={member.username}
           className="display-block h-[100px] w-[100px]"
         />
-        <div className="flex flex-1 flex-col justify-center px-4">
-          <div className="flex items-center gap-2">
+        <div className="flex flex-1 flex-col justify-center gap-2 px-4">
+          <div className="flex items-center">
             <span className="text-xl">{member.name}</span>
+          </div>
+          <div className="text-muted-foreground">
             <a
               href={`https://github.com/${member.username}`}
-              aria-label="GitHub repository"
-              rel="noopener noreferrer"
-              target="_blank"
-              className={cn(
-                buttonVariants({ variant: "ghost" }),
-                "rounded-full",
-                "w-10",
-                "h-10",
-                "p-0"
-              )}
+              className="font-mono text-primary hover:underline"
             >
-              <GoMarkGithub size={24} />
-            </a>
-          </div>
-          <div className="text-muted-foreground">{member.username}</div>
-          <div className="text-secondary-foreground">
-            {formatNumber(member.followers)} followers
+              {member.username}
+            </a>{" "}
+            on GitHub
           </div>
         </div>
       </div>
@@ -74,6 +62,9 @@ function HallOfFameMember({ member }: { member: BestOfJS.HallOfFameMember }) {
                   "font-normal"
                 )}
               >
+                {project.icon && (
+                  <ProjectAvatar project={project} size={20} className="mr-2" />
+                )}
                 {project.name}
               </NextLink>
             ))}

--- a/apps/bestofjs-nextjs/src/app/hall-of-fame/loading.tsx
+++ b/apps/bestofjs-nextjs/src/app/hall-of-fame/loading.tsx
@@ -1,0 +1,39 @@
+import { Card } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { PageHeading } from "@/components/core/typography";
+
+const memberNames = ["Evan", "Dan", "Sindre", "Ryan", "Kent", "TJ"];
+
+export default function HallOfFameLoading() {
+  return (
+    <>
+      <PageHeading
+        title={<>JavaScript Hall of Fame</>}
+        subtitle={
+          <>
+            Loading the greatest developers, authors and speakers of the
+            JavaScript community...
+            <br />
+            {memberNames.join(", ")}... and many more!
+          </>
+        }
+      />
+      <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
+        {memberNames.map((name) => (
+          <Card key={name} className="sm:rounded-none">
+            <div className="flex border-b">
+              <Skeleton className="h-[100px] w-[100px] rounded-none" />
+              <div className="flex flex-1 items-center px-4 text-xl text-muted">
+                {name}
+              </div>
+            </div>
+            <div className="flex gap-4 p-4">
+              <Skeleton className="h-5 w-20" />
+              <Skeleton className="h-5 w-20" />
+            </div>
+          </Card>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/apps/bestofjs-nextjs/src/app/hall-of-fame/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/hall-of-fame/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 
-import { PageHeading } from "@/components/core/typography";
+import { APP_REPO_URL } from "@/config/site";
+import { ExternalLink, PageHeading } from "@/components/core/typography";
 
 import { searchClient } from "../backend";
 import { HallOfFameMemberList } from "./hall-of-member-list";
@@ -12,7 +13,7 @@ export async function generateMetadata(): Promise<Metadata> {
   return {
     title: "Hall of Fame",
     description:
-      "The greatest developers, authors and speakers of the JavaScript community",
+      "Some of the greatest developers, authors and speakers of the JavaScript community. Meet Evan, Dan, Sindre, TJ and friends!",
   };
 }
 
@@ -29,7 +30,14 @@ export default async function HallOfFamePage() {
             Here are some of the greatest developers, authors and speakers of
             the JavaScript community.
             <br />
-            Contact us on GitHub to add more members!
+            They are sorted by number of followers,{" "}
+            <ExternalLink
+              url={APP_REPO_URL}
+              className="underline hover:no-underline color-primary"
+            >
+              contact us
+            </ExternalLink>{" "}
+            to add more members!
           </>
         }
       />

--- a/apps/bestofjs-nextjs/src/app/hall-of-fame/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/hall-of-fame/page.tsx
@@ -1,0 +1,26 @@
+import { PageHeading } from "@/components/core/typography";
+
+import { searchClient } from "../backend";
+import { HallOfFameMemberList } from "./hall-of-member-list";
+
+export default async function HallOfFamePage() {
+  const { members } = await fetchHallOfFameMembers();
+  return (
+    <>
+      <PageHeading
+        title={<>JavaScript Hall of Fame</>}
+        subtitle={
+          <>
+            Here are some of the greatest developers, authors and speakers of
+            the JavaScript community.
+          </>
+        }
+      />
+      <HallOfFameMemberList members={members} />
+    </>
+  );
+}
+
+function fetchHallOfFameMembers() {
+  return searchClient.findHallOfFameMembers();
+}

--- a/apps/bestofjs-nextjs/src/app/hall-of-fame/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/hall-of-fame/page.tsx
@@ -1,10 +1,25 @@
+import { Metadata } from "next";
+
 import { PageHeading } from "@/components/core/typography";
 
 import { searchClient } from "../backend";
 import { HallOfFameMemberList } from "./hall-of-member-list";
+import Loading from "./loading";
+
+const forceLoadingState = false; // set to true when debugging the loading state
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: "Hall of Fame",
+    description:
+      "The greatest developers, authors and speakers of the JavaScript community",
+  };
+}
 
 export default async function HallOfFamePage() {
   const { members } = await fetchHallOfFameMembers();
+  if (forceLoadingState) return <Loading />;
+
   return (
     <>
       <PageHeading
@@ -13,6 +28,8 @@ export default async function HallOfFamePage() {
           <>
             Here are some of the greatest developers, authors and speakers of
             the JavaScript community.
+            <br />
+            Contact us on GitHub to add more members!
           </>
         }
       />

--- a/apps/bestofjs-nextjs/src/components/core/project-avatar.tsx
+++ b/apps/bestofjs-nextjs/src/components/core/project-avatar.tsx
@@ -5,8 +5,9 @@ import { useTheme } from "next-themes";
 type Props = {
   project: Pick<BestOfJS.Project, "name" | "owner_id" | "icon">;
   size: number;
+  className?: string;
 };
-export const ProjectAvatar = ({ project, size = 100 }: Props) => {
+export const ProjectAvatar = ({ project, size = 100, className }: Props) => {
   const { resolvedTheme } = useTheme();
 
   const { src, srcSet } = getProjectImageProps({
@@ -26,6 +27,7 @@ export const ProjectAvatar = ({ project, size = 100 }: Props) => {
         width: `${size}px`,
       }}
       alt={project.name}
+      className={className}
     />
   );
 };

--- a/apps/bestofjs-nextjs/src/components/core/typography.tsx
+++ b/apps/bestofjs-nextjs/src/components/core/typography.tsx
@@ -11,7 +11,9 @@ export const PageHeading = ({ icon, subtitle, title }: Props) => {
       {icon && <div className="pr-2 text-yellow-500">{icon}</div>}
       <div className="grow">
         <h1 className="font-mono text-3xl">{title}</h1>
-        {subtitle && <div className="text-muted-foreground">{subtitle}</div>}
+        {subtitle && (
+          <div className="mt-2 text-muted-foreground">{subtitle}</div>
+        )}
       </div>
     </div>
   );

--- a/apps/bestofjs-nextjs/src/components/footer/footer.tsx
+++ b/apps/bestofjs-nextjs/src/components/footer/footer.tsx
@@ -81,7 +81,10 @@ export const Footer = () => {
           </div>
           <div className="flex items-center justify-center gap-1">
             <div>Powered by</div>
-            <a href="https://vercel.com?utm_source=bestofjs">
+            <a
+              href="https://vercel.com?utm_source=bestofjs"
+              aria-label="Vercel"
+            >
               <Icons.vercel width={80} height={18.1} />
             </a>
           </div>

--- a/apps/bestofjs-nextjs/src/components/footer/footer.tsx
+++ b/apps/bestofjs-nextjs/src/components/footer/footer.tsx
@@ -36,6 +36,9 @@ export const Footer = () => {
               <NextLink href="/rankings/monthly" className="hover:underline">
                 Monthly Rankings
               </NextLink>
+              <NextLink href="/hall-of-fame" className="hover:underline">
+                JavaScript Hall of Fame
+              </NextLink>
               <NextLink href="/about" className="hover:underline">
                 About
               </NextLink>

--- a/apps/bestofjs-nextjs/src/components/header/desktop-nav.tsx
+++ b/apps/bestofjs-nextjs/src/components/header/desktop-nav.tsx
@@ -5,9 +5,20 @@
 import * as React from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { ChevronDown } from "lucide-react";
 
-import { mainNavItems } from "@/config/site";
+import { RISING_STARS_URL, extraNavItems, mainNavItems } from "@/config/site";
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Icons } from "@/components/icons";
 
 import { MobileMenuButton } from "./mobile-nav";
@@ -32,27 +43,66 @@ export function MainNav() {
             className="h-[37.15px] w-[130px] text-primary"
           />
         </Link>
-        <nav className="flex gap-6">
-          {mainNavItems?.map(
-            (item, index) =>
-              item.href && (
-                <Link
-                  key={index}
-                  href={item.href}
-                  className={cn(
-                    "flex items-center text-sm font-medium text-muted-foreground hover:text-foreground/80",
-                    item.isActive(pathname)
-                      ? "text-foreground"
-                      : "text-foreground/60",
-                    item.disabled && "cursor-not-allowed opacity-80"
-                  )}
-                >
-                  {item.title}
-                </Link>
-              )
-          )}
-        </nav>
+        <div className="flex gap-4">
+          <nav className="flex gap-6">
+            {mainNavItems?.map(
+              (item, index) =>
+                item.href && (
+                  <Link
+                    key={index}
+                    href={item.href}
+                    className={cn(
+                      "flex items-center text-sm font-medium text-muted-foreground hover:text-foreground/80",
+                      item.isActive(pathname)
+                        ? "text-foreground"
+                        : "text-foreground/60",
+                      item.disabled && "cursor-not-allowed opacity-80"
+                    )}
+                  >
+                    {item.title}
+                  </Link>
+                )
+            )}
+          </nav>
+          <MoreLinksButton />
+        </div>
       </div>
     </>
+  );
+}
+
+export function MoreLinksButton() {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          size="sm"
+          variant="ghost"
+          className={cn("text-muted-foreground")}
+        >
+          More
+          <ChevronDown className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-60" align="end" sideOffset={0}>
+        <DropdownMenuLabel className="text-xs">Links</DropdownMenuLabel>
+        <DropdownMenuGroup>
+          {extraNavItems.map((navItem) => {
+            return (
+              <DropdownMenuItem key={navItem.href} asChild>
+                <Link href={navItem.href}>{navItem.title}</Link>
+              </DropdownMenuItem>
+            );
+          })}
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel className="text-xs">
+          Related projects
+        </DropdownMenuLabel>
+        <DropdownMenuItem>
+          <a href={RISING_STARS_URL}>JavaScript Rising Stars</a>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/apps/bestofjs-nextjs/src/components/header/mobile-nav.tsx
+++ b/apps/bestofjs-nextjs/src/components/header/mobile-nav.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Bars3Icon } from "@heroicons/react/20/solid";
 
-import { mainNavItems } from "@/config/site";
+import { extraNavItems, mainNavItems } from "@/config/site";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
@@ -34,6 +34,7 @@ function SidebarContent({
   onOpenChange: (open: boolean) => void;
 }) {
   const pathname = usePathname();
+  const allNavItems = [...mainNavItems, ...extraNavItems];
 
   return (
     <>
@@ -45,11 +46,11 @@ function SidebarContent({
         <Icons.logo
           width={130}
           height={37.15}
-          className="h-[37.15px] w-[130px] text-orange-600 dark:text-yellow-400"
+          className="h-[37.15px] w-[130px] text-primary"
         />
       </Link>
       <div className="w-full space-y-2">
-        {mainNavItems?.map(
+        {allNavItems.map(
           (item, index) =>
             item.href && (
               <Link

--- a/apps/bestofjs-nextjs/src/components/header/mobile-nav.tsx
+++ b/apps/bestofjs-nextjs/src/components/header/mobile-nav.tsx
@@ -17,7 +17,7 @@ export function MobileMenuButton() {
   return (
     <Sheet open={isOpen} onOpenChange={setIsOpen}>
       <SheetTrigger asChild>
-        <Button variant="outline" size="icon">
+        <Button variant="outline" size="icon" aria-label="Menu">
           <Bars3Icon className="h-5 w-5" />
         </Button>
       </SheetTrigger>

--- a/apps/bestofjs-nextjs/src/components/home/home-featured-projects.client.tsx
+++ b/apps/bestofjs-nextjs/src/components/home/home-featured-projects.client.tsx
@@ -48,10 +48,11 @@ export function FeaturedProjectsClient({
           title="Featured"
           subtitle={
             <>
-              <div className="flex items-center justify-between pt-0">
+              <div className="flex items-center justify-between">
                 <div>Random order</div>
                 <div className="flex items-center">
                   <Button
+                    aria-label="Previous"
                     onClick={setPreviousPageNumber}
                     variant="ghost"
                     size="icon"
@@ -61,6 +62,7 @@ export function FeaturedProjectsClient({
                     <ChevronLeftIcon size={24} />
                   </Button>
                   <Button
+                    aria-label="Next"
                     onClick={setNextPageNumber}
                     variant="ghost"
                     size="icon"

--- a/apps/bestofjs-nextjs/src/config/site.ts
+++ b/apps/bestofjs-nextjs/src/config/site.ts
@@ -11,7 +11,7 @@ export const ADD_PROJECT_REQUEST_URL = `${ISSUE_TRACKER_URL}/issues/new?template
 
 export interface NavItem {
   title: string;
-  href?: string;
+  href: string;
   disabled?: boolean;
   external?: boolean;
   isActive: (pathname: string) => boolean;
@@ -38,10 +38,17 @@ export const mainNavItems: NavItem[] = [
     href: "/rankings/monthly",
     isActive: (pathname: string) => pathname.startsWith("/rankings"),
   },
-  // TODO: add a "More" button to reveal more links from the top nav bar?
-  // {
-  //   title: "About",
-  //   href: "/about",
-  //   isActive: (pathname: string) => pathname.startsWith("/about"),
-  // },
+];
+
+export const extraNavItems: NavItem[] = [
+  {
+    title: "Hall of Fame",
+    href: "/hall-of-fame",
+    isActive: (pathname: string) => pathname.startsWith("/hall-of-fame"),
+  },
+  {
+    title: "About",
+    href: "/about",
+    isActive: (pathname: string) => pathname.startsWith("/about"),
+  },
 ];

--- a/apps/bestofjs-nextjs/src/lib/global.d.ts
+++ b/apps/bestofjs-nextjs/src/lib/global.d.ts
@@ -104,13 +104,19 @@ declare namespace BestOfJS {
     projects: BestOfJS.Project[];
   }
 
-  type HallOfFameMember = {
-    username: string;
+  interface RawHallOfFameMember {
     avatar: string;
-    followers: numbers;
     bio: string;
     blog: string;
-  };
+    followers: numbers;
+    name: string;
+    projects: string[];
+    username: string;
+  }
+
+  interface HallOfFameMember extends RawHallOfFameMember {
+    projects: BestOfJS.Project[];
+  }
 
   type Bookmark = { slug: string; bookmarked_at: string };
 

--- a/apps/bestofjs-webui/src/global.d.ts
+++ b/apps/bestofjs-webui/src/global.d.ts
@@ -85,6 +85,7 @@ declare namespace BestOfJS {
   }
 
   type HallOfFameMember = {
+    name: string;
     username: string;
     avatar: string;
     followers: numbers;


### PR DESCRIPTION
## Goal

Add missing _Hall of Fame_ page from the current version: https://bestofjs.org/hall-of-fame

I was not sure about where to put the link to the Hall of Fame: I reproduced what we do in production, adding a "More" button in the site header, to reveal more links.

Instead of this button, we could use the "Navigation Menu" component: https://ui.shadcn.com/docs/components/navigation-menu

I like the fact that you don't have to click to reveal the navigation items with this "Navigation Menu", it's triggered by a mouse `hover`, it helps to discover all the links of the application.

I added a loading state but I realized we never see it when the application is built: the page has no search parameters, so it's statically built and I think the loading state never shows up.

## How to test

Click on "More" button in the header and enjoy the company of great people 😄 

## Screenshots

![image](https://github.com/bestofjs/bestofjs/assets/5546996/9c90ba6d-3274-4604-92d5-747cf2fe11af)


![image](https://github.com/bestofjs/bestofjs/assets/5546996/ef7e1e05-4681-4b13-8730-411b350456b5)


