### PR TITLE
Fix 404 error in the console because of redirect

### DIFF
--- a/apps/bestofjs-nextjs/next.config.mjs
+++ b/apps/bestofjs-nextjs/next.config.mjs
@@ -1,4 +1,4 @@
-import "./src/env.mjs";
+import { env } from "./src/env.mjs";
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -14,13 +14,28 @@ const nextConfig = {
       },
     ],
   },
-  redirects: () => [
-    {
-      source: "/tags/:tag",
-      destination: "/projects?tags=:tag",
-      permanent: false,
-    },
-  ],
+  redirects: async () => {
+    const { year, month } = await fetchLatestRankings();
+    return [
+      {
+        source: "/tags/:tag",
+        destination: "/projects?tags=:tag",
+        permanent: false,
+      },
+      {
+        source: "/rankings/monthly",
+        destination: `/rankings/monthly/${year}/${month}`,
+        permanent: false,
+      },
+    ];
+  },
 };
+
+function fetchLatestRankings() {
+  const url = `${env.RANKINGS_ROOT_URL}/monthly/latest`;
+  console.log("Fetching latest rankings from", url);
+  const data = fetch(url).then((res) => res.json());
+  return data;
+}
 
 export default nextConfig;

--- a/apps/bestofjs-nextjs/scripts/build-project-data.mjs
+++ b/apps/bestofjs-nextjs/scripts/build-project-data.mjs
@@ -6,6 +6,8 @@ To speed up requests and avoid network errors when the domain is black-listed, w
 import path from "path";
 import fs from "fs-extra";
 
+import { env } from "../src/env.mjs";
+
 async function main() {
   console.log("=== Build JSON files for the backend... ===");
   await buildJsonFile("projects.json");
@@ -15,8 +17,7 @@ async function main() {
 main();
 
 async function buildJsonFile(filename) {
-  const rootURL = "https://bestofjs-static-api.vercel.app";
-  const url = rootURL + `/` + filename;
+  const url = env.STATIC_API_ROOT_URL + `/` + filename;
   console.log(`Fetching data from ${url}`);
   const data = await fetch(url).then((res) => res.json());
   const filepath = path.join(process.cwd(), "public", "data", filename);

--- a/apps/bestofjs-nextjs/src/app/rankings/monthly/route.tsx
+++ b/apps/bestofjs-nextjs/src/app/rankings/monthly/route.tsx
@@ -1,8 +1,0 @@
-import { redirect } from "next/navigation";
-
-import { fetchMonthlyRankings } from "./monthly-rankings-data";
-
-export async function GET() {
-  const { year, month } = await fetchMonthlyRankings({ limit: 0 });
-  return redirect(`/rankings/monthly/${year}/${month}`);
-}


### PR DESCRIPTION
## Goal

Fix a 404 error showing up in the console, about React Server Components for `/rankings/monthly` path:

```        
GET https://bestofjs.org/rankings/monthly?_rsc=acgkz 404 (Not Found)
```

This path, used for the "Monthly" link in the menu, redirects the user to the latest month rankings page (E.g. `/rankings/monthly/2023/9`).

The redirect was setup using a API route (`route.tsx`).
Now it's setup using the main Next.js config file (which is a `.mjs` file, not TypeScript).

## How to test

- Ensure the error is gone
- Ensure the redirect works as expected: click on "Monthly" in the top bar
