### PR TITLE
Add timestamp to OG image URL to fix caching issue

### DIFF
--- a/apps/bestofjs-nextjs/src/app/layout.tsx
+++ b/apps/bestofjs-nextjs/src/app/layout.tsx
@@ -28,7 +28,7 @@ export const metadata: Metadata = {
   },
   metadataBase: getMetadataRootURL(),
   openGraph: {
-    images: ["/api/og"],
+    images: [`/api/og?date=${new Date().toISOString().slice(0, 10)}`], // to avoid caching issues as the image is supposed to change every day
   },
 };
 


### PR DESCRIPTION
## Goal

Fix caching issue about the OG image generated when sharing Best of JS link on social networks.
I noticed the problem when creating a post on LinkedIn that includes the link https://bestofjs.org/ and from several autonatic messages on Slack

The image was including data about the hottest projects a few days ago, not today.

## How to test

You can see the problem when using a HTTP client like `Bruno` and making a request to https://bestofjs.org/api/og

Adding the timestamp to the URL solves the issue.

## Screenshots

![image](https://github.com/bestofjs/bestofjs/assets/5546996/131a3894-199e-41f6-93e3-976c2e9c0ea4)

