### PR TITLE
Add revalidate API end-point

### DIFF
--- a/apps/bestofjs-nextjs/src/app/api/revalidate/route.ts
+++ b/apps/bestofjs-nextjs/src/app/api/revalidate/route.ts
@@ -1,0 +1,30 @@
+import { revalidateTag } from "next/cache";
+
+export const runtime = "edge";
+
+// API end-point to be called when we need to purge the cache for a given project
+// without having to wait the delay of 24 hours set via fetch `revalidate` option
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const fullName = searchParams.get("fullName");
+    if (!fullName) throw new Error("Provide `fullName` parameter");
+    revalidateTag(fullName);
+    const output = { status: "No error!", fullName };
+
+    return new Response(JSON.stringify(output), {
+      status: 200,
+      headers: {
+        "content-type": "application/json",
+      },
+    });
+  } catch (error) {
+    const output = { status: "error", message: (error as Error).message };
+    return new Response(JSON.stringify(output), {
+      status: 400,
+      headers: {
+        "content-type": "application/json",
+      },
+    });
+  }
+}

--- a/apps/bestofjs-nextjs/src/app/api/revalidate/route.ts
+++ b/apps/bestofjs-nextjs/src/app/api/revalidate/route.ts
@@ -2,15 +2,16 @@ import { revalidateTag } from "next/cache";
 
 export const runtime = "edge";
 
-// API end-point to be called when we need to purge the cache for a given project
+// API end-point to be called when we need to purge the cache for a given tag
 // without having to wait the delay of 24 hours set via fetch `revalidate` option
