### PR TITLE
Improve OG image for projects's pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Made of two applications:
 
 ```shell
 ./apps
-├── bestofjs-nextjs # the beta version:    https://beta.bestofjs.org
-└── bestofjs-webui  # the current version: https://bestofjs.org
+├── bestofjs-nextjs # Next.js app  https://bestofjs.org
+└── bestofjs-webui  # Classic app  https://classic.bestofjs.org
 ```
 
-[![image](https://github.com/bestofjs/bestofjs/assets/5546996/6415339d-d004-4498-b5d1-0757a26d5ab6)](https://bestofjs.org/)
+[![image](https://github.com/bestofjs/bestofjs/assets/5546996/e0e48657-90de-4bc0-b0a0-80968e826217)](https://bestofjs.org/)
 
 ## Concept
 

--- a/apps/bestofjs-nextjs/next.config.mjs
+++ b/apps/bestofjs-nextjs/next.config.mjs
@@ -12,6 +12,13 @@ const nextConfig = {
       },
     ],
   },
+  redirects: () => [
+    {
+      source: "/tags/:tag",
+      destination: "/projects?tags=:tag",
+      permanent: false,
+    },
+  ],
 };
 
 export default nextConfig;

--- a/apps/bestofjs-nextjs/src/app/api/og/projects/[slug]/route.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/projects/[slug]/route.tsx
@@ -30,8 +30,9 @@ export async function GET(_req: Request, { params: { slug } }: Context) {
           style={{
             flex: 1,
             flexDirection: "column",
-            gap: 32,
             position: "relative",
+            height: 360,
+            justifyContent: "space-between",
             top: -20, // to align the top of the project's name with the top of the logo
           }}
         >

--- a/apps/bestofjs-nextjs/src/app/api/og/projects/[slug]/route.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/projects/[slug]/route.tsx
@@ -24,9 +24,17 @@ export async function GET(_req: Request, { params: { slug } }: Context) {
 
   return generateImageResponse(
     <ImageLayout>
-      <Box style={{ alignItems: "center", gap: 64 }}>
+      <Box style={{ alignItems: "flex-start", gap: 48 }}>
         <ProjectLogo project={project} size={200} />
-        <Box style={{ flex: 1, flexDirection: "column", gap: 32 }}>
+        <Box
+          style={{
+            flex: 1,
+            flexDirection: "column",
+            gap: 32,
+            position: "relative",
+            top: -20, // to align the top of the project's name with the top of the logo
+          }}
+        >
           <Box style={{ gap: 32, fontSize: 80 }}>{project.name}</Box>
           <div style={{ color: mutedColor }}>{project.description}</div>
           <Trend project={project} />

--- a/apps/bestofjs-nextjs/src/app/api/og/projects/[slug]/route.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/projects/[slug]/route.tsx
@@ -71,5 +71,7 @@ function Trend({ project }: { project: BestOfJS.Project }) {
       <div style={{ color: mutedColor }}>Total</div>
       <ShowStarsTotal value={project.stars} />
     </Box>
-  ) : null;
+  ) : (
+    <ShowStarsTotal value={project.stars} />
+  );
 }

--- a/apps/bestofjs-nextjs/src/components/search-palette/search-trigger.tsx
+++ b/apps/bestofjs-nextjs/src/components/search-palette/search-trigger.tsx
@@ -25,7 +25,7 @@ export function SearchTrigger({ onClick }: Props) {
         </kbd>
       </Button>
       <div className="flex items-center gap-4 lg:hidden">
-        <Button onClick={onClick} size="sm" variant="ghost">
+        <Button onClick={onClick} size="sm" variant="ghost" aria-label="Search">
           <Icons.search className="h-5 w-5" />
         </Button>
         <Separator orientation="vertical" className="h-6" />


### PR DESCRIPTION
## Goal

- Update README after the release of the Next.js version and the creation of the URL `classic.bestofjs.org`
- Add redirect from `/tags/:tag` to `/projects?tags=:tag` to take into account some links in the README (I think it would be nice to have URLs `/tags/:tag` in the future, we could generate the page statically because of the absence of query string parameters)
- Improve OG image layout for project details, it was not good when the description was long (E.g. `Epic Stack` project), the logo is now aligned to the top
 
## Screenshots

![image](https://github.com/bestofjs/bestofjs/assets/5546996/eb06cc5f-f0f8-435e-9f5a-94a0934809a7)

![image](https://github.com/bestofjs/bestofjs/assets/5546996/68b9f009-b85b-4685-8a4d-9b034e2f8dd9)




