### PR TITLE
Fix slow Hall of Fame search

### DIFF
--- a/apps/bestofjs-nextjs/src/app/api/revalidate/route.ts
+++ b/apps/bestofjs-nextjs/src/app/api/revalidate/route.ts
@@ -1,24 +1,26 @@
-import { revalidateTag } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 
 export const runtime = "edge";
 
-// API end-point to be called when we need to purge the cache for a given tag
-// without having to wait the delay of 24 hours set via fetch `revalidate` option
+// API end-point to be called when we need to purge the cache for a given tag or path
 // Doc: https://nextjs.org/docs/app/building-your-application/caching
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
     const tag = searchParams.get("tag");
-    if (!tag) throw new Error("Provide `tag` parameter");
-    revalidateTag(tag);
-    const output = { status: "No error!", tag };
+    const path = searchParams.get("path");
 
-    return new Response(JSON.stringify(output), {
-      status: 200,
-      headers: {
-        "content-type": "application/json",
-      },
-    });
+    if (tag) {
+      revalidateTag(tag);
+      return sendResponse({ tag });
+    }
+
+    if (path) {
+      revalidatePath(path);
+      return sendResponse({ path });
+    }
+
+    throw new Error("Provide `tag` or `path` parameter to invalidate cache");
   } catch (error) {
     const output = { status: "error", message: (error as Error).message };
     return new Response(JSON.stringify(output), {
@@ -28,4 +30,16 @@ export async function GET(request: Request) {
       },
     });
   }
+}
+
+function sendResponse(data: { tag?: string; path?: string }) {
+  return new Response(
+    JSON.stringify({ message: "Revalidate request sent, no error", ...data }),
+    {
+      status: 200,
+      headers: {
+        "content-type": "application/json",
+      },
+    }
+  );
 }

--- a/apps/bestofjs-nextjs/src/app/hall-of-fame/actions.ts
+++ b/apps/bestofjs-nextjs/src/app/hall-of-fame/actions.ts
@@ -5,10 +5,5 @@ import { api } from "@/server/api";
 export async function searchHallOfFameMembers(query: string) {
   "use server";
   const { members } = await api.hallOfFame.findMembers({ query });
-  await sleep(1000);
   return members;
-}
-
-function sleep(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
## Goal

- Make Hall of Fame search feature (introduced here #222) faster by removing the `sleep` function used during testing 😅 
- Add `/api/revalidate?path=/hall-of-fame` API route to be able to re-build the Hall of Fame page

## How to test

- Go to the Hall of Fame page (you have to click to the "More" button from the top page)
- By default, all members are displayed (+140 members, no pagination for now!)
- Enter something like `"theo"`
- Search results should be displayed quickly, this time!

## Screenshots

![image](https://github.com/bestofjs/bestofjs/assets/5546996/65f8c824-e61e-4bea-872f-2037065e7270)

