### PR TITLE
Fix OG image not showing up on Twitter

### DIFF
--- a/apps/bestofjs-nextjs/src/app/api/og/og-utils.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/og-utils.tsx
@@ -10,8 +10,8 @@ export function generateImageResponse(
   content: ConstructorParameters<typeof ImageResponse>[0]
 ) {
   return new ImageResponse(content, {
-    width: 1200,
-    height: 630,
+    width: 843,
+    height: 441,
   });
 }
 

--- a/apps/bestofjs-nextjs/src/app/api/og/og-utils.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/og-utils.tsx
@@ -10,8 +10,8 @@ export function generateImageResponse(
   content: ConstructorParameters<typeof ImageResponse>[0]
 ) {
   return new ImageResponse(content, {
-    width: 843,
-    height: 441,
+    width: 1200,
+    height: 630,
   });
 }
 

--- a/apps/bestofjs-nextjs/src/app/api/og/projects/[slug]/route.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/projects/[slug]/route.tsx
@@ -24,7 +24,7 @@ export async function GET(_req: Request, { params: { slug } }: Context) {
 
   return generateImageResponse(
     <ImageLayout>
-      <Box style={{ alignItems: "flex-start", gap: 48 }}>
+      <Box style={{ alignItems: "center", gap: 48 }}>
         <ProjectLogo project={project} size={200} />
         <Box
           style={{

--- a/apps/bestofjs-nextjs/src/app/hall-of-fame/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/hall-of-fame/page.tsx
@@ -1,6 +1,10 @@
 import { Metadata } from "next";
 
-import { APP_CANONICAL_URL, APP_DISPLAY_NAME, APP_REPO_URL } from "@/config/site";
+import {
+  APP_CANONICAL_URL,
+  APP_DISPLAY_NAME,
+  APP_REPO_URL,
+} from "@/config/site";
 import { ExternalLink, PageHeading } from "@/components/core/typography";
 import { api } from "@/server/api";
 
@@ -10,13 +14,13 @@ import Loading from "./loading";
 
 const forceLoadingState = false; // set to true when debugging the loading state
 
-const description="Some of the greatest developers, authors and speakers of the JavaScript community. Meet Evan, Dan, Sindre, TJ and friends!"
+const description =
+  "Some of the greatest developers, authors and speakers of the JavaScript community. Meet Evan, Dan, Sindre, TJ and friends!";
 
 export async function generateMetadata(): Promise<Metadata> {
   return {
     title: "Hall of Fame",
-    description:
-      ,
+    description,
     openGraph: {
       images: [`/api/og/hall-of-fame`],
       url: APP_CANONICAL_URL + "/hall-of-fame",

--- a/apps/bestofjs-nextjs/src/app/hall-of-fame/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/hall-of-fame/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from "next";
 
-import { APP_REPO_URL } from "@/config/site";
+import { APP_CANONICAL_URL, APP_REPO_URL } from "@/config/site";
 import { ExternalLink, PageHeading } from "@/components/core/typography";
 import { api } from "@/server/api";
 
@@ -17,6 +17,7 @@ export async function generateMetadata(): Promise<Metadata> {
       "Some of the greatest developers, authors and speakers of the JavaScript community. Meet Evan, Dan, Sindre, TJ and friends!",
     openGraph: {
       images: [`/api/og/hall-of-fame`],
+      url: APP_CANONICAL_URL + "/hall-of-fame",
     },
   };
 }

--- a/apps/bestofjs-nextjs/src/app/hall-of-fame/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/hall-of-fame/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from "next";
 
-import { APP_CANONICAL_URL, APP_REPO_URL } from "@/config/site";
+import { APP_CANONICAL_URL, APP_DISPLAY_NAME, APP_REPO_URL } from "@/config/site";
 import { ExternalLink, PageHeading } from "@/components/core/typography";
 import { api } from "@/server/api";
 
@@ -10,14 +10,18 @@ import Loading from "./loading";
 
 const forceLoadingState = false; // set to true when debugging the loading state
 
+const description="Some of the greatest developers, authors and speakers of the JavaScript community. Meet Evan, Dan, Sindre, TJ and friends!"
+
 export async function generateMetadata(): Promise<Metadata> {
   return {
     title: "Hall of Fame",
     description:
-      "Some of the greatest developers, authors and speakers of the JavaScript community. Meet Evan, Dan, Sindre, TJ and friends!",
+      ,
     openGraph: {
       images: [`/api/og/hall-of-fame`],
       url: APP_CANONICAL_URL + "/hall-of-fame",
+      title: APP_DISPLAY_NAME,
+      description,
     },
   };
 }

--- a/apps/bestofjs-nextjs/src/app/layout.tsx
+++ b/apps/bestofjs-nextjs/src/app/layout.tsx
@@ -2,7 +2,11 @@ import "@/app/globals.css";
 import { Metadata } from "next";
 import { Analytics } from "@vercel/analytics/react";
 
-import { APP_CANONICAL_URL, APP_DISPLAY_NAME } from "@/config/site";
+import {
+  APP_CANONICAL_URL,
+  APP_DESCRIPTION,
+  APP_DISPLAY_NAME,
+} from "@/config/site";
 import { fontSans, fontSerif } from "@/lib/fonts";
 import { cn } from "@/lib/utils";
 import { Footer } from "@/components/footer/footer";
@@ -15,8 +19,7 @@ export const metadata: Metadata = {
     default: APP_DISPLAY_NAME,
     template: `${APP_DISPLAY_NAME} • %s`,
   },
-  description:
-    "Check out the most popular open-source projects and the latest trends about the web platform: React, Vue.js, Node.js, Deno, Bun... The best of JavaScript, TypeScript and friends!",
+  description: APP_DESCRIPTION,
   themeColor: [
     { media: "(prefers-color-scheme: light)", color: "white" },
     { media: "(prefers-color-scheme: dark)", color: "black" },
@@ -29,6 +32,9 @@ export const metadata: Metadata = {
   metadataBase: getMetadataRootURL(),
   openGraph: {
     images: [`/api/og?date=${new Date().toISOString().slice(0, 10)}`], // to avoid caching issues as the image is supposed to change every day
+    url: APP_CANONICAL_URL,
+    title: APP_DISPLAY_NAME,
+    description: APP_DESCRIPTION,
   },
 };
 

--- a/apps/bestofjs-nextjs/src/app/projects/[slug]/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/[slug]/page.tsx
@@ -27,7 +27,7 @@ export async function generateMetadata({
   const project = await getData(slug);
   if (!project) return { title: "Project not found" };
 
-  const title = `${project.name} project`;
+  const title = project.name;
   const description = `Trends and data about ${project.name} project. ${project.description}`;
 
   return {

--- a/apps/bestofjs-nextjs/src/app/projects/[slug]/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { ProjectDetailsGitHubCard } from "./project-details-github/github-card";
 import { ProjectHeader } from "./project-header";
 import { ReadmeCard } from "./project-readme/project-readme";
 import "./project-readme/readme.css";
+import { APP_CANONICAL_URL } from "@/config/site";
 import { Card, CardContent } from "@/components/ui/card";
 import { api } from "@/server/api";
 
@@ -26,11 +27,17 @@ export async function generateMetadata({
   const project = await getData(slug);
   if (!project) return { title: "Project not found" };
 
+  const title = `${project.name} project`;
+  const description = `Trends and data about ${project.name} project. ${project.description}`;
+
   return {
-    title: project.name,
-    description: project.description,
+    title: title,
+    description: description,
     openGraph: {
       images: [`/api/og/projects/${slug}`],
+      url: `${APP_CANONICAL_URL}/projects/${slug}`,
+      title,
+      description,
     },
   };
 }

--- a/apps/bestofjs-nextjs/src/config/site.ts
+++ b/apps/bestofjs-nextjs/src/config/site.ts
@@ -1,4 +1,5 @@
 export const APP_DISPLAY_NAME = "Best of JS";
+export const APP_DESCRIPTION = `Check out the most popular open-source projects and the latest trends about the web platform: React, Vue.js, Node.js, Deno, Bun... The best of JavaScript, TypeScript and friends!`;
 export const APP_CANONICAL_URL = "https://bestofjs.org";
 export const APP_REPO_FULL_NAME = "bestofjs/bestofjs";
 export const APP_REPO_URL = "https://github.com/" + APP_REPO_FULL_NAME;


### PR DESCRIPTION
## Goal

Fix the OG image not showing up when posting on Twitter.
Everything works finw on Slack, Discord and any OG data viewer I have checked, including Twitter card preview... but not on Twitter itself.

It seems the reason is the absence of `og:url` metadata.

So this PR add meta data for the 3 pages that have an OG image:

- home page
- project details page
- hall of fame

## How to test

- Go to Twitter (or X depending on how you call it!
- Create a tweet including a URL from Best of JS
- The draft should include the card after a few seconds

## Screenshots

![image](https://github.com/bestofjs/bestofjs/assets/5546996/b9017c42-0715-43dc-af69-ab4e04dbfc7c)

