### PR TITLE
Show the last update date on the home page using GMT time

### DIFF
--- a/apps/bestofjs-nextjs/src/app/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/page.tsx
@@ -240,10 +240,9 @@ function MoreProjectsSection({
   lastUpdateDate: Date;
   total: number;
 }) {
-  const timeOnlyFormat = new Intl.DateTimeFormat("default", {
-    hour: "numeric",
-    minute: "numeric",
-  });
+  function formatDateGMT(date: Date) {
+    return date.toJSON().slice(0, 10) + " " + date.toJSON().slice(11, 16);
+  }
 
   return (
     <div className="sm:px-4">
@@ -265,8 +264,11 @@ function MoreProjectsSection({
           .
         </p>
         <p>
-          Data is updated from GitHub every 24 hours, the last update was{" "}
-          <b>{fromNow(lastUpdateDate)}</b>.
+          Data is updated from GitHub every 24 hours, the last update was at{" "}
+          <code className="relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-sm font-semibold mr-2">
+            {formatDateGMT(lastUpdateDate)}
+          </code>
+          (GMT).
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Goal

The home page being generated server-side, using a relative time "N hours ago" does not work, it always show "a few seconds ago" because the page is statically generated just after data is available, every 24 hour.

To avoid a client component, the simplest option is to show the absolute data, using GMT time.

## Screenshots

![image](https://github.com/bestofjs/bestofjs/assets/5546996/178b0618-6d6f-4eb7-a7b5-a7add4dbee74)

