### PR TITLE
Ensure a branch name is set when fetching README from API

### DIFF
--- a/apps/bestofjs-nextjs/src/app/projects/[slug]/project-readme/project-readme.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/[slug]/project-readme/project-readme.tsx
@@ -26,7 +26,7 @@ export async function ReadmeCard({ project }: { project: BestOfJS.Project }) {
 }
 
 async function ReadmeContent({ project }: { project: BestOfJS.Project }) {
-  const html = await getData(project.full_name, project.branch);
+  const html = await getData(project.full_name, project.branch || "master");
   return <div dangerouslySetInnerHTML={{ __html: html }} />;
 }
 

--- a/apps/bestofjs-nextjs/src/lib/global.d.ts
+++ b/apps/bestofjs-nextjs/src/lib/global.d.ts
@@ -18,7 +18,7 @@ declare namespace BestOfJS {
     created_at: string;
     owner_id: string;
     url: string;
-    branch: string;
+    branch?: string;
     npm: string;
     downloads: number;
     icon: string;


### PR DESCRIPTION
## Goal

Fix missing images the README section of the project details page.

E.g. https://bestofjs.org/projects/guide-to-fp

![image](https://github.com/bestofjs/bestofjs/assets/5546996/f8fa5794-d40b-4707-b580-0ab567736ab1)

Reason: a branch name is not passed to the API end-point that fetches the README

The branch name is needed to create the URLs for local images included in the README, currently we pass `undefined` as a string instead of the default branch name: `https://raw.githubusercontent.com/MostlyAdequate/mostly-adequate-guide/undefined/images/cover.png`

Note: the JSON data only include the default branch name if it's different than `master`, otherwise the the `branch` field is missing, this is why I adjusted the type to make it optional.

## How to test

Ensure the image shows up correctly when going to `/projects/guide-to-fp`

## Screenshots

After, the book cover shows up :)

![image](https://github.com/bestofjs/bestofjs/assets/5546996/d70fbcd1-5bb6-4e17-a0ca-00d04917c19c)



