### PR TITLE
Improve `/projects` pages metadata

### DIFF
--- a/apps/bestofjs-nextjs/src/app/projects/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/page.tsx
@@ -91,7 +91,7 @@ function getPageDescription(data: ProjectsPageData, query: string) {
     .map((project) => project.name)
     .slice(0, 10)
     .join(", ");
-  const tagNames = tags.map((tag) => tag.name).join(" + ");
+  const tagNames = tags.map((tag) => `“${tag.name}“`).join(" + ");
 
   if (!query && tags.length === 0) {
     return `All the ${total} projects tracked by Best of JS: ${projectNames}...`;
@@ -100,7 +100,7 @@ function getPageDescription(data: ProjectsPageData, query: string) {
     return `The ${total} projects tagged with ${tagNames}: ${projectNames}...`;
   }
   if (query && tags.length > 0) {
-    return `${total} projects matching the query “${query}” and the tags ${tagNames}: ${projectNames}...}`;
+    return `${total} projects matching the query “${query}” and the tags ${tagNames}: ${projectNames}...`;
   }
   return `${total} projects matching the query “${query}”: ${projectNames}...`;
 }

--- a/apps/bestofjs-nextjs/src/app/projects/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import NextLink from "next/link";
 
+import { APP_CANONICAL_URL } from "@/config/site";
 import { cn } from "@/lib/utils";
 import { formatNumber } from "@/helpers/numbers";
 import { badgeVariants } from "@/components/ui/badge";
@@ -53,20 +54,28 @@ type PageProps = {
 export async function generateMetadata({
   searchParams,
 }: PageProps): Promise<Metadata> {
-  const { selectedTags } = await getData(searchParams);
+  const data = await getData(searchParams);
   const searchState = parseSearchParams(searchParams);
-  const title = getPageTitle(selectedTags, searchState.query);
+
+  const title = getPageTitle(data, searchState.query);
+  const description = getPageDescription(data, searchState.query);
+
   const queryString = stateToQueryString(searchState);
 
   return {
     title,
+    description,
     openGraph: {
       images: [`/api/og/projects/?${queryString}`],
+      url: `${APP_CANONICAL_URL}/projects/?${queryString}`,
+      title,
+      description,
     },
   };
 }
 
-function getPageTitle(tags: BestOfJS.Tag[], query: string) {
+function getPageTitle(data: ProjectsPageData, query: string) {
+  const { selectedTags: tags } = data;
   if (!query && tags.length === 0) {
     return "All Projects";
   }
@@ -76,6 +85,25 @@ function getPageTitle(tags: BestOfJS.Tag[], query: string) {
   return "Search results";
 }
 
+function getPageDescription(data: ProjectsPageData, query: string) {
+  const { projects, selectedTags: tags, total } = data;
+  const projectNames = projects
+    .map((project) => project.name)
+    .slice(0, 10)
+    .join(", ");
+  const tagNames = tags.map((tag) => tag.name).join(" + ");
+
+  if (!query && tags.length === 0) {
+    return `All the ${total} projects tracked by Best of JS: ${projectNames}...`;
+  }
+  if (!query && tags.length > 0) {
+    return `The ${total} projects tagged with ${tagNames}: ${projectNames}...`;
+  }
+  if (query && tags.length > 0) {
+    return `${total} projects matching the query “${query}” and the tags ${tagNames}: ${projectNames}...}`;
+  }
+  return `${total} projects matching the query “${query}”: ${projectNames}...`;
+}
 const showLoadingPage = false; // for debugging purpose only
 
 export default async function Projects({ searchParams }: PageProps) {


### PR DESCRIPTION
## Goal

Add missing metadata in the projects list pages (`/projects?...` path), taking into account different scenarios (with or without tags, with or without text query)

- Custom description
- Custom title
- Add missing OG URL to get the OG image working in Twitter (see #230 )

It should improve the content of the cards when sharing links on social networks and it could improve the SEO too.

## How to test

- Go to the Projects page 
- Trigger different searches
- Check page meta data from the DevTools, inspecting the page `<head>`.

#### `/projects`

- title = `All projects`
- description = `All the 1940 projects tracked by Best of JS: freeCodeCamp, React, Vue.js 2, JS Algorithms & Data Structures, You Don't Know JS, Bootstrap, VS Code, Airbnb Style Guide, 30 seconds of code, Next.js...`

#### `projects?tags=?tags=nodejs-framework`

- title = `Node.js framework`
- description = `The 54 projects tagged with “Node.js framework“: Next.js, Express, Nest, Strapi, Nuxt, Meteor, Koa, tRPC, Fastify, Remix...`

#### `/projects?query=css`

- title = `Search results`
- description = `92 projects matching the query “css”: CSS Modules, css.gg, CSSFX, CSS-Doodle, CSS Grid Generator, csso, css-select, Animate.css, Tailwind CSS, Normalize.css...`

#### `/projects?query=css&tags=css-in-js&sort=total`

- title = `Search results`
- description = `22 projects matching the query “css” and the tags “CSS in JS“: CSS Modules, UnoCSS, Master CSS, Styled Components, Emotion, Linaria, Stitches, Twin, Styled JSX, JSS...`

## Screenshot

![image](https://github.com/bestofjs/bestofjs/assets/5546996/4e9bb42b-d62e-4b0b-97e3-2674a654491e)


