### PR TITLE
Simplify NPM dependencies layout

### DIFF
--- a/apps/bestofjs-nextjs/README.md
+++ b/apps/bestofjs-nextjs/README.md
@@ -11,7 +11,7 @@
 Requirements:
 
 - Node.js 18
-- [PNPM](https://pnpm.io/)
+- [PNPM](https://pnpm.io/) 8
 
 The app is part of a monorepo built using [PNPM workspace](https://pnpm.io/workspaces) feature.
 

--- a/apps/bestofjs-nextjs/src/app/projects/[slug]/project-details-npm/dependencies-section.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/[slug]/project-details-npm/dependencies-section.tsx
@@ -1,5 +1,5 @@
 import { Badge } from "@/components/ui/badge";
-import { Card, CardHeader } from "@/components/ui/card";
+import { Card } from "@/components/ui/card";
 import {
   Collapsible,
   CollapsibleContent,

--- a/apps/bestofjs-nextjs/src/app/projects/[slug]/project-details-npm/dependencies-section.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/[slug]/project-details-npm/dependencies-section.tsx
@@ -39,26 +39,11 @@ export async function DependenciesSection({
       <CollapsibleContent className="space-y-4 py-4">
         {projects.length > 0 && (
           <Card>
-            <CardHeader>
-              Dependencies on <i>Best of JS</i>{" "}
-              <Badge variant="secondary" className="ml-2">
-                {projects.length}
-              </Badge>
-            </CardHeader>
             <ProjectTable projects={projects} />
           </Card>
         )}
         {dependenciesNotOnBestOfJS.length > 0 && (
           <Card>
-            {projects.length > 0 && (
-              <CardHeader>
-                Dependencies not on <i>Best of JS</i>
-                <Badge variant={"secondary"} className="ml-2">
-                  {dependenciesNotOnBestOfJS.length}
-                </Badge>
-              </CardHeader>
-            )}
-
             <Table className="text-md">
               <TableBody>
                 {dependenciesNotOnBestOfJS.map((dependency) => (

--- a/apps/bestofjs-nextjs/src/components/ui/card.tsx
+++ b/apps/bestofjs-nextjs/src/components/ui/card.tsx
@@ -23,7 +23,10 @@ const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col space-y-1.5 border-b p-4", className)}
+    className={cn(
+      "flex flex-row items-center space-y-1.5 border-b p-4",
+      className
+    )}
     {...props}
   />
 ));


### PR DESCRIPTION
## Goal

Fix the layout of the dependencies table, removing table headers "Dependencies on Best of JS" and "Dependencies not on Best of JS".

The layout is currently broken on production:

![image](https://github.com/bestofjs/bestofjs/assets/5546996/e8c8a43c-2c1a-4318-8a88-1474969f4e44)

I think it looks better without header at all? (screenshot below)

## How to test

Check projects that have a related NPM package, with different scenarios.

Only deps that are NOT on Best of JS:

http://localhost:3000/projects/axios

A mix of projects on and not on Best of JS: 

- http://localhost:3000/projects/tldraw
- http://localhost:3000/projects/genql


## Screenshots

![image](https://github.com/bestofjs/bestofjs/assets/5546996/80d73935-d818-4884-8ee5-e1d30cd05cb9)
