### PR TITLE
Fix pages metadata URLs and tags number of projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Made of two applications:
 
 ```shell
 ./apps
-├── bestofjs-nextjs # Next.js app  https://bestofjs.org
-└── bestofjs-webui  # Classic app  https://classic.bestofjs.org
+├── bestofjs-nextjs # The Next.js app running on https://bestofjs.org
+└── bestofjs-webui  # The original Single Page Application available at https://classic.bestofjs.org
 ```
 
 [![image](https://github.com/bestofjs/bestofjs/assets/5546996/e0e48657-90de-4bc0-b0a0-80968e826217)](https://bestofjs.org/)

--- a/apps/bestofjs-nextjs/README.md
+++ b/apps/bestofjs-nextjs/README.md
@@ -1,12 +1,8 @@
 # Best of JS Next.js 13 application
 
-The "next" version of Best of JS is coming soon!
-
-Available at https://beta.bestofjs.org/
-
 ## Technology
 
-- Next.js app router with React Server Components
+- [Next.js](https://nextjs.org/) with app router and React Server Components
 - [shadcn/ui](https://ui.shadcn.com/) UI components, built on top of headless [Radix](https://radix-ui.com/)
 - [TailwindCSS](https://tailwindcss.com/) for styling
 

--- a/apps/bestofjs-nextjs/src/app/layout.tsx
+++ b/apps/bestofjs-nextjs/src/app/layout.tsx
@@ -2,7 +2,7 @@ import "@/app/globals.css";
 import { Metadata } from "next";
 import { Analytics } from "@vercel/analytics/react";
 
-import { APP_DISPLAY_NAME } from "@/config/site";
+import { APP_CANONICAL_URL, APP_DISPLAY_NAME } from "@/config/site";
 import { fontSans, fontSerif } from "@/lib/fonts";
 import { cn } from "@/lib/utils";
 import { Footer } from "@/components/footer/footer";
@@ -26,11 +26,22 @@ export const metadata: Metadata = {
     shortcut: "/favicon-16x16.png",
     apple: "/apple-touch-icon.png",
   },
-  metadataBase: new URL(`https://${process.env.VERCEL_URL}`), // to avoid warnings at build time
+  metadataBase: getMetadataRootURL(),
   openGraph: {
     images: ["/api/og"],
   },
 };
+
+function getMetadataRootURL() {
+  switch (process.env.VERCEL_ENV) {
+    case "production":
+      return new URL(APP_CANONICAL_URL); // ensure URLs start with https://bestofjs.org in production
+    case "preview":
+      return new URL(`https://${process.env.VERCEL_URL}`); // https://xxx.vercel.app
+    default:
+      return new URL(`http://localhost:${process.env.PORT || 3000}`);
+  }
+}
 
 interface RootLayoutProps {
   children: React.ReactNode;

--- a/apps/bestofjs-nextjs/src/app/projects/[slug]/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/[slug]/page.tsx
@@ -29,7 +29,6 @@ export async function generateMetadata({
   return {
     title: project.name,
     description: project.description,
-    metadataBase: new URL(`https://${process.env.VERCEL_URL}`), // to avoid warnings at build time
     openGraph: {
       images: [`/api/og/projects/${slug}`],
     },

--- a/apps/bestofjs-nextjs/src/app/projects/loading.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/loading.tsx
@@ -11,8 +11,8 @@ export default function ProjectListLoading() {
           Loading project list...
         </CardHeader>
         <div className="divide-y">
-          {[...Array(5)].map((i) => (
-            <LoadingProject key={i} />
+          {[...Array(5)].map((_, index) => (
+            <LoadingProject key={index} />
           ))}
         </div>
       </Card>

--- a/apps/bestofjs-nextjs/src/server/api-utils.tsx
+++ b/apps/bestofjs-nextjs/src/server/api-utils.tsx
@@ -103,9 +103,11 @@ export function getTagsByKey(
   tags: BestOfJS.RawTag[],
   projects: BestOfJS.RawProject[]
 ) {
-  const byKey = tags.reduce((acc, tag) => {
-    return { ...acc, [tag.code]: tag };
-  }, {}) as { [tag: string]: BestOfJS.Tag };
+  const byKey = {} as { [tag: string]: BestOfJS.Tag };
+
+  tags.forEach((tag) => {
+    byKey[tag.code] = { name: tag.name, code: tag.code, counter: 0 };
+  });
 
   projects.forEach(({ tags }) => {
     tags.forEach((tag) => {

--- a/apps/bestofjs-webui/src/components/home/beta-version-news.tsx
+++ b/apps/bestofjs-webui/src/components/home/beta-version-news.tsx
@@ -23,19 +23,19 @@ export const BetaVersionNews = () => {
     >
       <Flex mb={3} fontSize="xl" alignItems="center">
         <Icon as={GoMegaphone} fontSize="24px" color="var(--iconColor)" />
-        <Box ml={2}>Beta version live!</Box>
+        <Box ml={2}>Next.js version live!</Box>
       </Flex>
       <Stack>
         <Box>
           Check the new{" "}
           <ExternalLink
-            url="https://beta.bestofjs.org"
+            url="https://bestofjs.org"
             color="var(--textPrimaryColor)"
             fontFamily="var(--buttonFontFamily)"
             textDecoration="underline"
             fontWeight="bold"
           >
-            beta.bestofjs.org
+            bestofjs.org
           </ExternalLink>{" "}
           built with Next.js.
         </Box>


### PR DESCRIPTION
## Goal

In production, absolute URLs used to link the OG image in the page `<head>` should start with `https://bestofjs.org` instead of the Vercel URL (E.g. `https://bestofjs-kzvsa011l-bestofjs.vercel.app/api/og"`)

It might be the cause of OG images showing "Project not found" for projects added recently to _Best of JS_.

Also: fixes the number of projects displayed about the tag name, in several places, including the "Popular Tags" section in the home page.

## How to test

Check the page code source.

#### local

```html
<meta property="og:image" content="http://localhost:3000/api/og"/>
```

#### preview

https://bestofjs-nextjs-git-fix-metadata-bestofjs.vercel.app/

```html
<meta property="og:image" content="https://bestofjs-nextjs-gc5avwdbx-bestofjs.vercel.app/api/og"/
```


## Screenshots

The image I'd like to fix:

<img width="429" alt="image" src="https://github.com/bestofjs/bestofjs/assets/5546996/e0f52512-25b7-4481-a5c8-d99d3d8171a2">

Probable cause: Next.js looks up a project among stale JSON data (that don't include the projects added recently.

