### PR TITLE
Use a serif font in Beta version

### DIFF
--- a/apps/bestofjs-nextjs/src/app/about/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/about/page.tsx
@@ -19,7 +19,7 @@ export default function AboutPage() {
   return (
     <>
       <PageHeading title="About Best of JS" />
-      <Card className="space-y-4 p-4">
+      <Card className="space-y-4 p-4 font-serif">
         <div>
           <h2 className="text-xl">Why {APP_DISPLAY_NAME}?</h2>
           <p className="mt-2">

--- a/apps/bestofjs-nextjs/src/app/globals.css
+++ b/apps/bestofjs-nextjs/src/app/globals.css
@@ -49,6 +49,9 @@
     --card: 240 10% 15%;
     --card-foreground: 0 0% 98%;
 
+    /* Add a lighter background for elements displayed inside a card (E.g. code block inside README) */
+    --card-element: 240 10% 25%;
+
     --popover: 240 10% 3.9%;
     --popover-foreground: 0 0% 98%;
 

--- a/apps/bestofjs-nextjs/src/app/globals.css
+++ b/apps/bestofjs-nextjs/src/app/globals.css
@@ -52,7 +52,8 @@
     /* Add a lighter background for elements displayed inside a card (E.g. code block inside README) */
     --card-element: 240 10% 25%;
 
-    --popover: 240 10% 3.9%;
+    /* Make popover less dark to match the card bg (original L=3.9%;) */
+    --popover: 240 10% 15%;
     --popover-foreground: 0 0% 98%;
 
     /* Setup orange as the primary color instead of 0 0% 98% */

--- a/apps/bestofjs-nextjs/src/app/hall-of-fame/hall-of-member-list.tsx
+++ b/apps/bestofjs-nextjs/src/app/hall-of-fame/hall-of-member-list.tsx
@@ -33,12 +33,12 @@ function HallOfFameMember({ member }: { member: BestOfJS.HallOfFameMember }) {
         />
         <div className="flex flex-1 flex-col justify-center gap-2 px-4">
           <div className="flex items-center">
-            <span className="text-xl">{member.name}</span>
+            <span className="font-serif text-xl">{member.name}</span>
           </div>
           <div className="text-muted-foreground">
             <a
               href={`https://github.com/${member.username}`}
-              className="font-mono text-primary hover:underline"
+              className="text-primary hover:underline"
             >
               {member.username}
             </a>{" "}

--- a/apps/bestofjs-nextjs/src/app/hall-of-fame/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/hall-of-fame/page.tsx
@@ -33,7 +33,7 @@ export default async function HallOfFamePage() {
             They are sorted by number of followers,{" "}
             <ExternalLink
               url={APP_REPO_URL}
-              className="underline hover:no-underline color-primary"
+              className="color-primary underline hover:no-underline"
             >
               contact us
             </ExternalLink>{" "}

--- a/apps/bestofjs-nextjs/src/app/layout.tsx
+++ b/apps/bestofjs-nextjs/src/app/layout.tsx
@@ -3,7 +3,7 @@ import { Metadata } from "next";
 import { Analytics } from "@vercel/analytics/react";
 
 import { APP_DISPLAY_NAME } from "@/config/site";
-import { fontSans } from "@/lib/fonts";
+import { fontSans, fontSerif } from "@/lib/fonts";
 import { cn } from "@/lib/utils";
 import { Footer } from "@/components/footer/footer";
 import { SiteHeader } from "@/components/header/site-header";
@@ -40,7 +40,8 @@ export default function RootLayout({ children }: RootLayoutProps) {
         <body
           className={cn(
             "min-h-screen bg-background font-sans antialiased",
-            fontSans.variable
+            fontSans.variable,
+            fontSerif.variable
           )}
         >
           <ThemeProvider attribute="class" defaultTheme="system" enableSystem>

--- a/apps/bestofjs-nextjs/src/app/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/page.tsx
@@ -42,10 +42,10 @@ export default async function IndexPage() {
   return (
     <div className="flex flex-col gap-8">
       <div className="flex flex-col items-start gap-2">
-        <h1 className="text-3xl font-extrabold leading-tight tracking-tighter md:text-4xl">
-          The best of JS and friends
+        <h1 className="text-3xl leading-tight tracking-tighter md:text-4xl font-serif">
+          The best of JS, HTML and CSS
         </h1>
-        <p className="text-lg text-muted-foreground">
+        <p className="text-lg text-muted-foreground font-serif">
           A place to find the best open source projects related to the web
           platform:
           <br />
@@ -190,7 +190,7 @@ function BestOfJSSection({ project }: { project: BestOfJS.Project | null }) {
           icon={<GoHeart fontSize={32} />}
           title={<>Do you find {APP_DISPLAY_NAME} useful?</>}
         />
-        <div className="pl-10">
+        <div className="pl-10 font-serif">
           <p>
             Show your appreciation by starring the project on{" "}
             <ExternalLink url={APP_REPO_URL}>GitHub</ExternalLink>, or becoming
@@ -239,7 +239,7 @@ function MoreProjectsSection() {
         icon={<GoPlus fontSize={32} />}
         title="Do you want more projects?"
       />
-      <div className="pl-10">
+      <div className="pl-10 font-serif">
         <p>
           <i>{APP_DISPLAY_NAME}</i> is a curated list of about 1500 open-source
           projects related to the web platform and Node.js.

--- a/apps/bestofjs-nextjs/src/app/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/page.tsx
@@ -42,10 +42,10 @@ export default async function IndexPage() {
   return (
     <div className="flex flex-col gap-8">
       <div className="flex flex-col items-start gap-2">
-        <h1 className="text-3xl leading-tight tracking-tighter md:text-4xl font-serif">
+        <h1 className="font-serif text-3xl leading-tight tracking-tighter md:text-4xl">
           The best of JS, HTML and CSS
         </h1>
-        <p className="text-lg text-muted-foreground font-serif">
+        <p className="font-serif text-lg text-muted-foreground">
           A place to find the best open source projects related to the web
           platform:
           <br />

--- a/apps/bestofjs-nextjs/src/app/projects/[slug]/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/[slug]/page.tsx
@@ -35,7 +35,7 @@ export default async function ProjectDetailsPage({ params }: PageProps) {
   const project = await getData(slug);
 
   return (
-    <div className="flex flex-col space-y-8">
+    <div className="flex flex-col space-y-8 font-serif">
       <ProjectHeader project={project} />
       <Suspense
         fallback={

--- a/apps/bestofjs-nextjs/src/app/projects/[slug]/project-details-github/github-card.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/[slug]/project-details-github/github-card.tsx
@@ -65,7 +65,7 @@ const GitHubData = ({ project }: { project: BestOfJS.ProjectDetails }) => {
           href={repository}
           target="_blank"
           rel="noreferrer"
-          className="font-mono hover:underline"
+          className="font-sans text-primary hover:underline"
         >
           {full_name}
         </a>

--- a/apps/bestofjs-nextjs/src/app/projects/[slug]/project-details-npm/dependencies-section.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/[slug]/project-details-npm/dependencies-section.tsx
@@ -75,7 +75,7 @@ export async function DependenciesSection({
                   <TableRow key={dependency}>
                     <TableCell>
                       <a
-                        className="font-mono hover:underline"
+                        className="font-sans hover:underline"
                         href={`https://npmjs.org/package/${dependency}`}
                       >
                         {dependency}

--- a/apps/bestofjs-nextjs/src/app/projects/[slug]/project-details-npm/project-details-npm.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/[slug]/project-details-npm/project-details-npm.tsx
@@ -26,7 +26,7 @@ export function ProjectDetailsNpmCard({
           <div className="flex items-center gap-2">
             <a
               href={`https://www.npmjs.com/package/${packageName}`}
-              className="font-mono hover:underline"
+              className="font-sans text-primary hover:underline"
             >
               {packageName}
               {/* <ExternalLinkIcon /> */}

--- a/apps/bestofjs-nextjs/src/app/projects/[slug]/project-header.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/[slug]/project-header.tsx
@@ -21,7 +21,7 @@ export function ProjectHeader({ project }: Props) {
           <ProjectAvatar project={project} size={75} />
         </div>
         <div className="flex flex-col space-y-4 pl-4">
-          <h2 className="text-4xl">{project.name}</h2>
+          <h2 className="text-4xl font-serif">{project.name}</h2>
           <div>
             <Suspense fallback={project.description}>
               {/* @ts-expect-error Server Component */}

--- a/apps/bestofjs-nextjs/src/app/projects/[slug]/project-header.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/[slug]/project-header.tsx
@@ -33,7 +33,7 @@ export function ProjectHeader({ project }: Props) {
           </div>
         </div>
       </div>
-      <aside className="flex flex-col justify-center space-y-2 sm:w-[280px] sm:pl-4">
+      <aside className="flex flex-col justify-center space-y-2 sm:w-[280px] sm:pl-4 font-sans">
         <ButtonLink href={repository} icon={<GoMarkGithub size={20} />}>
           {full_name}
         </ButtonLink>

--- a/apps/bestofjs-nextjs/src/app/projects/[slug]/project-header.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/[slug]/project-header.tsx
@@ -21,7 +21,7 @@ export function ProjectHeader({ project }: Props) {
           <ProjectAvatar project={project} size={75} />
         </div>
         <div className="flex flex-col space-y-4 pl-4">
-          <h2 className="text-4xl font-serif">{project.name}</h2>
+          <h2 className="font-serif text-4xl">{project.name}</h2>
           <div>
             <Suspense fallback={project.description}>
               {/* @ts-expect-error Server Component */}

--- a/apps/bestofjs-nextjs/src/app/projects/[slug]/project-readme/readme.css
+++ b/apps/bestofjs-nextjs/src/app/projects/[slug]/project-readme/readme.css
@@ -723,6 +723,7 @@
 
 .markdown-body li {
   word-wrap: break-all;
+  list-style: disc; /* override reset CSS applied by TailwindCSS */
 }
 
 .markdown-body li > p {
@@ -1131,17 +1132,17 @@
   border-top: 1px solid #272c32;
 }
 .dark .markdown-body table tr:nth-child(2n) {
-  background-color: var(--backgroundColor);
+  background-color: var(--background);
 }
 .dark .markdown-body img {
   background-color: transparent;
 }
 .dark .markdown-body code {
-  background-color: rgba(240, 246, 252, 0.15);
+  background-color: hsl(var(--card-element));
 }
 .dark .markdown-body .highlight pre,
 .dark .markdown-body pre {
-  background-color: var(--backgroundColor);
+  background-color: hsl(var(--card-element));
 }
 .dark .markdown-body .commit-tease-sha {
   color: #b1bac4;

--- a/apps/bestofjs-nextjs/src/app/projects/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/page.tsx
@@ -4,6 +4,7 @@ import { PlusIcon, XMarkIcon } from "@heroicons/react/20/solid";
 
 import { cn } from "@/lib/utils";
 import { badgeVariants } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
 import { TagIcon } from "@/components/core";
 import { PageHeading } from "@/components/core/typography";
 import {
@@ -90,6 +91,7 @@ export default async function Projects({ searchParams }: PageProps) {
   if (showLoadingPage) return <ProjectListLoading />;
 
   const searchState = parseSearchParams(searchParams);
+  const { query } = searchState;
 
   const buildPageURL = (updater: SearchQueryUpdater<ProjectSearchQuery>) => {
     const nextState = updater(searchState);
@@ -104,12 +106,12 @@ export default async function Projects({ searchParams }: PageProps) {
         tags={selectedTags}
         total={total}
       />
-      {selectedTags.length > 0 && (
+      {(selectedTags.length > 0 || query) && (
         <CurrentTags
           tags={selectedTags}
           buildPageURL={buildPageURL}
           allTags={allTags}
-          textQuery={searchState.query}
+          textQuery={query}
         />
       )}
       {relevantTags.length > 0 && (
@@ -144,7 +146,8 @@ function ProjectPageHeader({
       <PageHeading
         title={
           <>
-            All Projects <ShowNumberOfProject count={total} />
+            All Projects
+            <ShowNumberOfProject count={total} />
           </>
         }
       />
@@ -155,7 +158,7 @@ function ProjectPageHeader({
       <PageHeading
         title={
           <>
-            {tags.map((tag) => tag.name).join(" + ")}{" "}
+            {tags.map((tag) => tag.name).join(" + ")}
             <ShowNumberOfProject count={total} />
           </>
         }
@@ -163,14 +166,25 @@ function ProjectPageHeader({
       />
     );
   }
-  return <PageHeading title="Search results" />;
+  return (
+    <PageHeading
+      title={
+        <>
+          Search results
+          <ShowNumberOfProject count={total} />
+        </>
+      }
+    />
+  );
 }
 
 function ShowNumberOfProject({ count }: { count: number }) {
   return (
     <>
-      <span className="px-1 text-yellow-500">•</span>
-      {count === 1 ? "One project" : `${count} projects`}
+      <span className="px-2 text-yellow-500">•</span>
+      <span className="text-muted-foreground">
+        {count === 1 ? "One project" : `${count} projects`}
+      </span>
     </>
   );
 }
@@ -184,7 +198,6 @@ function RelevantTags({
 }) {
   return (
     <div className="mb-4 flex flex-wrap gap-2">
-      <span>Refine your search:</span>
       {tags.map((tag) => {
         const url = buildPageURL((state) => ({
           ...state,
@@ -232,7 +245,6 @@ function CurrentTags({
           ...state,
           page: 1,
           tags: state.tags.filter((tagCode) => tagCode !== tag.code),
-          query: "",
         }));
         return (
           <NextLink

--- a/apps/bestofjs-nextjs/src/components/core/section.tsx
+++ b/apps/bestofjs-nextjs/src/components/core/section.tsx
@@ -15,7 +15,7 @@ export const SectionHeading = ({ className, icon, title, subtitle }: Props) => {
         <div className="pr-2 text-yellow-500 dark:text-yellow-600">{icon}</div>
       )}
       <div className="grow">
-        <h2 className="text-2xl font-serif">{title}</h2>
+        <h2 className="font-serif text-2xl">{title}</h2>
         {subtitle && <div className="text-muted-foreground">{subtitle}</div>}
       </div>
     </div>

--- a/apps/bestofjs-nextjs/src/components/core/section.tsx
+++ b/apps/bestofjs-nextjs/src/components/core/section.tsx
@@ -15,7 +15,7 @@ export const SectionHeading = ({ className, icon, title, subtitle }: Props) => {
         <div className="pr-2 text-yellow-500 dark:text-yellow-600">{icon}</div>
       )}
       <div className="grow">
-        <h2 className="font-mono text-2xl">{title}</h2>
+        <h2 className="text-2xl font-serif">{title}</h2>
         {subtitle && <div className="text-muted-foreground">{subtitle}</div>}
       </div>
     </div>

--- a/apps/bestofjs-nextjs/src/components/core/typography.tsx
+++ b/apps/bestofjs-nextjs/src/components/core/typography.tsx
@@ -10,7 +10,7 @@ export const PageHeading = ({ icon, subtitle, title }: Props) => {
     <div className="mb-6 flex items-center">
       {icon && <div className="pr-2 text-yellow-500">{icon}</div>}
       <div className="grow">
-        <h1 className="font-mono text-3xl">{title}</h1>
+        <h1 className="text-3xl font-serif">{title}</h1>
         {subtitle && (
           <div className="mt-2 text-muted-foreground">{subtitle}</div>
         )}

--- a/apps/bestofjs-nextjs/src/components/core/typography.tsx
+++ b/apps/bestofjs-nextjs/src/components/core/typography.tsx
@@ -10,7 +10,7 @@ export const PageHeading = ({ icon, subtitle, title }: Props) => {
     <div className="mb-6 flex items-center">
       {icon && <div className="pr-2 text-yellow-500">{icon}</div>}
       <div className="grow">
-        <h1 className="text-3xl font-serif">{title}</h1>
+        <h1 className="font-serif text-3xl">{title}</h1>
         {subtitle && (
           <div className="mt-2 text-muted-foreground">{subtitle}</div>
         )}

--- a/apps/bestofjs-nextjs/src/components/core/typography.tsx
+++ b/apps/bestofjs-nextjs/src/components/core/typography.tsx
@@ -9,8 +9,8 @@ export const PageHeading = ({ icon, subtitle, title }: Props) => {
   return (
     <div className="mb-6 flex items-center">
       {icon && <div className="pr-2 text-yellow-500">{icon}</div>}
-      <div className="grow">
-        <h1 className="font-serif text-3xl">{title}</h1>
+      <div className="grow font-serif">
+        <h1 className="text-3xl">{title}</h1>
         {subtitle && (
           <div className="mt-2 text-muted-foreground">{subtitle}</div>
         )}

--- a/apps/bestofjs-nextjs/src/components/footer/footer.tsx
+++ b/apps/bestofjs-nextjs/src/components/footer/footer.tsx
@@ -69,7 +69,7 @@ export const Footer = () => {
           </div>
         </div>
         <Separator />
-        <div className="flex flex-col gap-4 py-8">
+        <div className="flex flex-col gap-4 py-8 font-serif">
           <div className="flex items-center justify-center">
             <p>
               <i>{APP_DISPLAY_NAME}</i> is a project by{" "}

--- a/apps/bestofjs-nextjs/src/components/home/featured-project-list.tsx
+++ b/apps/bestofjs-nextjs/src/components/home/featured-project-list.tsx
@@ -38,7 +38,7 @@ function FeaturedProject({
       <div className="flex-1 space-y-2 overflow-hidden text-center">
         <NextLink
           href={`/projects/${project.slug}`}
-          className="block truncate font-mono text-primary hover:underline"
+          className="block truncate text-primary hover:underline"
         >
           {project.name}
         </NextLink>

--- a/apps/bestofjs-nextjs/src/components/project-list/project-table.tsx
+++ b/apps/bestofjs-nextjs/src/components/project-list/project-table.tsx
@@ -115,7 +115,7 @@ const ProjectTableRow = ({
         </div>
 
         <div className="mb-4 mt-2 space-y-2 text-sm">
-          <div className="font-serif truncate">{project.description}</div>
+          <div className="truncate font-serif">{project.description}</div>
           {showDetails && (
             <>
               <div className="md:hidden">

--- a/apps/bestofjs-nextjs/src/components/project-list/project-table.tsx
+++ b/apps/bestofjs-nextjs/src/components/project-list/project-table.tsx
@@ -75,10 +75,7 @@ const ProjectTableRow = ({
 
       <Cell className="w-auto py-4 pl-4 md:pl-2">
         <div className="relative flex items-center space-x-2">
-          <NextLink
-            href={path}
-            className="font-mono text-primary hover:underline"
-          >
+          <NextLink href={path} className="text-primary hover:underline">
             {project.name}
           </NextLink>
           <div className="flex space-x-1">
@@ -118,7 +115,7 @@ const ProjectTableRow = ({
         </div>
 
         <div className="mb-4 mt-2 space-y-2 text-sm">
-          <div>{project.description}</div>
+          <div className="font-serif truncate">{project.description}</div>
           {showDetails && (
             <>
               <div className="md:hidden">

--- a/apps/bestofjs-nextjs/src/components/project-list/project-table.tsx
+++ b/apps/bestofjs-nextjs/src/components/project-list/project-table.tsx
@@ -66,7 +66,7 @@ const ProjectTableRow = ({
   const path = `/projects/${project.slug}`;
 
   return (
-    <tr data-testid="project-card" className="border-b hover:bg-muted/50">
+    <tr data-testid="project-card" className="border-b">
       <Cell className="w-[50px] pl-4 sm:p-4">
         <NextLink href={path}>
           <ProjectAvatar project={project} size={48} />

--- a/apps/bestofjs-nextjs/src/components/project-list/project-table.tsx
+++ b/apps/bestofjs-nextjs/src/components/project-list/project-table.tsx
@@ -115,7 +115,7 @@ const ProjectTableRow = ({
         </div>
 
         <div className="mb-4 mt-2 space-y-2 text-sm">
-          <div className="truncate font-serif">{project.description}</div>
+          <div className="font-serif">{project.description}</div>
           {showDetails && (
             <>
               <div className="md:hidden">

--- a/apps/bestofjs-nextjs/src/components/search-palette/search-palette.tsx
+++ b/apps/bestofjs-nextjs/src/components/search-palette/search-palette.tsx
@@ -164,7 +164,7 @@ export function SearchPalette({ allProjects, allTags }: SearchProps) {
       >
         <span className="hidden lg:inline-flex">Search in projects...</span>
         <span className="inline-flex lg:hidden">Search...</span>
-        <kbd className="pointer-events-none absolute right-1.5 top-2 hidden h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium opacity-100 sm:flex">
+        <kbd className="pointer-events-none absolute right-1.5 top-2 hidden h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 text-[10px] font-medium opacity-100 sm:flex">
           <span className="text-xs">⌘</span>K
         </kbd>
       </Button>

--- a/apps/bestofjs-nextjs/src/components/tags/project-tag.tsx
+++ b/apps/bestofjs-nextjs/src/components/tags/project-tag.tsx
@@ -47,7 +47,7 @@ export const ProjectTag = ({
       href={url}
       className={cn(
         badgeVariants({ variant: "outline" }),
-        "rounded-sm px-3 py-1 text-sm font-normal hover:bg-accent",
+        "rounded-sm px-3 py-1 text-sm font-normal hover:bg-accent font-sans",
         className
       )}
     >

--- a/apps/bestofjs-nextjs/src/components/tags/project-tag.tsx
+++ b/apps/bestofjs-nextjs/src/components/tags/project-tag.tsx
@@ -47,7 +47,7 @@ export const ProjectTag = ({
       href={url}
       className={cn(
         badgeVariants({ variant: "outline" }),
-        "rounded-sm px-3 py-1 text-sm font-normal hover:bg-accent font-sans",
+        "rounded-sm px-3 py-1 font-sans text-sm font-normal hover:bg-accent",
         className
       )}
     >

--- a/apps/bestofjs-nextjs/src/components/tailwind-indicator.tsx
+++ b/apps/bestofjs-nextjs/src/components/tailwind-indicator.tsx
@@ -1,8 +1,8 @@
 export function TailwindIndicator() {
-  if (process.env.NODE_ENV === "production") return null
+  if (process.env.NODE_ENV === "production") return null;
 
   return (
-    <div className="fixed bottom-1 left-1 z-50 flex h-6 w-6 items-center justify-center rounded-full bg-gray-800 p-3 font-mono text-xs text-white">
+    <div className="fixed bottom-1 left-1 z-50 flex h-6 w-6 items-center justify-center rounded-full bg-gray-800 p-3 text-xs text-white">
       <div className="block sm:hidden">xs</div>
       <div className="hidden sm:block md:hidden">sm</div>
       <div className="hidden md:block lg:hidden">md</div>
@@ -10,5 +10,5 @@ export function TailwindIndicator() {
       <div className="hidden xl:block 2xl:hidden">xl</div>
       <div className="hidden 2xl:block">2xl</div>
     </div>
-  )
+  );
 }

--- a/apps/bestofjs-nextjs/src/components/ui/button.tsx
+++ b/apps/bestofjs-nextjs/src/components/ui/button.tsx
@@ -12,8 +12,7 @@ const buttonVariants = cva(
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
-        outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        outline: "border bg-card hover:bg-accent hover:text-accent-foreground",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",

--- a/apps/bestofjs-nextjs/src/lib/fonts.ts
+++ b/apps/bestofjs-nextjs/src/lib/fonts.ts
@@ -1,17 +1,8 @@
-import {
-  JetBrains_Mono as FontMono,
-  Inter as FontSans,
-  Roboto_Slab,
-} from "next/font/google";
+import { Inter as FontSans, Roboto_Slab } from "next/font/google";
 
 export const fontSans = FontSans({
   subsets: ["latin"],
   variable: "--font-sans",
-});
-
-export const fontMono = FontMono({
-  subsets: ["latin"],
-  variable: "--font-mono",
 });
 
 export const fontSerif = Roboto_Slab({

--- a/apps/bestofjs-nextjs/src/lib/fonts.ts
+++ b/apps/bestofjs-nextjs/src/lib/fonts.ts
@@ -1,11 +1,20 @@
-import { JetBrains_Mono as FontMono, Inter as FontSans } from "next/font/google"
+import {
+  JetBrains_Mono as FontMono,
+  Inter as FontSans,
+  Roboto_Slab,
+} from "next/font/google";
 
 export const fontSans = FontSans({
   subsets: ["latin"],
   variable: "--font-sans",
-})
+});
 
 export const fontMono = FontMono({
   subsets: ["latin"],
   variable: "--font-mono",
-})
+});
+
+export const fontSerif = Roboto_Slab({
+  subsets: ["latin"],
+  variable: "--font-serif",
+});

--- a/apps/bestofjs-nextjs/tailwind.config.js
+++ b/apps/bestofjs-nextjs/tailwind.config.js
@@ -55,6 +55,7 @@ module.exports = {
       },
       fontFamily: {
         sans: ["var(--font-sans)", ...fontFamily.sans],
+        serif: ["var(--font-serif)", ...fontFamily.serif],
       },
       keyframes: {
         "accordion-down": {


### PR DESCRIPTION
## Goal

Following the feedback about fonts #176 this PR introduces the same serif font we use in production (`Roboto_Slab`) for headings and paragraphs.

The mono font (`JetBrains_Mono`) is removed.

The `OpenSans` font is used for interactive elements: menus, links, buttons...

Extra fix: when removing a tag from the search results page, the current text filter should not be reset.

## How to test

- Search for `sindre`
- Add a tag from the list of tag used to refine the search
- Removing the tag or the search filter by pushing the X button should not reset the whole search state

## Screenshots

![image](https://github.com/bestofjs/bestofjs/assets/5546996/91690468-c4eb-4faf-9f84-10bf649ecdec)

![image](https://github.com/bestofjs/bestofjs/assets/5546996/23d447b2-f998-4426-80f7-7b055d486289)

