### PR TITLE
fix(e2e:ci): make sure we target the bestofjs-nextjs

### DIFF
--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -34,6 +34,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           check_interval: 5 # seconds
           max_timeout: 600 # seconds
+          environment: "Preview - bestofjs" # https://github.com/patrickedqvist/wait-for-vercel-preview/issues/16#issuecomment-1140179571
 
       - name: Code Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -34,7 +34,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           check_interval: 5 # seconds
           max_timeout: 600 # seconds
-          environment: "Preview - bestofjs" # https://github.com/patrickedqvist/wait-for-vercel-preview/issues/16#issuecomment-1140179571
+          environment: "Preview – bestofjs" # https://github.com/patrickedqvist/wait-for-vercel-preview/issues/16#issuecomment-1140179571
 
       - name: Code Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -24,17 +24,20 @@ jobs:
 
   automated-testing:
     name: E2E Tests
-    timeout-minutes: 30
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - name: Waiting for 200 from the Vercel Preview
         uses: patrickedqvist/wait-for-vercel-preview@v1.2.0 # https://github.com/patrickedqvist/wait-for-vercel-preview
-        id: waitForDeploy
+        id: vercel_preview_url
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           check_interval: 5 # seconds
-          max_timeout: 600 # seconds
-          environment: "Preview – bestofjs" # https://github.com/patrickedqvist/wait-for-vercel-preview/issues/16#issuecomment-1140179571
+          max_timeout: 6000 # seconds
+          # Environment uses a special ASCII dash example: "Preview – bestofjs"
+          # If having issues, need to confirm environment name from the github deployments API
+          # https://github.com/patrickedqvist/wait-for-vercel-preview/issues/33
+          environment: "Preview – bestofjs"
 
       - name: Code Checkout
         uses: actions/checkout@v3
@@ -48,7 +51,7 @@ jobs:
       - name: Run Playwright tests
         run: pnpm test:e2e
         env:
-          BASE_URL: ${{ steps.waitForDeploy.outputs.url }}
+          BASE_URL: ${{ steps.vercel_preview_url.outputs.url }}
 
       - name: Upload report
         if: always()


### PR DESCRIPTION
## Goal
Ensure e2e runs on the `nextjs` version of our vercel deployment.

Needed to specify the correct `environment:` in the plugin.

### Gotchas:
Github's environment names use a special ASCII dash

> example: "Preview – bestofjs"

You need to confirm the name as returned from the API

```
curl -L \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer API_AUTH_TOKEN" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  https://api.github.com/repos/bestofjs/bestofjs/deployments
  ```

## How to test
When bestofjs-classic vercel builds and deploys first, our e2e test will not run.

You can confirm by the timestamps on this PR's run
by checking `bestofjs-classic` was ready first, and the e2e tests waited until the correct environment was up.

1. Classic was deployed first.
![image](https://github.com/bestofjs/bestofjs/assets/2955134/49e97c9e-5253-49e4-8394-aa70084710b4)
![image](https://github.com/bestofjs/bestofjs/assets/2955134/b2bfde16-8922-4d8e-bd44-6b549e57d4f2)

2. E2E test waited for the correct version of the app to be deployed.
![image](https://github.com/bestofjs/bestofjs/assets/2955134/8c3a5bfa-42da-4b35-b63c-9d6617fd8ee0)


