### PR TITLE
Zawarudo/searchbar improvements

### DIFF
--- a/apps/bestofjs-nextjs/src/app/projects/[slug]/project-header.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/[slug]/project-header.tsx
@@ -33,7 +33,7 @@ export function ProjectHeader({ project }: Props) {
           </div>
         </div>
       </div>
-      <aside className="flex flex-col justify-center space-y-2 sm:w-[280px] sm:pl-4 font-sans">
+      <aside className="flex flex-col justify-center space-y-2 font-sans sm:w-[280px] sm:pl-4">
         <ButtonLink href={repository} icon={<GoMarkGithub size={20} />}>
           {full_name}
         </ButtonLink>

--- a/apps/bestofjs-nextjs/src/components/search-palette/search-palette.tsx
+++ b/apps/bestofjs-nextjs/src/components/search-palette/search-palette.tsx
@@ -215,7 +215,12 @@ export function SearchPalette({ allProjects, allTags }: SearchProps) {
                           <div className="items-center justify-center">
                             <ProjectAvatar project={project} size={32} />
                           </div>
-                          <div className="">{project.name}</div>
+                          <div>
+                            {project.name}
+                            <div className="truncate pt-2 text-xs text-muted-foreground">
+                              {project.description}
+                            </div>
+                          </div>
                           <div className="text-right">
                             <StarTotal value={project.stars} />
                           </div>

--- a/apps/bestofjs-nextjs/src/components/search-palette/search-palette.tsx
+++ b/apps/bestofjs-nextjs/src/components/search-palette/search-palette.tsx
@@ -292,7 +292,7 @@ export function SearchPalette({ allProjects, allTags }: SearchProps) {
                       onSelect={onSelectTag}
                     >
                       <div className="flex">
-                        <div className="w-8 flex justify-center items-center justify-center">
+                        <div className="flex w-8 items-center justify-center">
                           <TagIcon />
                         </div>
                         <span className="pl-4 pr-2">{tag.name}</span>

--- a/apps/bestofjs-nextjs/src/components/search-palette/search-palette.tsx
+++ b/apps/bestofjs-nextjs/src/components/search-palette/search-palette.tsx
@@ -291,13 +291,13 @@ export function SearchPalette({ allProjects, allTags }: SearchProps) {
                       value={"tag/" + tag.code}
                       onSelect={onSelectTag}
                     >
-                      <div className="grid w-full grid-cols-[32px_1fr_100px] items-center gap-4">
-                        <div className="flex w-full items-center justify-center">
+                      <div className="flex">
+                        <div className="items-center justify-center">
                           <TagIcon />
                         </div>
-                        <span className="">{tag.name}</span>
-                        <div className="text-right text-muted-foreground">
-                          {tag.counter}
+                        <span className="mx-2">{tag.name}</span>
+                        <div className="text-muted-foreground">
+                          ({tag.counter})
                         </div>
                       </div>
                     </CommandItem>

--- a/apps/bestofjs-nextjs/src/components/search-palette/search-palette.tsx
+++ b/apps/bestofjs-nextjs/src/components/search-palette/search-palette.tsx
@@ -292,10 +292,10 @@ export function SearchPalette({ allProjects, allTags }: SearchProps) {
                       onSelect={onSelectTag}
                     >
                       <div className="flex">
-                        <div className="items-center justify-center">
+                        <div className="w-8 flex justify-center items-center justify-center">
                           <TagIcon />
                         </div>
-                        <span className="mx-2">{tag.name}</span>
+                        <span className="pl-4 pr-2">{tag.name}</span>
                         <div className="text-muted-foreground">
                           ({tag.counter})
                         </div>


### PR DESCRIPTION
## Goal
Search Results:
- Add descriptions to search results in the `Projects` section.
- Move tag results number from the right side of the screen closer to the main content for easier usability.


## How to test
CMD+K
Search React

## Screenshots
![image](https://github.com/bestofjs/bestofjs/assets/2955134/4105e263-4b58-4ed4-a38d-6c27d2e2262c)

![image](https://github.com/bestofjs/bestofjs/assets/2955134/b0e4fdda-0dde-412c-9cb8-6249d026d3cb)

![image](https://github.com/bestofjs/bestofjs/assets/2955134/aab23788-6dc2-4609-89fb-23bf0cbae8cb)