### PR TITLE
Improve UX on small screens for the beta version

### DIFF
--- a/apps/bestofjs-nextjs/src/app/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/page.tsx
@@ -59,7 +59,7 @@ export default async function IndexPage() {
 
           <NewestProjectList projects={newestProjects} />
         </div>
-        <div className="lg:w-[300px] space-y-8">
+        <div className="space-y-8 lg:w-[300px]">
           {/* @ts-expect-error Server Component */}
           <FeaturedProjects />
           <PopularTagsList tags={popularTags} />

--- a/apps/bestofjs-nextjs/src/app/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/page.tsx
@@ -59,7 +59,7 @@ export default async function IndexPage() {
 
           <NewestProjectList projects={newestProjects} />
         </div>
-        <div className="w-[300px] space-y-8">
+        <div className="lg:w-[300px] space-y-8">
           {/* @ts-expect-error Server Component */}
           <FeaturedProjects />
           <PopularTagsList tags={popularTags} />

--- a/apps/bestofjs-nextjs/src/app/search-container.tsx
+++ b/apps/bestofjs-nextjs/src/app/search-container.tsx
@@ -1,15 +1,18 @@
 "use client";
 
-import useSWR from "swr";
+import useSWR, { SWRConfiguration } from "swr";
 
 import { SearchPalette } from "@/components/search-palette/search-palette";
 
 export function SearchContainer() {
-  const { data, error } = useSWR("search-data", fetchSearchData);
+  const options: SWRConfiguration = {
+    revalidateIfStale: false,
+    revalidateOnFocus: false,
+  };
+  const { data, error } = useSWR("search-data", fetchSearchData, options);
 
-  if (error) return <div className="text-xs">Unable to load data</div>;
-  if (!data)
-    return <div className="text-xs text-muted-foreground">Loading</div>;
+  if (error) return <div className="text-xs">Error</div>;
+  if (!data) return <div className="text-xs text-muted-foreground">...</div>;
 
   return <SearchPalette allProjects={data.projects} allTags={data.tags} />;
 }

--- a/apps/bestofjs-nextjs/src/components/header/desktop-nav.tsx
+++ b/apps/bestofjs-nextjs/src/components/header/desktop-nav.tsx
@@ -28,10 +28,10 @@ export function MainNav() {
 
   return (
     <>
-      <div className="md:hidden">
+      <div className="mr-4 lg:hidden">
         <MobileMenuButton />
       </div>
-      <div className="hidden gap-6 md:flex md:gap-8">
+      <div className="flex gap-6 lg:gap-8">
         <Link
           href="/"
           className="flex items-center space-x-2"
@@ -43,7 +43,7 @@ export function MainNav() {
             className="h-[37.15px] w-[130px] text-primary"
           />
         </Link>
-        <div className="flex gap-4">
+        <div className="hidden gap-4 lg:flex">
           <nav className="flex gap-6">
             {mainNavItems?.map(
               (item, index) =>

--- a/apps/bestofjs-nextjs/src/components/header/mobile-nav.tsx
+++ b/apps/bestofjs-nextjs/src/components/header/mobile-nav.tsx
@@ -5,9 +5,15 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Bars3Icon } from "@heroicons/react/20/solid";
 
-import { extraNavItems, mainNavItems } from "@/config/site";
+import {
+  APP_REPO_URL,
+  DISCORD_URL,
+  extraNavItems,
+  mainNavItems,
+} from "@/config/site";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { Icons } from "@/components/icons";
 
@@ -60,7 +66,7 @@ function SidebarContent({
                   "flex items-center",
                   item.isActive(pathname)
                     ? "text-foreground"
-                    : "text-foreground/60",
+                    : "text-foreground/70",
                   item.disabled && "cursor-not-allowed opacity-80"
                 )}
                 onClick={() => onOpenChange(false)}
@@ -69,6 +75,25 @@ function SidebarContent({
               </Link>
             )
         )}
+        <Separator />
+        <div className="space-y-2">
+          <a
+            href={DISCORD_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="block text-foreground/70"
+          >
+            Discord
+          </a>
+          <a
+            href={APP_REPO_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="block text-foreground/70"
+          >
+            GitHub
+          </a>
+        </div>
       </div>
     </>
   );

--- a/apps/bestofjs-nextjs/src/components/header/site-header.tsx
+++ b/apps/bestofjs-nextjs/src/components/header/site-header.tsx
@@ -27,8 +27,13 @@ export function SiteHeader() {
           >
             <SearchContainer />
           </Suspense>
-          <nav className="flex items-center space-x-1">
-            <Link href={APP_REPO_URL} target="_blank" rel="noreferrer">
+          <nav className="flex items-center gap-1">
+            <Link
+              href={APP_REPO_URL}
+              target="_blank"
+              rel="noreferrer"
+              className="hidden sm:inline"
+            >
               <div
                 className={buttonVariants({
                   size: "sm",
@@ -39,7 +44,12 @@ export function SiteHeader() {
                 <span className="sr-only">GitHub</span>
               </div>
             </Link>
-            <Link href={DISCORD_URL} target="_blank" rel="noreferrer">
+            <Link
+              href={DISCORD_URL}
+              target="_blank"
+              rel="noreferrer"
+              className="hidden sm:inline"
+            >
               <div
                 className={buttonVariants({
                   size: "sm",

--- a/apps/bestofjs-nextjs/src/components/home/home-featured-projects.client.tsx
+++ b/apps/bestofjs-nextjs/src/components/home/home-featured-projects.client.tsx
@@ -111,7 +111,7 @@ function DynamicFeaturedProjectList({
   );
   const { mutate } = useSWRConfig();
   useEffect(() => {
-    if (pageNumber > 1) {
+    if (pageNumber > 0) {
       mutate("random-projects");
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/bestofjs-nextjs/src/components/icons.tsx
+++ b/apps/bestofjs-nextjs/src/components/icons.tsx
@@ -1,6 +1,7 @@
 import {
   LucideProps,
   Moon,
+  Search,
   SunMedium,
   type Icon as LucideIcon,
 } from "lucide-react";
@@ -10,6 +11,7 @@ export type Icon = LucideIcon;
 export const Icons = {
   sun: SunMedium,
   moon: Moon,
+  search: Search,
   logo: (props: LucideProps) => (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/apps/bestofjs-nextjs/src/components/search-palette/search-palette.tsx
+++ b/apps/bestofjs-nextjs/src/components/search-palette/search-palette.tsx
@@ -194,24 +194,24 @@ export function SearchPalette({ allProjects, allTags }: SearchProps) {
                   {filteredProjects.slice(0, 10).map((project) => (
                     <div
                       key={project.slug}
-                      className="grid gap-2 md:grid-cols-[1fr_40px_40px]"
+                      className="gap-2 md:grid md:grid-cols-[1fr_40px_40px]"
                     >
                       <CommandItem
                         key={project.slug}
                         value={`project/` + project.slug}
                         onSelect={onSelectProject}
                       >
-                        <div className="grid w-full grid-cols-[32px_1fr_100px] items-center gap-4">
+                        <div className="flex w-full min-w-0 items-center gap-4">
                           <div className="items-center justify-center">
                             <ProjectAvatar project={project} size={32} />
                           </div>
-                          <div>
+                          <div className="flex-1 truncate">
                             {project.name}
-                            <div className="truncate pt-2 text-xs text-muted-foreground">
+                            <div className="truncate pt-2 text-muted-foreground">
                               {project.description}
                             </div>
                           </div>
-                          <div className="text-right">
+                          <div className="hidden text-right md:block">
                             <StarTotal value={project.stars} />
                           </div>
                         </div>

--- a/apps/bestofjs-nextjs/src/components/search-palette/search-palette.tsx
+++ b/apps/bestofjs-nextjs/src/components/search-palette/search-palette.tsx
@@ -2,12 +2,12 @@
 
 import * as React from "react";
 import { useRouter } from "next/navigation";
-import { MagnifyingGlassIcon, XMarkIcon } from "@heroicons/react/20/solid";
+import { XMarkIcon } from "@heroicons/react/20/solid";
 import { GoHome, GoMarkGithub } from "react-icons/go";
 
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
-import { Button, buttonVariants } from "@/components/ui/button";
+import { buttonVariants } from "@/components/ui/button";
 import {
   CommandDialog,
   CommandEmpty,
@@ -16,12 +16,14 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
+import { Skeleton } from "@/components/ui/skeleton";
 
 import { ProjectAvatar, StarTotal, TagIcon } from "../core";
+import { Icons } from "../icons";
 import { stateToQueryString } from "../project-list/navigation-state";
 import { useSearchState } from "../project-list/search-state";
-import { Skeleton } from "../ui/skeleton";
 import { filterProjectsByTagsAndQuery } from "./find-projects";
+import { SearchTrigger } from "./search-trigger";
 
 export type SearchProps = {
   allProjects: BestOfJS.SearchIndexProject[];
@@ -155,19 +157,7 @@ export function SearchPalette({ allProjects, allTags }: SearchProps) {
 
   return (
     <>
-      <Button
-        variant="outline"
-        className={cn(
-          "relative ml-4 h-9 w-full justify-start rounded-[0.5rem] text-sm text-muted-foreground sm:pr-12 md:w-40 lg:w-64"
-        )}
-        onClick={() => setOpen(true)}
-      >
-        <span className="hidden lg:inline-flex">Search in projects...</span>
-        <span className="inline-flex lg:hidden">Search...</span>
-        <kbd className="pointer-events-none absolute right-1.5 top-2 hidden h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 text-[10px] font-medium opacity-100 sm:flex">
-          <span className="text-xs">⌘</span>K
-        </kbd>
-      </Button>
+      <SearchTrigger onClick={() => setOpen(true)} />
       <CommandDialog open={open} onOpenChange={onOpenChange}>
         {isPending ? (
           <div className="flex h-[300px] items-center justify-center">
@@ -271,7 +261,7 @@ export function SearchPalette({ allProjects, allTags }: SearchProps) {
                       className="grid w-full grid-cols-[32px_1fr] items-center gap-4"
                     >
                       <div className="flex justify-center">
-                        <MagnifyingGlassIcon className="" />
+                        <Icons.search />
                       </div>
                       <div>
                         Search for

--- a/apps/bestofjs-nextjs/src/components/search-palette/search-trigger.tsx
+++ b/apps/bestofjs-nextjs/src/components/search-palette/search-trigger.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { Icons } from "@/components/icons";
+
+type Props = {
+  onClick: () => void;
+};
+export function SearchTrigger({ onClick }: Props) {
+  return (
+    <>
+      <Button
+        variant="outline"
+        className={cn(
+          "relative ml-4 hidden h-9 w-full justify-start rounded-[0.5rem] text-sm text-muted-foreground sm:pr-12 md:w-40 lg:inline-flex lg:w-64"
+        )}
+        onClick={onClick}
+      >
+        <span className="hidden lg:inline-flex">Search in projects...</span>
+        <span className="inline-flex lg:hidden">Search...</span>
+        <kbd className="pointer-events-none absolute right-1.5 top-2 hidden h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 text-[10px] font-medium opacity-100 sm:flex">
+          <span className="text-xs">⌘</span>K
+        </kbd>
+      </Button>
+      <div className="flex items-center gap-4 lg:hidden">
+        <Button onClick={onClick} size="sm" variant="ghost">
+          <Icons.search className="h-5 w-5" />
+        </Button>
+        <Separator orientation="vertical" className="h-6" />
+      </div>
+    </>
+  );
+}

--- a/apps/bestofjs-nextjs/src/components/ui/command.tsx
+++ b/apps/bestofjs-nextjs/src/components/ui/command.tsx
@@ -68,7 +68,7 @@ const CommandList = React.forwardRef<
   <CommandPrimitive.List
     ref={ref}
     className={cn(
-      "h-[300px] overflow-y-auto overflow-x-hidden lg:h-[80vh] xl:h-[70vh]",
+      "h-[100vh] sm:h-[80vh] overflow-y-auto overflow-x-hidden lg:h-[80vh] xl:h-[70vh]",
       className
     )}
     {...props}

--- a/apps/bestofjs-nextjs/src/components/ui/command.tsx
+++ b/apps/bestofjs-nextjs/src/components/ui/command.tsx
@@ -68,7 +68,7 @@ const CommandList = React.forwardRef<
   <CommandPrimitive.List
     ref={ref}
     className={cn(
-      "h-[100vh] sm:h-[80vh] overflow-y-auto overflow-x-hidden lg:h-[80vh] xl:h-[70vh]",
+      "h-[100vh] overflow-y-auto overflow-x-hidden sm:h-[80vh] lg:h-[80vh] xl:h-[70vh]",
       className
     )}
     {...props}


### PR DESCRIPTION
## Goal

Improve UX on mobile, following the feedback we got here https://github.com/bestofjs/bestofjs/issues/176#issuecomment-1685607435

- show _Best of JS_ logo
- replace the input field that triggers the search palette with a search icon
- hide Discord and GitHub icons (moved to the navigation menu for mobiles)
- make "Featured Projects" block take all the available space instead of the hard-coded 300px
- make the search palette take the whole height

On small screens, the top bar is now made of the following elements:

- The menu button that reveals a meeny sliding from the left
- The _Best of JS logo_
- The search icon
- The dark/light mode switcher

## Screenshots

![image](https://github.com/bestofjs/bestofjs/assets/5546996/8d95850c-038f-4b44-a535-69fdd3b9856c)

![image](https://github.com/bestofjs/bestofjs/assets/5546996/325754d8-4e34-4d5a-9a3a-ccbed8437495)




