### PR TITLE
Show Ctrl K on non apple platforms

### DIFF
--- a/apps/bestofjs-nextjs/src/components/search-palette/search-trigger.tsx
+++ b/apps/bestofjs-nextjs/src/components/search-palette/search-trigger.tsx
@@ -5,10 +5,14 @@ import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { Icons } from "@/components/icons";
 
+import { useIsApplePlatform } from "./use-is-apple-platform";
+
 type Props = {
   onClick: () => void;
 };
 export function SearchTrigger({ onClick }: Props) {
+  const isApplePlatform = useIsApplePlatform();
+
   return (
     <>
       <Button
@@ -21,7 +25,13 @@ export function SearchTrigger({ onClick }: Props) {
         <span className="hidden lg:inline-flex">Search in projects...</span>
         <span className="inline-flex lg:hidden">Search...</span>
         <kbd className="pointer-events-none absolute right-1.5 top-2 hidden h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 text-[10px] font-medium opacity-100 sm:flex">
-          <span className="text-xs">⌘</span>K
+          {isApplePlatform ? (
+            <>
+              <span className="text-xs">⌘</span>K
+            </>
+          ) : (
+            <>Ctrl K</>
+          )}
         </kbd>
       </Button>
       <div className="flex items-center gap-4 lg:hidden">

--- a/apps/bestofjs-nextjs/src/components/search-palette/use-is-apple-platform.ts
+++ b/apps/bestofjs-nextjs/src/components/search-palette/use-is-apple-platform.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react";
+
+export function useIsApplePlatform() {
+  let [isApplePlatform, setIsApplePlatform] = useState<boolean>();
+
+  useEffect(() => {
+    if (typeof navigator !== "undefined") {
+      if (/(Mac|iPhone|iPod|iPad)/i.test(navigator.platform)) {
+        setIsApplePlatform(true);
+      } else {
+        setIsApplePlatform(false);
+      }
+    }
+  }, []);
+
+  return isApplePlatform;
+}


### PR DESCRIPTION
## Goal

Show `Ctrl K` on non apple platforms, and `⌘ K` on Apple platforms.

## How to test

I tested on Linux. Maybe @michaelrambeau you can test on MacOS? :grin: 

## Screenshots
![Screenshot from 2023-09-05 11-21-05](https://github.com/bestofjs/bestofjs/assets/7598058/c86f7ae3-5af8-4162-a6c6-088367087ce1)
![Screenshot from 2023-09-05 11-20-45](https://github.com/bestofjs/bestofjs/assets/7598058/dddcedec-c434-41ca-8d6f-9933ad38c985)

