### PR TITLE
Fix "Featured Projects" pagination

### DIFF
--- a/apps/bestofjs-nextjs/src/app/featured/loading.tsx
+++ b/apps/bestofjs-nextjs/src/app/featured/loading.tsx
@@ -1,0 +1,3 @@
+export default function FeaturedProjectsLoading() {
+  return <>Loading Featured Projects</>;
+}

--- a/apps/bestofjs-nextjs/src/app/featured/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/featured/page.tsx
@@ -19,8 +19,6 @@ type PageProps = {
   searchParams: ProjectPageSearchParams;
 };
 
-export const dynamic = "force-dynamic";
-
 export default async function FeaturedProjectsPage({
   searchParams,
 }: PageProps) {

--- a/apps/bestofjs-nextjs/src/app/featured/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/featured/page.tsx
@@ -19,6 +19,8 @@ type PageProps = {
   searchParams: ProjectPageSearchParams;
 };
 
+export const revalidate = 0;
+
 export default async function FeaturedProjectsPage({
   searchParams,
 }: PageProps) {

--- a/apps/bestofjs-nextjs/src/app/featured/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/featured/page.tsx
@@ -19,7 +19,7 @@ type PageProps = {
   searchParams: ProjectPageSearchParams;
 };
 
-export const revalidate = 0;
+export const dynamic = "force-dynamic";
 
 export default async function FeaturedProjectsPage({
   searchParams,

--- a/apps/bestofjs-nextjs/src/components/project-list/navigation-state.tsx
+++ b/apps/bestofjs-nextjs/src/components/project-list/navigation-state.tsx
@@ -26,7 +26,7 @@ export function stateToQueryString({
   const params = {
     query: query || undefined,
     tags: tags.length === 0 ? undefined : tags,
-    sort: sort === DEFAULT_SEARCH_ORDER ? undefined : sort,
+    sort,
     page: page === 1 ? undefined : page,
     direction,
   };


### PR DESCRIPTION
## Goal

Fix an issue related to the "Featured projects" page (`/featured`) pagination in production.

When you go to `/featured` and then click on the next button (which has the effect of adding a query string:`/featured?page=2`), it does not not work, nothing happens.

Oddly the problem cannot be reproduced in local when building for production (`build` and `start` commands) 🙀 

If I manually add the query string `?page=1` and load the URL, the next button works.

This problem does not happens with other paginated pages like `/pages` and `/tags`.

After several tests (the different commits of this PR), the difference is that there is no `loading.tsx` page, for the loading state. Adding `loading.tsx` seems to fix the problem... it's very weird, I can't understand the reason.

## How to test

- Check the Preview link from the PR as the issue only happens on production (on Vercel), not in local
- Click on "View more" from the "Featured" block in the home page
- Scroll down and try to go to the next page
- Check the drop down button to change the sort order works correctly

## Screenshots

![image](https://github.com/bestofjs/bestofjs/assets/5546996/8ac638b2-c438-432d-bb3c-8a5461f80274)

