### PR TITLE
Improve UX on small screens for the beta version 

### DIFF
--- a/apps/bestofjs-nextjs/src/components/project-list/project-table.tsx
+++ b/apps/bestofjs-nextjs/src/components/project-list/project-table.tsx
@@ -75,7 +75,10 @@ const ProjectTableRow = ({
 
       <Cell className="w-auto py-4 pl-4 md:pl-2">
         <div className="relative flex items-center space-x-2">
-          <NextLink href={path} className="text-primary hover:underline">
+          <NextLink
+            href={path}
+            className="whitespace-nowrap text-primary hover:underline"
+          >
             {project.name}
           </NextLink>
           <div className="flex w-full space-x-1">

--- a/apps/bestofjs-nextjs/src/components/project-list/project-table.tsx
+++ b/apps/bestofjs-nextjs/src/components/project-list/project-table.tsx
@@ -116,14 +116,14 @@ const ProjectTableRow = ({
             )}
           </div>
           {metricsCell && (
-            <div className="flex w-[100px] justify-end pr-4 text-right md:hidden">
+            <div className="flex w-full justify-end pr-4 text-right md:hidden">
               {metricsCell(project)}
             </div>
           )}
         </div>
 
         <div className="mb-4 mt-2 space-y-2 text-sm">
-          <div className="font-serif">{project.description}</div>
+          <div className="pr-4 font-serif sm:pr-0">{project.description}</div>
           {showDetails && (
             <>
               <div className="md:hidden">

--- a/apps/bestofjs-nextjs/src/components/project-list/project-table.tsx
+++ b/apps/bestofjs-nextjs/src/components/project-list/project-table.tsx
@@ -78,7 +78,7 @@ const ProjectTableRow = ({
           <NextLink href={path} className="text-primary hover:underline">
             {project.name}
           </NextLink>
-          <div className="flex space-x-1">
+          <div className="flex w-full space-x-1">
             <a
               href={project.repository}
               aria-label="GitHub repository"
@@ -112,6 +112,11 @@ const ProjectTableRow = ({
               </a>
             )}
           </div>
+          {metricsCell && (
+            <div className="flex w-[100px] justify-end pr-4 text-right md:hidden">
+              {metricsCell(project)}
+            </div>
+          )}
         </div>
 
         <div className="mb-4 mt-2 space-y-2 text-sm">
@@ -143,7 +148,9 @@ const ProjectTableRow = ({
       )}
 
       {metricsCell && (
-        <Cell className="w-[100px] p-4 text-right">{metricsCell(project)}</Cell>
+        <Cell className="hidden w-[100px] p-4 text-right md:table-cell">
+          {metricsCell(project)}
+        </Cell>
       )}
     </tr>
   );

--- a/apps/bestofjs-nextjs/src/components/project-list/project-table.tsx
+++ b/apps/bestofjs-nextjs/src/components/project-list/project-table.tsx
@@ -81,7 +81,7 @@ const ProjectTableRow = ({
           >
             {project.name}
           </NextLink>
-          <div className="flex w-full space-x-1">
+          <div className="hidden w-full space-x-1 md:flex">
             <a
               href={project.repository}
               aria-label="GitHub repository"

--- a/apps/bestofjs-nextjs/src/components/project-list/project-table.tsx
+++ b/apps/bestofjs-nextjs/src/components/project-list/project-table.tsx
@@ -124,16 +124,6 @@ const ProjectTableRow = ({
 
         <div className="mb-4 mt-2 space-y-2 text-sm">
           <div className="pr-4 font-serif sm:pr-0">{project.description}</div>
-          {showDetails && (
-            <>
-              <div className="md:hidden">
-                Updated {fromNow(project.pushed_at)}
-              </div>
-              <div className="md:hidden">
-                {formatNumber(project.contributor_count)} contributors
-              </div>
-            </>
-          )}
         </div>
         <div>
           <ProjectTagGroup tags={project.tags} buildPageURL={buildPageURL} />


### PR DESCRIPTION
## Goal
I noticed in the [previous PR](https://github.com/bestofjs/bestofjs/pull/193), projects cards with many tags tend to get squished in mobile.

![image](https://github.com/bestofjs/bestofjs/assets/2955134/9c7d5114-44dd-48d6-a16c-221eaed94c93)


This PR moves the github-stars area to the top on mobile to free up more space.

## Screenshots

By screen size **( Original | PR fixed )**

XS:
![image](https://github.com/bestofjs/bestofjs/assets/2955134/efd82261-e3d7-4edd-a011-74e7e76c8a59)

SM:
![image](https://github.com/bestofjs/bestofjs/assets/2955134/85655d5d-310e-4c52-858b-0abfcb869e86)

MD:
![image](https://github.com/bestofjs/bestofjs/assets/2955134/6c3315b3-ba06-490c-9d0f-cfe80ad9249b)

LG:
![image](https://github.com/bestofjs/bestofjs/assets/2955134/dfd92a18-bf00-47e8-b6d0-5d799f3f7bdf)

