### PR TITLE
Zawarudo/fix tag search results

### DIFF
--- a/apps/bestofjs-nextjs/src/components/search-palette/search-palette.tsx
+++ b/apps/bestofjs-nextjs/src/components/search-palette/search-palette.tsx
@@ -308,10 +308,12 @@ export function SearchPalette({ allProjects, allTags }: SearchProps) {
 }
 
 function filterTagsByQuery(tags: BestOfJS.Tag[], searchQuery: string) {
+  const normalizedQuery = searchQuery.toLowerCase();
+
   return tags.filter(
     (tag) =>
-      tag.code.includes(searchQuery) ||
-      tag.name.toLowerCase().includes(searchQuery)
+      tag.code.includes(normalizedQuery) ||
+      tag.name.toLowerCase().includes(normalizedQuery)
   );
 }
 


### PR DESCRIPTION
## Goal
When searching React, no tags are shown in results. Where as "react" works fine.
## Screenshots


Left: Current   |  Right: Fixed

![image](https://github.com/bestofjs/bestofjs/assets/2955134/65b104de-8e91-4078-9cba-5fb7fa4e7f4c)

