### PR TITLE
Fix local build using a local JSON file for data

### DIFF
--- a/apps/bestofjs-nextjs/.eslintrc.cjs
+++ b/apps/bestofjs-nextjs/.eslintrc.cjs
@@ -1,3 +1,5 @@
+const path = require("path");
+
 module.exports = {
   $schema: "https://json.schemastore.org/eslintrc",
   root: true,

--- a/apps/bestofjs-nextjs/src/app/api/featured-projects/route.ts
+++ b/apps/bestofjs-nextjs/src/app/api/featured-projects/route.ts
@@ -1,4 +1,4 @@
-import { api } from "@/server/api";
+import { api } from "@/server/api-remote-json";
 
 export const runtime = "edge";
 

--- a/apps/bestofjs-nextjs/src/app/api/og/projects/[slug]/route.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/projects/[slug]/route.tsx
@@ -1,5 +1,5 @@
 import { formatNumber } from "@/helpers/numbers";
-import { api } from "@/server/api";
+import { api } from "@/server/api-remote-json";
 import {
   Box,
   ProjectLogo,

--- a/apps/bestofjs-nextjs/src/app/api/og/route.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/route.tsx
@@ -1,4 +1,4 @@
-import { api } from "@/server/api";
+import { api } from "@/server/api-remote-json";
 import { getHotProjectsRequest } from "@/app/backend-search-requests";
 
 import { ImageLayout } from "./og-image-layout";

--- a/apps/bestofjs-nextjs/src/app/api/search-data/route.ts
+++ b/apps/bestofjs-nextjs/src/app/api/search-data/route.ts
@@ -1,4 +1,4 @@
-import { api } from "@/server/api";
+import { api } from "@/server/api-remote-json";
 
 export const runtime = "edge";
 

--- a/apps/bestofjs-nextjs/src/server/api-local-json.ts
+++ b/apps/bestofjs-nextjs/src/server/api-local-json.ts
@@ -1,0 +1,25 @@
+import path from "node:path";
+import fs from "fs-extra";
+
+import { RawData } from "./api-utils";
+import { createAPI } from "./create-api";
+
+export const api = createAPI(fetchProjectData);
+
+let data: RawData; // cache the data to avoid reading the file system on each request
+
+async function fetchProjectData(): Promise<RawData> {
+  try {
+    if (!data) data = (await fetchDataFromFileSystem()) as RawData;
+    return data;
+  } catch (error) {
+    console.error("Unable to fetch local JSON data", (error as Error).message);
+    throw error;
+  }
+}
+
+function fetchDataFromFileSystem() {
+  console.log("Fetch from the file system");
+  const filepath = path.join(process.cwd(), "public", "data/projects.json");
+  return fs.readJSON(filepath);
+}

--- a/apps/bestofjs-nextjs/src/server/api-remote-json.ts
+++ b/apps/bestofjs-nextjs/src/server/api-remote-json.ts
@@ -1,0 +1,26 @@
+import { FETCH_ALL_PROJECTS_URL, RawData } from "./api-utils";
+import { createAPI } from "./create-api";
+
+export const api = createAPI(fetchProjectData);
+
+async function fetchProjectData(): Promise<RawData> {
+  try {
+    const data = await fetchDataFromRemoteJSON();
+    return data as RawData;
+  } catch (error) {
+    console.error("Unable to fetch remote JSON data", (error as Error).message);
+    throw error;
+  }
+}
+
+function fetchDataFromRemoteJSON() {
+  const url = FETCH_ALL_PROJECTS_URL + `/projects.json`;
+  console.log(`Fetching JSON data from ${url}`);
+  const options = {
+    next: {
+      revalidate: 60 * 60 * 24, // Revalidate every day
+      tags: ["all-projects"],
+    },
+  };
+  return fetch(url, options).then((res) => res.json());
+}

--- a/apps/bestofjs-nextjs/src/server/api-utils.tsx
+++ b/apps/bestofjs-nextjs/src/server/api-utils.tsx
@@ -4,6 +4,12 @@ import { shuffle } from "@/helpers/shuffle";
 
 export const FETCH_ALL_PROJECTS_URL = "https://bestofjs-static-api.vercel.app";
 
+export type RawData = {
+  projects: BestOfJS.RawProject[];
+  tags: BestOfJS.RawTag[];
+  date: string;
+};
+
 export type Data = {
   projectCollection: BestOfJS.RawProject[];
   featuredProjectIds: BestOfJS.Project["slug"][];

--- a/apps/bestofjs-nextjs/src/server/api.ts
+++ b/apps/bestofjs-nextjs/src/server/api.ts
@@ -1,0 +1,1 @@
+export * from "./api-local-json";

--- a/apps/bestofjs-nextjs/src/server/create-api.tsx
+++ b/apps/bestofjs-nextjs/src/server/create-api.tsx
@@ -5,24 +5,15 @@ import {
   APIContext,
   Data,
   FETCH_ALL_PROJECTS_URL,
+  RawData,
   getFeaturedRandomList,
   getProjectId,
   getTagsByKey,
   populateProject,
 } from "./api-utils";
 
-type RawData = {
-  projects: BestOfJS.RawProject[];
-  tags: BestOfJS.RawTag[];
-  date: string;
-};
-
-export function createAPI() {
+export function createAPI(fetchProjectData: () => Promise<RawData>) {
   async function getData() {
-    return await fetchData();
-  }
-
-  async function fetchData() {
     const { projects, tags: rawTags, date } = await fetchProjectData();
     const tagsByKey = getTagsByKey(rawTags, projects);
     const projectsBySlug: Data["projectsBySlug"] = {};
@@ -55,28 +46,4 @@ export function createAPI() {
     tags: tagsAPI,
     hallOfFame: hallOfFameAPI,
   };
-}
-
-export const api = createAPI();
-
-async function fetchProjectData(): Promise<RawData> {
-  try {
-    const data = await fetchDataFromRemoteJSON();
-    return data as RawData;
-  } catch (error) {
-    console.error("Unable to fetch data!", (error as Error).message);
-    throw error;
-  }
-}
-
-function fetchDataFromRemoteJSON() {
-  const url = FETCH_ALL_PROJECTS_URL + `/projects.json`;
-  console.log(`Fetching JSON data from ${url}`);
-  const options = {
-    next: {
-      revalidate: 60 * 60 * 24, // Revalidate every day
-      tags: ["all-projects"],
-    },
-  };
-  return fetch(url, options).then((res) => res.json());
 }


### PR DESCRIPTION
## Goal

Fix local build and re-introduce the local JSON file used as a local cache and re-built every day.

Because we have edge functions that generate images dynamically and that can access the file system, there are 2 versions of the API layer:

- one that uses the local JSON data `import {api} from "@app/server/api"` (the default one used for all pages) 
- one that uses that fetches JSON data remotely `import {api} from "@app/server/api-remote-json"`, used by API end-points with the `edge` runtime
 
The gist: the function that creates the `api` object used to query data now accepts a `fetchProjectData` function.
The strategy to fetch data (using local or remote JSOB) is considered as a dependency.

```ts
function createAPI(fetchProjectData: () => Promise<RawData>) {
  const { projects, tags, date } = await fetchProjectData();
  // ...
}
```

This way we can create different `api` objects that use a different strategy.

## How to test

Build locally end ensure there is no more errors:

```sh
pnpm -F bestofjs-nextjs build
```

## Thinking about the future

The current strategy of loading a big JSON file is not great, the implementation could be simplified if we had a real API server that responds to queries, instead of making the Next.js app handle the JSON data.