+// Doc: https://nextjs.org/docs/app/building-your-application/caching
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
-    const fullName = searchParams.get("fullName");
-    if (!fullName) throw new Error("Provide `fullName` parameter");
-    revalidateTag(fullName);
-    const output = { status: "No error!", fullName };
+    const tag = searchParams.get("tag");
+    if (!tag) throw new Error("Provide `tag` parameter");
+    revalidateTag(tag);
+    const output = { status: "No error!", tag };
 
     return new Response(JSON.stringify(output), {
       status: 200,

--- a/apps/bestofjs-nextjs/src/app/not-found.tsx
+++ b/apps/bestofjs-nextjs/src/app/not-found.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+
+import { APP_REPO_URL } from "@/config/site";
+import { ExternalLink, PageHeading } from "@/components/core/typography";
+
+export default function NotFound() {
+  return (
+    <>
+      <PageHeading title={"Not Found"} />
+      <div className="space-y-4 font-serif">
+        <p>Sorry, we cannot find this page!</p>
+        <p>
+          Please contact us on{" "}
+          <ExternalLink url={APP_REPO_URL}>GitHub</ExternalLink> to mention this
+          problem.
+        </p>
+        <p>
+          Return to{" "}
+          <Link href="/" className="text-primary hover:underline">
+            Best of JS Home
+          </Link>
+        </p>
+      </div>
+    </>
+  );
+}

--- a/apps/bestofjs-nextjs/src/app/projects/[slug]/get-project-details.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/[slug]/get-project-details.tsx
@@ -5,7 +5,13 @@ export async function getProjectDetails(project: BestOfJS.Project) {
 
 async function fetchProjectDetailsData(fullName: string) {
   const url = `https://bestofjs-serverless.vercel.app/api/project-details?fullName=${fullName}`;
-  return fetch(url).then((r) => r.json());
+  const options = {
+    next: {
+      revalidate: 60 * 60 * 24, // Revalidate every day to avoid showing stale data
+      tags: ["project-details", fullName], // to be able to revalidate via API calls, on-demand
+    },
+  };
+  return fetch(url, options).then((res) => res.json());
 }
 
 function mergeProjectData(project: BestOfJS.Project, details: any) {

--- a/apps/bestofjs-nextjs/src/app/projects/[slug]/project-details-npm/monthly-downloads-charts.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/[slug]/project-details-npm/monthly-downloads-charts.tsx
@@ -28,6 +28,12 @@ export async function MonthlyDownloadsChart({
 
 async function fetchDownloadData(packageName: string) {
   const url = `https://bestofjs-serverless.vercel.app/api/package-monthly-downloads?packageName=${packageName}`;
-  const data = await fetch(url).then((r) => r.json());
+  const options = {
+    next: {
+      revalidate: 60 * 60 * 24, // Revalidate every day to avoid showing stale data
+      tags: ["package-downloads", packageName], // to be able to revalidate via API calls, on-demand
+    },
+  };
+  const data = await fetch(url, options).then((res) => res.json());
   return data as DataItem[];
 }

--- a/apps/bestofjs-nextjs/src/app/projects/[slug]/project-readme/project-readme.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/[slug]/project-readme/project-readme.tsx
@@ -27,15 +27,17 @@ export async function ReadmeCard({ project }: { project: BestOfJS.Project }) {
 
 async function ReadmeContent({ project }: { project: BestOfJS.Project }) {
   const html = await getData(project.full_name, project.branch);
-  // if (error) return <div>Unable to fetch README.md content from GitHub</div>;
-
-  // if (!html) return <Spinner />;
-
   return <div dangerouslySetInnerHTML={{ __html: html }} />;
 }
 
 async function getData(fullName: string, branch: string) {
   const url = `https://bestofjs-serverless.vercel.app/api/project-readme?fullName=${fullName}&branch=${branch}`;
-  const html = await fetch(url).then((r) => r.text());
+  const options = {
+    next: {
+      revalidate: 60 * 60 * 24, // Revalidate every day as we assume a README file can change frequently
+      tags: ["readme", fullName], // to be able to revalidate via API calls, on-demand
+    },
+  };
+  const html = await fetch(url, options).then((res) => res.text());
   return html;
 }

--- a/apps/bestofjs-nextjs/src/app/rankings/monthly/monthly-rankings-data.ts
+++ b/apps/bestofjs-nextjs/src/app/rankings/monthly/monthly-rankings-data.ts
@@ -21,10 +21,16 @@ export async function fetchMonthlyRankings({
   limit: number;
 }) {
   const rootURL = "https://bestofjs-rankings.vercel.app";
-  const url = date
-    ? `${rootURL}/monthly/${formatDate(date)}`
-    : `${rootURL}/monthly/latest`;
-  const data = (await fetch(url).then((res) => res.json())) as RankingsData;
+  const key = date ? formatDate(date) : `latest`;
+  const url = `${rootURL}/monthly/${key}`;
+  const options = {
+    next: {
+      tags: ["monthly", key], // to be able to revalidate via API calls, on-demand
+    },
+  };
+  const data = (await fetch(url, options).then((res) =>
+    res.json()
+  )) as RankingsData;
   const { isFirst, isLatest, month, year } = data;
   const projects = data.trending.slice(0, limit);
   const fullNames = projects.map((project) => project.full_name);


### PR DESCRIPTION
## Goal

We have an issue related to caching on beta.bestofjs.org: page details (`/projects/:id`) show stale data instead of the latest data.

It's obvious on this screenshot: the data for July is missing, in the graph:

![image](https://github.com/bestofjs/bestofjs/assets/5546996/31fceb87-5365-4a57-a75c-30615959108a)

The reason: the page is cached after the first visit and because it has no search parameters, and it's never re-validated.

https://nextjs.org/docs/app/building-your-application/caching

This PR fixes the problem by forcing the page to be re-validated every 24 hours and by providing an end-point to purge the cache on-demand.

https://nextjs.org/docs/app/api-reference/functions/revalidateTag#parameters

TODO in the backend: call this end-point when the static API (the big JSON file consumed) is re-built, every day.

This PR also adds `not-found` page to avoid showing the Vercel's default 404 page when a page is not found.
