### PR TITLE
Fix total number of projects in home page

### DIFF
--- a/apps/bestofjs-nextjs/src/app/hall-of-fame/hall-of-fame-search.client.tsx
+++ b/apps/bestofjs-nextjs/src/app/hall-of-fame/hall-of-fame-search.client.tsx
@@ -51,7 +51,7 @@ export function HallOfFameSearchBar({
         type="button"
         onClick={handleReset}
         disabled={!query}
-        variant="secondary"
+        variant="outline"
       >
         <span className="mr-2 hidden md:inline">Reset</span>
         <XMarkIcon size={20} />

--- a/apps/bestofjs-nextjs/src/app/hall-of-fame/hall-of-member-list.tsx
+++ b/apps/bestofjs-nextjs/src/app/hall-of-fame/hall-of-member-list.tsx
@@ -29,6 +29,7 @@ function HallOfFameMember({ member }: { member: BestOfJS.HallOfFameMember }) {
           height="100"
           alt={member.username}
           className="display-block h-[100px] w-[100px]"
+          loading="lazy"
         />
         <div className="flex flex-1 flex-col justify-center gap-2 px-4">
           <div className="flex items-center">

--- a/apps/bestofjs-nextjs/src/app/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/page.tsx
@@ -273,11 +273,10 @@ function MoreProjectsSection({
 }
 
 async function getData() {
-  const {
-    projects: hotProjects,
-    lastUpdateDate,
-    total,
-  } = await api.projects.findProjects(getHotProjectsRequest());
+  const { lastUpdateDate, total } = await api.projects.getStats();
+  const { projects: hotProjects } = await api.projects.findProjects(
+    getHotProjectsRequest()
+  );
   const { projects: newestProjects } = await api.projects.findProjects(
     getLatestProjects()
   );

--- a/apps/bestofjs-nextjs/src/components/core/section.tsx
+++ b/apps/bestofjs-nextjs/src/components/core/section.tsx
@@ -10,7 +10,7 @@ type Props = {
 };
 export const SectionHeading = ({ className, icon, title, subtitle }: Props) => {
   return (
-    <div className={cn("flex items-center", className)}>
+    <div className={cn("flex w-full items-center", className)}>
       {icon && (
         <div className="pr-2 text-yellow-500 dark:text-yellow-600">{icon}</div>
       )}

--- a/apps/bestofjs-nextjs/src/server/api-projects.tsx
+++ b/apps/bestofjs-nextjs/src/server/api-projects.tsx
@@ -107,6 +107,11 @@ export function createProjectsAPI({ getData }: APIContext) {
       return { projects, total: featuredProjectIds.length };
     },
 
+    async getStats() {
+      const { projectCollection, lastUpdateDate } = await getData();
+      return { lastUpdateDate, total: projectCollection.length };
+    },
+
     async getSearchIndex() {
       const { projectCollection } = await getData();
       const projection = {


### PR DESCRIPTION
## Goal

- Fix incorrect total number of projects displayed in the "Do you want more projects?" section of the home page, adding a new API method `api.projects.getStats()`
- Load Hall of Fame members lazily (about 150 images are included in the page as we show ALL members by default)

## How to test

Check the "Do you want more projects?" at the bottom of the top page: the number of projects should match what you see when visiting the "All Projects" page (`/projects`)

## Screenshots

![image](https://github.com/bestofjs/bestofjs/assets/5546996/9b68e707-5b7e-4b5b-a375-4b77da4c9e1a)

