### PR TITLE
Fix errors related to caching in Beta

### DIFF
--- a/apps/bestofjs-nextjs/src/app/backend.ts
+++ b/apps/bestofjs-nextjs/src/app/backend.ts
@@ -145,6 +145,8 @@ export function createSearchClient() {
         .map((tag) => tagsByKey[tag])
         .filter(Boolean);
 
+      throw new Error("bug");
+
       return {
         projects,
         total,

--- a/apps/bestofjs-nextjs/src/app/backend.ts
+++ b/apps/bestofjs-nextjs/src/app/backend.ts
@@ -46,9 +46,8 @@ const defaultTagSearchQuery = {
 };
 
 export function createSearchClient() {
-  let data: Data;
   async function getData() {
-    return data || (await fetchData());
+    return await fetchData();
   }
 
   async function fetchData() {
@@ -60,7 +59,7 @@ export function createSearchClient() {
     });
     const featuredProjectIds = getFeaturedRandomList(projects);
 
-    data = {
+    return {
       projectCollection: projects,
       featuredProjectIds,
       tagCollection: Object.values(tagsByKey),
@@ -69,7 +68,6 @@ export function createSearchClient() {
       projectsBySlug,
       lastUpdateDate: new Date(date),
     };
-    return data;
   }
 
   function findRawProjects(
@@ -222,8 +220,7 @@ export function createSearchClient() {
       skip = 0,
       limit = 5,
     }: Pick<QueryParams, "skip" | "limit">) {
-      const { populate, projectsBySlug } = await getData();
-      const { featuredProjectIds } = data;
+      const { featuredProjectIds, populate, projectsBySlug } = await getData();
       const slugs = featuredProjectIds.slice(skip, skip + limit);
       const projects = slugs.map((slug) => populate(projectsBySlug[slug]));
       return { projects, total: featuredProjectIds.length };

--- a/apps/bestofjs-nextjs/src/app/backend.ts
+++ b/apps/bestofjs-nextjs/src/app/backend.ts
@@ -145,8 +145,6 @@ export function createSearchClient() {
         .map((tag) => tagsByKey[tag])
         .filter(Boolean);
 
-      throw new Error("bug");
-
       return {
         projects,
         total,

--- a/apps/bestofjs-nextjs/src/app/backend.ts
+++ b/apps/bestofjs-nextjs/src/app/backend.ts
@@ -343,7 +343,12 @@ async function fetchProjectData(): Promise<RawData> {
 function fetchDataFromRemoteJSON() {
   const url = FETCH_ALL_PROJECTS_URL + `/projects.json`;
   console.log(`Fetching JSON data from ${url}`);
-  const options = { next: { tags: ["all-projects"] } };
+  const options = {
+    next: {
+      revalidate: 60 * 60 * 24, // Revalidate every day
+      tags: ["all-projects"],
+    },
+  };
   return fetch(url, options).then((res) => res.json());
 }
 

--- a/apps/bestofjs-nextjs/src/app/backend.ts
+++ b/apps/bestofjs-nextjs/src/app/backend.ts
@@ -137,9 +137,13 @@ export function createSearchClient() {
       const projects = rawProjects.map(populate);
 
       const selectedTagIds: string[] = (criteria?.tags as any)?.$all || [];
-      const selectedTags = selectedTagIds.map((tag) => tagsByKey[tag]);
+      const selectedTags = selectedTagIds
+        .map((tag) => tagsByKey[tag])
+        .filter(Boolean);
 
-      const relevantTags = relevantTagIds.map((tag) => tagsByKey[tag]);
+      const relevantTags = relevantTagIds
+        .map((tag) => tagsByKey[tag])
+        .filter(Boolean);
 
       return {
         projects,

--- a/apps/bestofjs-nextjs/src/app/projects/error.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/error.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+// Error components must be Client Components
+import { useEffect } from "react";
+
+import { APP_REPO_URL, DISCORD_URL } from "@/config/site";
+import { ExternalLink, PageHeading } from "@/components/core/typography";
+
+export default function Error({ error }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    // Log the error to an error reporting service
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div>
+      <PageHeading title="Error" />
+      <div className="space-y-4">
+        <p>Sorry, something went wrong!</p>
+        <p>
+          Please contact us on{" "}
+          <ExternalLink url={APP_REPO_URL}>GitHub</ExternalLink> or{" "}
+          <ExternalLink url={DISCORD_URL}>Discord</ExternalLink>, thank you for
+          your help!
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/bestofjs-nextjs/src/components/core/project-avatar.tsx
+++ b/apps/bestofjs-nextjs/src/components/core/project-avatar.tsx
@@ -28,7 +28,6 @@ export const ProjectAvatar = ({ project, size = 100, className }: Props) => {
       height={size}
       alt={project.name}
       className={cn(className, `w-[${size}px] h-[${size}px max-w-none`)}
-      placeholder="blur"
     />
   );
 };


### PR DESCRIPTION
## Goal

In an attempt to avoid fetching too many times the JSON data used server-side, a caching mechanism was implemented to hold the data "in memory".

It seems to lead to inconsistencies when using https://beta.bestofjs.org/: 

- on the top page we can see new projects added recently (so the top page has been re-built with the latest data, as expected)
- clicking on one of the links to see the details of new project (Example: `https://beta.bestofjs.org/projects/typedi` leads to a page showing "Project not found", which happens when a given project is not found in the JSON data.

This PR removes this caching mechanism as Next.js already provides its own mechanism: https://nextjs.org/docs/app/building-your-application/data-fetching/fetching-caching-and-revalidating#fetching-data-on-the-server-with-fetch

This PR fixes an ugly error when trying to view a tag that does not exist, adding some basic error handling: https://nextjs.org/docs/app/building-your-application/routing/error-handling

## How to test

Go to a search URL using a tag that does not exist: `/projects?tags=xxx`, there should be a page showing no results, but no error should be triggered in the server-side.

TODO: detect invalid tags were provided and show an appropriate message?