### PR TITLE
Add Hall of Fame basic search feature

### DIFF
--- a/apps/bestofjs-nextjs/next.config.mjs
+++ b/apps/bestofjs-nextjs/next.config.mjs
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  experimental: {
+    serverActions: true,
+  },
   images: {
     remotePatterns: [
       {

--- a/apps/bestofjs-nextjs/src/app/api/og/hall-of-fame/route.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/hall-of-fame/route.tsx
@@ -14,12 +14,10 @@ export async function GET() {
 
   return generateImageResponse(
     <ImageLayout>
-      <Box style={{ gap: 16 }}>
-        <div>The JavaScript Hall of Fame</div>
-      </Box>
+      <Box style={{ fontSize: 64 }}>JavaScript Hall of Fame</Box>
       <Box style={{ flexDirection: "row", gap: 32, flexWrap: "wrap" }}>
         {members.map((member) => (
-          <MemberBox key={member.username} member={member} size={100} />
+          <MemberBox key={member.username} member={member} size={112} />
         ))}
       </Box>
     </ImageLayout>

--- a/apps/bestofjs-nextjs/src/app/api/og/hall-of-fame/route.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/hall-of-fame/route.tsx
@@ -1,0 +1,46 @@
+/* eslint-disable @next/next/no-img-element */
+import { api } from "@/server/api-remote-json";
+
+import { ImageLayout } from "../og-image-layout";
+import { Box, generateImageResponse } from "../og-utils";
+
+export const runtime = "edge";
+
+export async function GET() {
+  const NUMBER_OF_CARD = 16;
+  const { members } = await api.hallOfFame.findMembers({
+    limit: NUMBER_OF_CARD,
+  });
+
+  return generateImageResponse(
+    <ImageLayout>
+      <Box style={{ gap: 16 }}>
+        <div>The JavaScript Hall of Fame</div>
+      </Box>
+      <Box style={{ flexDirection: "row", gap: 32, flexWrap: "wrap" }}>
+        {members.map((member) => (
+          <MemberBox key={member.username} member={member} size={100} />
+        ))}
+      </Box>
+    </ImageLayout>
+  );
+}
+
+function MemberBox({
+  member,
+  size,
+}: {
+  member: BestOfJS.HallOfFameMember;
+  size: number;
+}) {
+  return (
+    <Box>
+      <img
+        src={`${member.avatar}&s=${size}`}
+        width={size}
+        height={size}
+        alt={member.username}
+      />
+    </Box>
+  );
+}

--- a/apps/bestofjs-nextjs/src/app/api/og/og-image-layout.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/og-image-layout.tsx
@@ -28,7 +28,7 @@ export function ImageLayout({ children }: Props) {
           display: "flex",
           flexDirection: "column",
           gap: 32,
-          padding: 64,
+          padding: 40,
         }}
       >
         {children}

--- a/apps/bestofjs-nextjs/src/app/hall-of-fame/actions.ts
+++ b/apps/bestofjs-nextjs/src/app/hall-of-fame/actions.ts
@@ -5,19 +5,10 @@ import { api } from "@/server/api";
 export async function searchHallOfFameMembers(query: string) {
   "use server";
   const { members } = await api.hallOfFame.findMembers({ query });
+  await sleep(1000);
   return members;
 }
 
-// an attempt to use FormData with `<form action={}>`
-// export async function searchHallOfFameMembers2(formData: FormData) {
-//   "use server";
-//   const query = formData.get("query") || "";
-//   console.log("searchMembers!!", query);
-//   const { members } = await api.hallOfFame.findMembers({ query });
-//   await sleep(1000);
-//   return members;
-// }
-
-// function sleep(ms: number) {
-//   return new Promise((resolve) => setTimeout(resolve, ms));
-// }
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/apps/bestofjs-nextjs/src/app/hall-of-fame/actions.ts
+++ b/apps/bestofjs-nextjs/src/app/hall-of-fame/actions.ts
@@ -1,0 +1,23 @@
+"use server";
+
+import { api } from "@/server/api";
+
+export async function searchHallOfFameMembers(query: string) {
+  "use server";
+  const { members } = await api.hallOfFame.findMembers({ query });
+  return members;
+}
+
+// an attempt to use FormData with `<form action={}>`
+// export async function searchHallOfFameMembers2(formData: FormData) {
+//   "use server";
+//   const query = formData.get("query") || "";
+//   console.log("searchMembers!!", query);
+//   const { members } = await api.hallOfFame.findMembers({ query });
+//   await sleep(1000);
+//   return members;
+// }
+
+// function sleep(ms: number) {
+//   return new Promise((resolve) => setTimeout(resolve, ms));
+// }

--- a/apps/bestofjs-nextjs/src/app/hall-of-fame/hall-of-fame-search.client.tsx
+++ b/apps/bestofjs-nextjs/src/app/hall-of-fame/hall-of-fame-search.client.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useRef } from "react";
+import invariant from "tiny-invariant";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+export function HallOfFameSearchBar({
+  query,
+  onSubmit,
+  onReset,
+}: {
+  query: string;
+  onSubmit: (value: string) => void;
+  onReset: () => void;
+}) {
+  const ref = useRef<HTMLInputElement>(null);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    onSubmit(ref.current?.value || "");
+  };
+
+  const handleReset = () => {
+    invariant(ref.current);
+    ref.current.value = "";
+    ref.current.focus();
+    onReset();
+  };
+
+  return (
+    <form
+      className="mb-4 flex w-full space-x-4"
+      onSubmit={handleSubmit}
+      autoComplete="off"
+    >
+      <Input
+        autoFocus
+        autoComplete="off"
+        autoCorrect="false"
+        spellCheck="false"
+        type="text"
+        placeholder="Filter by name or username"
+        name="query"
+        defaultValue={query}
+        ref={ref}
+      />
+      <Button
+        type="button"
+        onClick={handleReset}
+        disabled={!query}
+        variant="secondary"
+      >
+        Reset
+      </Button>
+      <Button type="submit">Search</Button>
+    </form>
+  );
+}

--- a/apps/bestofjs-nextjs/src/app/hall-of-fame/hall-of-fame-search.client.tsx
+++ b/apps/bestofjs-nextjs/src/app/hall-of-fame/hall-of-fame-search.client.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useRef } from "react";
+import { XMarkIcon } from "@heroicons/react/20/solid";
 import invariant from "tiny-invariant";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Icons } from "@/components/icons";
 
 export function HallOfFameSearchBar({
   query,
@@ -52,9 +54,13 @@ export function HallOfFameSearchBar({
         disabled={!query}
         variant="secondary"
       >
-        Reset
+        <span className="mr-2 hidden md:inline">Reset</span>
+        <XMarkIcon className="h-5 w-5" />
       </Button>
-      <Button type="submit">Search</Button>
+      <Button type="submit">
+        <span className="mr-2 hidden md:inline">Search</span>
+        <Icons.search className="h-5 w-5" />
+      </Button>
     </form>
   );
 }

--- a/apps/bestofjs-nextjs/src/app/hall-of-fame/hall-of-fame-view.client.tsx
+++ b/apps/bestofjs-nextjs/src/app/hall-of-fame/hall-of-fame-view.client.tsx
@@ -8,6 +8,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { searchHallOfFameMembers } from "./actions";
 import { HallOfFameSearchBar } from "./hall-of-fame-search.client";
 import { HallOfFameMemberList } from "./hall-of-member-list";
+import { HallOfFameSkeletonCard } from "./loading";
 
 export function HallOfFameClientView({
   initialContent,
@@ -30,8 +31,6 @@ export function HallOfFameClientView({
     setQuery("");
   };
 
-  if (isPending) return <>Searching...</>;
-
   return (
     <>
       <HallOfFameSearchBar
@@ -40,15 +39,39 @@ export function HallOfFameClientView({
         onReset={onReset}
       />
       {query ? (
-        <>
-          <div className="mb-4 text-muted-foreground">
-            <DescribeSearchResults count={results.length} />
-          </div>
-          <HallOfFameMemberList members={results} />
-        </>
+        <SearchResults results={results} isPending={isPending} />
       ) : (
         initialContent
       )}
+    </>
+  );
+}
+
+function SearchResults({
+  results,
+  isPending,
+}: {
+  results: BestOfJS.HallOfFameMember[];
+  isPending: boolean;
+}) {
+  if (isPending) {
+    return (
+      <>
+        <div className="mb-4 text-muted-foreground">Searching...</div>
+        <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
+          {["?", "?"].map((name, index) => (
+            <HallOfFameSkeletonCard key={index} name={name} />
+          ))}
+        </div>
+      </>
+    );
+  }
+  return (
+    <>
+      <div className="mb-4 text-muted-foreground">
+        <DescribeSearchResults count={results.length} />
+      </div>
+      <HallOfFameMemberList members={results} />
     </>
   );
 }

--- a/apps/bestofjs-nextjs/src/app/hall-of-fame/hall-of-fame-view.client.tsx
+++ b/apps/bestofjs-nextjs/src/app/hall-of-fame/hall-of-fame-view.client.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState } from "react";
+import { InfoIcon } from "lucide-react";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+
+import { searchHallOfFameMembers } from "./actions";
+import { HallOfFameSearchBar } from "./hall-of-fame-search.client";
+import { HallOfFameMemberList } from "./hall-of-member-list";
+
+export function HallOfFameClientView({
+  initialContent,
+}: {
+  initialContent: React.ReactNode;
+}) {
+  const [query, setQuery] = useState<string>("");
+  const [results, setResults] = useState<BestOfJS.HallOfFameMember[]>([]);
+  const [isPending, setIsPending] = useState(false);
+
+  const onSearch = async (searchQuery: string) => {
+    setQuery(searchQuery);
+    setIsPending(true);
+    const members = await searchHallOfFameMembers(searchQuery);
+    setIsPending(false);
+    setResults(members);
+  };
+
+  const onReset = () => {
+    setQuery("");
+  };
+
+  if (isPending) return <>Searching...</>;
+
+  return (
+    <>
+      <HallOfFameSearchBar
+        query={query}
+        onSubmit={onSearch}
+        onReset={onReset}
+      />
+      {query ? (
+        <>
+          <div className="mb-4 text-muted-foreground">
+            <DescribeSearchResults count={results.length} />
+          </div>
+          <HallOfFameMemberList members={results} />
+        </>
+      ) : (
+        initialContent
+      )}
+    </>
+  );
+}
+
+function DescribeSearchResults({ count }: { count: number }) {
+  if (count === 0) {
+    return (
+      <Alert className="mt-8">
+        <InfoIcon className="h-5 w-5" />
+        <AlertTitle>No results found</AlertTitle>
+        <AlertDescription>
+          Try another search or click on the Reset button.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+  return (
+    <div className="flex items-center">
+      <InfoIcon className="mr-2 h-5 w-5" />
+      {count === 1 ? "One member found" : `${count} members found`}
+    </div>
+  );
+}

--- a/apps/bestofjs-nextjs/src/app/hall-of-fame/loading.tsx
+++ b/apps/bestofjs-nextjs/src/app/hall-of-fame/loading.tsx
@@ -20,20 +20,26 @@ export default function HallOfFameLoading() {
       />
       <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
         {memberNames.map((name) => (
-          <Card key={name} className="sm:rounded-none">
-            <div className="flex border-b">
-              <Skeleton className="h-[100px] w-[100px] rounded-none" />
-              <div className="flex flex-1 items-center px-4 text-xl text-muted">
-                {name}
-              </div>
-            </div>
-            <div className="flex gap-4 p-4">
-              <Skeleton className="h-5 w-20" />
-              <Skeleton className="h-5 w-20" />
-            </div>
-          </Card>
+          <HallOfFameSkeletonCard key={name} name={name} />
         ))}
       </div>
     </>
+  );
+}
+
+export function HallOfFameSkeletonCard({ name }: { name: string }) {
+  return (
+    <Card className="sm:rounded-none">
+      <div className="flex border-b">
+        <Skeleton className="h-[100px] w-[100px] rounded-none" />
+        <div className="flex flex-1 items-center px-4 text-xl text-muted">
+          {name}
+        </div>
+      </div>
+      <div className="flex gap-4 p-4">
+        <Skeleton className="h-5 w-20" />
+        <Skeleton className="h-5 w-20" />
+      </div>
+    </Card>
   );
 }

--- a/apps/bestofjs-nextjs/src/app/hall-of-fame/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/hall-of-fame/page.tsx
@@ -15,6 +15,9 @@ export async function generateMetadata(): Promise<Metadata> {
     title: "Hall of Fame",
     description:
       "Some of the greatest developers, authors and speakers of the JavaScript community. Meet Evan, Dan, Sindre, TJ and friends!",
+    openGraph: {
+      images: [`/api/og/hall-of-fame`],
+    },
   };
 }
 

--- a/apps/bestofjs-nextjs/src/app/hall-of-fame/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/hall-of-fame/page.tsx
@@ -4,6 +4,7 @@ import { APP_REPO_URL } from "@/config/site";
 import { ExternalLink, PageHeading } from "@/components/core/typography";
 import { api } from "@/server/api";
 
+import { HallOfFameClientView } from "./hall-of-fame-view.client";
 import { HallOfFameMemberList } from "./hall-of-member-list";
 import Loading from "./loading";
 
@@ -18,7 +19,7 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function HallOfFamePage() {
-  const { members } = await fetchHallOfFameMembers();
+  const { members: allMembers } = await api.hallOfFame.findMembers();
   if (forceLoadingState) return <Loading />;
 
   return (
@@ -41,11 +42,17 @@ export default async function HallOfFamePage() {
           </>
         }
       />
-      <HallOfFameMemberList members={members} />
+      <HallOfFameClientView
+        initialContent={
+          <>
+            <div className="mb-4 text-muted-foreground">
+              Showing <b>all</b> {allMembers.length} members by number of
+              followers
+            </div>
+            <HallOfFameMemberList members={allMembers} />
+          </>
+        }
+      />
     </>
   );
-}
-
-function fetchHallOfFameMembers() {
-  return api.hallOfFame.findMembers();
 }

--- a/apps/bestofjs-nextjs/src/components/ui/input.tsx
+++ b/apps/bestofjs-nextjs/src/components/ui/input.tsx
@@ -1,0 +1,26 @@
+/* eslint-disable @typescript-eslint/no-empty-interface */
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Input.displayName = "Input";
+
+export { Input };

--- a/apps/bestofjs-nextjs/src/server/api-hall-of-fame.tsx
+++ b/apps/bestofjs-nextjs/src/server/api-hall-of-fame.tsx
@@ -49,7 +49,9 @@ export function createHallOfFameAPI(context: APIContext) {
       }
 
       const { heroes } = await fetchHallOfFameData();
-      const filteredMembers = query ? filterMembers(heroes, query) : heroes;
+      const filteredMembers = query
+        ? filterMembersByTextQuery(heroes, query)
+        : heroes;
       const populatedMembers = filteredMembers
         .map(populateMemberProjects)
         .filter(filterMember)
@@ -67,14 +69,16 @@ function fetchHallOfFameData() {
   }>;
 }
 
-function filterMembers(members: BestOfJS.RawHallOfFameMember[], query: string) {
+function filterMembersByTextQuery(
+  members: BestOfJS.RawHallOfFameMember[],
+  query: string
+) {
+  const includeRegExp = new RegExp(query, "i");
   const criteria = {
     $or: [
-      { name: { $regex: new RegExp(query, "i") } },
-      { username: { $regex: new RegExp(query, "i") } },
+      { name: { $regex: includeRegExp } },
+      { username: { $regex: includeRegExp } },
     ],
   };
-  const mingoQuery = new mingo.Query(criteria);
-  const filteredMembers = mingoQuery.find(members).all();
-  return filteredMembers as BestOfJS.RawHallOfFameMember[];
+  return mingo.find(members, criteria).all() as BestOfJS.RawHallOfFameMember[];
 }

--- a/apps/bestofjs-nextjs/src/server/api-hall-of-fame.tsx
+++ b/apps/bestofjs-nextjs/src/server/api-hall-of-fame.tsx
@@ -4,13 +4,14 @@ import mingo from "mingo";
 import { APIContext, FETCH_ALL_PROJECTS_URL } from "./api-utils";
 
 type FindOptions = {
+  limit?: number;
   query?: string;
 };
 
 export function createHallOfFameAPI(context: APIContext) {
   return {
     async findMembers(options?: FindOptions) {
-      const { query } = options || {};
+      const { limit = 1000, query } = options || {};
       const { populate, projectCollection, projectsBySlug } =
         await context.getData();
 
@@ -51,7 +52,8 @@ export function createHallOfFameAPI(context: APIContext) {
       const filteredMembers = query ? filterMembers(heroes, query) : heroes;
       const populatedMembers = filteredMembers
         .map(populateMemberProjects)
-        .filter(filterMember);
+        .filter(filterMember)
+        .slice(0, limit);
       return { members: populatedMembers };
     },
   };

--- a/apps/bestofjs-nextjs/src/server/api-hall-of-fame.tsx
+++ b/apps/bestofjs-nextjs/src/server/api-hall-of-fame.tsx
@@ -1,29 +1,47 @@
+import uniqBy from "lodash/uniqBy";
+import mingo from "mingo";
+
 import { APIContext, FETCH_ALL_PROJECTS_URL } from "./api-utils";
 
 export function createHallOfFameAPI(context: APIContext) {
   return {
     async findMembers() {
-      const { populate, projectsBySlug } = await context.getData();
+      const { populate, projectCollection, projectsBySlug } =
+        await context.getData();
       const { heroes } = await fetchHallOfFameData();
 
-      const populateMemberProjects = (member: BestOfJS.RawHallOfFameMember) => {
-        const projects: BestOfJS.Project[] = member.projects
+      function findProjectsByOwner(owner: string) {
+        const criteria = {
+          full_name: { $regex: new RegExp("^" + owner + "/") },
+        };
+        const projects = mingo
+          .find(projectCollection, criteria)
+          .sort({ stars: -1 })
+          .all() as BestOfJS.RawProject[];
+        return projects.map(populate);
+      }
+
+      function populateMemberProjects(member: BestOfJS.RawHallOfFameMember) {
+        const ownedProjects = findProjectsByOwner(member.username);
+        const extraProjects: BestOfJS.Project[] = member.projects
           .map((projectSlug) => projectsBySlug[projectSlug])
           .filter(Boolean) // needed as some members are linked to deprecated projects. TODO fix Hall of fame data?
           .map(populate);
+
+        const projects = uniqBy([...ownedProjects, ...extraProjects], "name");
         return {
           ...member,
           projects,
         } as BestOfJS.HallOfFameMember;
-      };
+      }
 
       // Include only members who have active projects on Best of JS
       // or a custom "bio" (used to describe book authors and speakers for example)
-      const filterMember = (member: BestOfJS.HallOfFameMember) => {
+      function filterMember(member: BestOfJS.HallOfFameMember) {
         return (
           member.followers > 100 && (member.projects.length > 0 || member.bio)
         );
-      };
+      }
 
       const members = heroes.map(populateMemberProjects).filter(filterMember);
       return { members };


### PR DESCRIPTION
## Goal

Improve the JavaScript Hall of Fame feature (`/hall-of-fame`):

- add a basic search form using Server actions, to filter the member by name and GitHub username
- show more projects related to Hall of Fame members by looking up projects from JSON projects data, adding projects whose "owner" is the Hall of Fame member

The `Input` component from https://ui.shadcn.com/docs/components/input was added.

About the implementation, this first iteration is very basic:

- No URL update (meaning it's not possible to share or to bookmark results)
- Even if the search happens on the server side, the search is triggered by JS running on the client, it could be improved by using `<form action={myServerAction}>` and `FormData` to read parameters

## How to test

- Go to the Hall of Fame page (you have to click to the "More" button from the top page)
- By default, all members are displayed (+140 members, no pagination for now!)
- Enter something like `"mike"` or `"paul"`
- Check the loading state
- Search results should be displayed quickly, even if it happens on the server


## Screenshots

### Default state

![image](https://github.com/bestofjs/bestofjs/assets/5546996/d6f77a01-f108-424c-ac4a-04d002af4fd5)

### Showing search results

![image](https://github.com/bestofjs/bestofjs/assets/5546996/40154424-1968-4eba-9633-1f0ca49d9778)

### No results

![image](https://github.com/bestofjs/bestofjs/assets/5546996/594d6373-56ce-4270-8a72-26b91c79bf87)

