### PR TITLE
Improve OG image of project list pages

### DIFF
--- a/apps/bestofjs-nextjs/src/app/api/og/hall-of-fame/route.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/hall-of-fame/route.tsx
@@ -17,7 +17,7 @@ export async function GET() {
       <Box style={{ fontSize: 64 }}>JavaScript Hall of Fame</Box>
       <Box style={{ flexDirection: "row", gap: 32, flexWrap: "wrap" }}>
         {members.map((member) => (
-          <MemberBox key={member.username} member={member} size={112} />
+          <MemberBox key={member.username} member={member} size={110} />
         ))}
       </Box>
     </ImageLayout>

--- a/apps/bestofjs-nextjs/src/app/api/og/og-image-layout.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/og-image-layout.tsx
@@ -41,7 +41,7 @@ export function ImageLayout({ children }: Props) {
 function AppLogo() {
   return (
     <div style={{ color: "#ffa666", display: "flex" }}>
-      <svg xmlns="http://www.w3.org/2000/svg" width="400" viewBox="0 0 700 200">
+      <svg xmlns="http://www.w3.org/2000/svg" width="200" viewBox="0 0 700 200">
         <g transform="translate(-40 -30)">
           <path
             fill="currentColor"

--- a/apps/bestofjs-nextjs/src/app/api/og/og-image-layout.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/og-image-layout.tsx
@@ -28,7 +28,7 @@ export function ImageLayout({ children }: Props) {
           display: "flex",
           flexDirection: "column",
           gap: 32,
-          padding: 40,
+          padding: "24px 48px",
         }}
       >
         {children}

--- a/apps/bestofjs-nextjs/src/app/api/og/og-utils.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/og-utils.tsx
@@ -34,7 +34,7 @@ export function getProjectRowStyles({ isFirst }: { isFirst: boolean }) {
     borderColor: "#3d3d42",
     borderStyle: "dashed",
     borderTopWidth: isFirst ? 1 : 0,
-    padding: "8px 0",
+    padding: "12px 0",
   };
 }
 

--- a/apps/bestofjs-nextjs/src/app/api/og/og-utils.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/og-utils.tsx
@@ -1,4 +1,6 @@
 /* eslint-disable @next/next/no-img-element */
+
+import React from "react";
 import { ImageResponse } from "next/server";
 
 import { APP_CANONICAL_URL } from "@/config/site";
@@ -21,6 +23,19 @@ export function generateImageResponse(
 export function Box(props: React.HTMLAttributes<HTMLDivElement>) {
   const { style, ...rest } = props;
   return <div style={{ display: "flex", ...style }} {...rest} />;
+}
+
+export function getProjectRowStyles({ isFirst }: { isFirst: boolean }) {
+  return {
+    color: "white",
+    gap: 24,
+    alignItems: "center",
+    borderBottom: "1px",
+    borderColor: "#3d3d42",
+    borderStyle: "dashed",
+    borderTopWidth: isFirst ? 1 : 0,
+    padding: "8px 0",
+  };
 }
 
 export function ProjectLogo({

--- a/apps/bestofjs-nextjs/src/app/api/og/projects/[slug]/route.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/projects/[slug]/route.tsx
@@ -33,7 +33,6 @@ export async function GET(_req: Request, { params: { slug } }: Context) {
             position: "relative",
             height: 360,
             justifyContent: "space-between",
-            top: -20, // to align the top of the project's name with the top of the logo
           }}
         >
           <Box style={{ gap: 32, fontSize: 80 }}>{project.name}</Box>

--- a/apps/bestofjs-nextjs/src/app/api/og/projects/route.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/projects/route.tsx
@@ -40,7 +40,12 @@ export async function GET(req: Request) {
       <ImageCaption tags={selectedTags} query={query} sortOption={sortOption} />
       <Box style={{ flexDirection: "column" }}>
         {projects.map((project, index) => (
-          <ProjectRow project={project} index={index} sortOption={sortOption} />
+          <ProjectRow
+            key={project.slug}
+            project={project}
+            index={index}
+            sortOption={sortOption}
+          />
         ))}
       </Box>
     </ImageLayout>

--- a/apps/bestofjs-nextjs/src/app/api/og/projects/route.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/projects/route.tsx
@@ -128,7 +128,7 @@ function ProjectScore({
   project: BestOfJS.Project;
   sortOptionKey: SortOptionKey;
 }) {
-  const { downloads, trends } = project;
+  const { contributor_count, created_at, downloads, trends } = project;
   switch (sortOptionKey) {
     case "daily":
       return <ShowStars value={trends.daily} showPrefix />;
@@ -146,6 +146,10 @@ function ProjectScore({
       ) : null;
     case "monthly-downloads":
       return <Box>{formatNumber(downloads, "compact")}</Box>;
+    case "contributors":
+      return <Box>{formatNumber(contributor_count, "compact")}</Box>;
+    case "created":
+      return <Box>{created_at}</Box>;
     default:
       return <ShowStars value={project.stars} />;
   }

--- a/apps/bestofjs-nextjs/src/app/api/og/projects/route.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/projects/route.tsx
@@ -15,6 +15,7 @@ import {
   StarIcon,
   TagIcon,
   generateImageResponse,
+  getProjectRowStyles,
   mutedColor,
 } from "@/app/api/og/og-utils";
 
@@ -39,12 +40,7 @@ export async function GET(req: Request) {
       <ImageCaption tags={selectedTags} query={query} sortOption={sortOption} />
       <Box style={{ flexDirection: "column" }}>
         {projects.map((project, index) => (
-          <ProjectRow
-            key={project.slug}
-            project={project}
-            rank={index + 1}
-            sortOption={sortOption}
-          />
+          <ProjectRow project={project} index={index} sortOption={sortOption} />
         ))}
       </Box>
     </ImageLayout>
@@ -98,26 +94,15 @@ function ImageCaption({
 
 function ProjectRow({
   project,
-  rank,
   sortOption,
+  index,
 }: {
   project: BestOfJS.Project;
-  rank: number;
   sortOption: SortOption;
+  index: number;
 }) {
   return (
-    <Box
-      style={{
-        color: "white",
-        gap: 24,
-        alignItems: "center",
-        borderBottom: "1px",
-        borderColor: "#3d3d42",
-        borderStyle: "dashed",
-        borderTopWidth: rank === 1 ? 1 : 0,
-        padding: "8px 0",
-      }}
-    >
+    <Box style={getProjectRowStyles({ isFirst: index === 0 })}>
       <Box>
         <ProjectLogo project={project} size={80} />
       </Box>

--- a/apps/bestofjs-nextjs/src/app/api/og/projects/route.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/projects/route.tsx
@@ -1,4 +1,5 @@
 import { formatNumber } from "@/helpers/numbers";
+import { getDeltaByDay } from "@/components/core";
 import {
   ProjectPageSearchParams,
   parseSearchParams,
@@ -136,18 +137,18 @@ function ProjectScore({
   const { contributor_count, created_at, downloads, trends } = project;
   switch (sortOptionKey) {
     case "daily":
-      return <ShowStars value={trends.daily} showPrefix />;
+      return <ShowStarsTotal value={trends.daily} showPrefix />;
     case "weekly":
       return trends.weekly ? (
-        <ShowStars value={trends.weekly} showPrefix />
+        <ShowStarsAverage value={getDeltaByDay("weekly")(project)} />
       ) : null;
     case "monthly":
       return trends.monthly ? (
-        <ShowStars value={trends.monthly} showPrefix />
+        <ShowStarsAverage value={getDeltaByDay("monthly")(project)} />
       ) : null;
     case "yearly":
       return trends.yearly ? (
-        <ShowStars value={trends.yearly} showPrefix />
+        <ShowStarsAverage value={getDeltaByDay("yearly")(project)} />
       ) : null;
     case "monthly-downloads":
       return <Box>{formatNumber(downloads, "compact")}</Box>;
@@ -156,11 +157,11 @@ function ProjectScore({
     case "created":
       return <Box>{created_at}</Box>;
     default:
-      return <ShowStars value={project.stars} />;
+      return <ShowStarsTotal value={project.stars} />;
   }
 }
 
-function ShowStars({
+function ShowStarsTotal({
   value,
   showPrefix,
 }: {
@@ -174,6 +175,18 @@ function ShowStars({
         {formatNumber(value, "compact")}
       </Box>
       <StarIcon />
+    </Box>
+  );
+}
+
+function ShowStarsAverage({ value }: { value?: number }) {
+  if (value === undefined) return null;
+  return (
+    <Box style={{ flexDirection: "row", alignItems: "center" }}>
+      {value > 0 ? "+" : ""}
+      <Box>{formatNumber(value, "compact")}</Box>
+      <StarIcon />
+      <Box style={{ color: mutedColor }}>/day</Box>
     </Box>
   );
 }

--- a/apps/bestofjs-nextjs/src/app/api/og/projects/route.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/projects/route.tsx
@@ -6,7 +6,7 @@ import {
 import {
   SortOption,
   SortOptionKey,
-  sortOrderOptionsByKey,
+  getSortOptionByKey,
 } from "@/components/project-list/sort-order-options";
 import { api } from "@/server/api-remote-json";
 import {
@@ -25,7 +25,7 @@ export const runtime = "edge";
 export async function GET(req: Request) {
   const NUMBER_OF_PROJECTS = 3;
   const { tags, query, sort, page } = getSearchParams(req.url);
-  const sortOption = getSortOption(sort);
+  const sortOption = getSortOptionByKey(sort);
   const { projects, selectedTags } = await api.projects.findProjects({
     criteria: tags.length > 0 ? { tags: { $all: tags } } : {},
     query,
@@ -68,12 +68,6 @@ function getSearchParams(url: string) {
     tags: searchParams.getAll("tags"), // take into account multiple tags
   } as ProjectPageSearchParams;
   return parseSearchParams(projectSearchParams);
-}
-
-function getSortOption(sortKey: string): SortOption {
-  const defaultOption = sortOrderOptionsByKey.daily;
-  if (!sortKey) return defaultOption;
-  return sortOrderOptionsByKey[sortKey as SortOptionKey] || defaultOption;
 }
 
 function ImageCaption({
@@ -180,9 +174,7 @@ function ShowStars({
   showPrefix?: boolean;
 }) {
   return (
-    <Box
-      style={{ flexDirection: "row", alignItems: "center", color: mutedColor }}
-    >
+    <Box style={{ flexDirection: "row", alignItems: "center" }}>
       <Box>
         {showPrefix && value > 0 ? "+" : ""}
         {formatNumber(value, "compact")}

--- a/apps/bestofjs-nextjs/src/app/api/og/route.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/route.tsx
@@ -5,7 +5,6 @@ import { ImageLayout } from "./og-image-layout";
 import {
   Box,
   ProjectLogo,
-  ProjectTable,
   StarIcon,
   generateImageResponse,
   getProjectRowStyles,

--- a/apps/bestofjs-nextjs/src/app/api/og/route.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/route.tsx
@@ -5,8 +5,10 @@ import { ImageLayout } from "./og-image-layout";
 import {
   Box,
   ProjectLogo,
+  ProjectTable,
   StarIcon,
   generateImageResponse,
+  getProjectRowStyles,
   mutedColor,
 } from "./og-utils";
 
@@ -28,7 +30,7 @@ export async function GET() {
       </Box>
       <Box style={{ flexDirection: "column" }}>
         {projects.map((project, index) => (
-          <ProjectRow key={project.slug} project={project} rank={index + 1} />
+          <ProjectRow project={project} index={index} />
         ))}
       </Box>
     </ImageLayout>
@@ -37,25 +39,14 @@ export async function GET() {
 
 function ProjectRow({
   project,
-  rank,
+  index,
 }: {
   project: BestOfJS.Project;
-  rank: number;
+  index: number;
 }) {
   return (
-    <Box
-      style={{
-        color: "white",
-        gap: 24,
-        alignItems: "center",
-        borderBottom: "1px",
-        borderColor: "#3d3d42",
-        borderStyle: "dashed",
-        borderTopWidth: rank === 1 ? 1 : 0,
-        padding: "8px 0",
-      }}
-    >
-      <Box style={{ color: mutedColor }}>#{rank}</Box>
+    <Box style={getProjectRowStyles({ isFirst: index === 0 })}>
+      <Box style={{ color: mutedColor }}>#{index + 1}</Box>
       <Box>
         <ProjectLogo project={project} size={80} />
       </Box>
@@ -65,7 +56,7 @@ function ProjectRow({
           flex: 1,
         }}
       >
-        <div>{project.name}</div>
+        <Box>{project.name}</Box>
         <Box>
           <ShowStars project={project} />
         </Box>

--- a/apps/bestofjs-nextjs/src/app/api/og/route.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/route.tsx
@@ -29,7 +29,7 @@ export async function GET() {
       </Box>
       <Box style={{ flexDirection: "column" }}>
         {projects.map((project, index) => (
-          <ProjectRow project={project} index={index} />
+          <ProjectRow key={project.slug} project={project} index={index} />
         ))}
       </Box>
     </ImageLayout>

--- a/apps/bestofjs-nextjs/src/app/api/stats/route.ts
+++ b/apps/bestofjs-nextjs/src/app/api/stats/route.ts
@@ -1,0 +1,22 @@
+import { api } from "@/server/api-remote-json";
+
+export const runtime = "edge";
+
+// This end-point is used to check the freshness of the static API data
+// that is supposed to be revalidated every day
+export async function GET() {
+  const stats = await api.projects.getStats();
+  const now = Date.now();
+  const timeDiff =
+    (now - new Date(stats.lastUpdateDate).getTime()) / (1000 * 60 * 60);
+
+  const output = { ...stats, relativeTime: timeDiff.toFixed(1) + " hours ago" };
+
+  return new Response(JSON.stringify(output), {
+    status: 200,
+    headers: {
+      "content-type": "application/json",
+      "Cache-Control": "max-age=0", // we don't want to cache this response
+    },
+  });
+}

--- a/apps/bestofjs-nextjs/src/app/featured/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/featured/page.tsx
@@ -6,11 +6,7 @@ import {
   stateToQueryString,
 } from "@/components/project-list/navigation-state";
 import { ProjectPaginatedList } from "@/components/project-list/project-paginated-list";
-import {
-  SortOption,
-  SortOptionKey,
-  sortOrderOptionsByKey,
-} from "@/components/project-list/sort-order-options";
+import { getSortOptionByKey } from "@/components/project-list/sort-order-options";
 import { api } from "@/server/api";
 
 import { ProjectSearchQuery, SearchQueryUpdater } from "../projects/types";
@@ -59,7 +55,7 @@ async function fetchFeaturedProjects({
   page,
   limit,
 }: ProjectSearchQuery) {
-  const sortOption = getSortOption(sort);
+  const sortOption = getSortOptionByKey(sort);
 
   const { projects, total } = await api.projects.findProjects({
     criteria: { isFeatured: true },
@@ -75,14 +71,4 @@ async function fetchFeaturedProjects({
     limit,
     sortOptionId: sortOption.key,
   };
-}
-
-function getSortOption(sortKey: string): SortOption {
-  const defaultOption = sortOrderOptionsByKey.newest;
-  if (!sortKey) return defaultOption;
-  return (
-    (sortKey in sortOrderOptionsByKey &&
-      sortOrderOptionsByKey[sortKey as SortOptionKey]) ||
-    defaultOption
-  );
 }

--- a/apps/bestofjs-nextjs/src/app/projects/[slug]/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/[slug]/page.tsx
@@ -34,7 +34,11 @@ export async function generateMetadata({
     title: title,
     description: description,
     openGraph: {
-      images: [`/api/og/projects/${slug}`],
+      images: [
+        `/api/og/projects/${slug}?date=${new Date()
+          .toISOString()
+          .slice(0, 10)}`,
+      ],
       url: `${APP_CANONICAL_URL}/projects/${slug}`,
       title,
       description,

--- a/apps/bestofjs-nextjs/src/app/projects/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/page.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from "next";
 import NextLink from "next/link";
 
-import { APP_CANONICAL_URL } from "@/config/site";
+import { APP_CANONICAL_URL, APP_DISPLAY_NAME } from "@/config/site";
 import { cn } from "@/lib/utils";
 import { formatNumber } from "@/helpers/numbers";
 import { badgeVariants } from "@/components/ui/badge";
@@ -20,20 +20,12 @@ import {
 } from "@/components/project-list/sort-order-options";
 import { api } from "@/server/api";
 
-// import { TagPickerPopover } from "@/components/tag-picker/tag-picker-popover"
-
 import ProjectListLoading from "./loading";
 import {
   ProjectSearchQuery,
   SearchQueryUpdater,
   SearchUrlBuilder,
 } from "./types";
-
-// needed when running the built app (`start` command)
-// otherwise Next.js always renders the same page, ignoring the query string parameters!
-// export const revalidate = 0;
-// export const dynamic = "force-dynamic";
-// Last Update: not needed with 13.4.9
 
 type ProjectsPageData = {
   projects: BestOfJS.Project[];
@@ -68,7 +60,7 @@ export async function generateMetadata({
     openGraph: {
       images: [`/api/og/projects/?${queryString}`],
       url: `${APP_CANONICAL_URL}/projects/?${queryString}`,
-      title,
+      title: `${title} • ${APP_DISPLAY_NAME}`,
       description,
     },
   };
@@ -80,24 +72,28 @@ function getPageTitle(data: ProjectsPageData, query: string) {
     return "All Projects";
   }
   if (!query && tags.length > 0) {
-    return tags.map((tag) => tag.name).join(" + ");
+    const tagNames = tags.map((tag) => tag.name).join(" + ");
+    return `${tagNames} projects`;
   }
   return "Search results";
 }
 
 function getPageDescription(data: ProjectsPageData, query: string) {
+  const NUMBER_OF_PROJECTS = 8;
   const { projects, selectedTags: tags, total } = data;
   const projectNames = projects
     .map((project) => project.name)
-    .slice(0, 10)
+    .slice(0, NUMBER_OF_PROJECTS)
     .join(", ");
   const tagNames = tags.map((tag) => `“${tag.name}“`).join(" + ");
+  const sortOption = getSortOption(data.sortOptionId);
+  const sortOptionLabel = sortOption.label.toLowerCase();
 
   if (!query && tags.length === 0) {
-    return `All the ${total} projects tracked by Best of JS: ${projectNames}...`;
+    return `All the ${total} projects tracked by ${APP_DISPLAY_NAME}, ${sortOptionLabel}: ${projectNames}...`;
   }
   if (!query && tags.length > 0) {
-    return `The ${total} projects tagged with ${tagNames}: ${projectNames}...`;
+    return `${total} projects tagged with ${tagNames}, ${sortOptionLabel}: ${projectNames}...`;
   }
   if (query && tags.length > 0) {
     return `${total} projects matching the query “${query}” and the tags ${tagNames}: ${projectNames}...`;

--- a/apps/bestofjs-nextjs/src/app/projects/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/page.tsx
@@ -57,7 +57,11 @@ export async function generateMetadata({
     title,
     description,
     openGraph: {
-      images: [`/api/og/projects/?${queryString}`],
+      images: [
+        `/api/og/projects/?${queryString}&date=${new Date()
+          .toISOString()
+          .slice(0, 10)}`,
+      ],
       url: `${APP_CANONICAL_URL}/projects/?${queryString}`,
       title: `${title} • ${APP_DISPLAY_NAME}`,
       description,

--- a/apps/bestofjs-nextjs/src/app/projects/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/page.tsx
@@ -14,9 +14,8 @@ import {
 } from "@/components/project-list/navigation-state";
 import { ProjectPaginatedList } from "@/components/project-list/project-paginated-list";
 import {
-  SortOption,
   SortOptionKey,
-  sortOrderOptionsByKey,
+  getSortOptionByKey,
 } from "@/components/project-list/sort-order-options";
 import { api } from "@/server/api";
 
@@ -86,7 +85,7 @@ function getPageDescription(data: ProjectsPageData, query: string) {
     .slice(0, NUMBER_OF_PROJECTS)
     .join(", ");
   const tagNames = tags.map((tag) => `“${tag.name}“`).join(" + ");
-  const sortOption = getSortOption(data.sortOptionId);
+  const sortOption = getSortOptionByKey(data.sortOptionId);
   const sortOptionLabel = sortOption.label.toLowerCase();
 
   if (!query && tags.length === 0) {
@@ -293,7 +292,7 @@ async function getData(
   searchParams: ProjectPageSearchParams
 ): Promise<ProjectsPageData> {
   const { tags, sort, page, limit, query } = parseSearchParams(searchParams);
-  const sortOption = getSortOption(sort);
+  const sortOption = getSortOptionByKey(sort);
 
   const { projects, selectedTags, relevantTags, total } =
     await api.projects.findProjects({
@@ -317,10 +316,4 @@ async function getData(
     tags,
     allTags,
   };
-}
-
-function getSortOption(sortKey: string): SortOption {
-  const defaultOption = sortOrderOptionsByKey.daily;
-  if (!sortKey) return defaultOption;
-  return sortOrderOptionsByKey[sortKey as SortOptionKey] || defaultOption;
 }

--- a/apps/bestofjs-nextjs/src/components/project-list/sort-order-options.ts
+++ b/apps/bestofjs-nextjs/src/components/project-list/sort-order-options.ts
@@ -83,3 +83,9 @@ export const sortOrderOptionsByKey = keyBy(sortOrderOptions, "key") as Record<
   SortOptionKey,
   SortOption
 >;
+
+export function getSortOptionByKey(sortKey: string): SortOption {
+  const defaultOption = sortOrderOptionsByKey.daily;
+  if (!sortKey) return defaultOption;
+  return sortOrderOptionsByKey[sortKey as SortOptionKey] || defaultOption;
+}

--- a/apps/bestofjs-nextjs/src/components/project-list/sort-order-options.ts
+++ b/apps/bestofjs-nextjs/src/components/project-list/sort-order-options.ts
@@ -65,7 +65,7 @@ export const sortOrderOptions: SortOption[] = [
   {
     key: "created",
     label: "By date of creation (Oldest first)",
-    sort: { created_at: -1 },
+    sort: { created_at: 1 },
   },
   {
     key: "newest",


### PR DESCRIPTION
## Goal

- Improve the OG image for the `/projects` paths (introduced by #215 ) by showing the current sort option
- Show tag display name instead of the tag code
- Add the current sort to page metadata, so that it shows up in the text displayed with the image on social networks
- Refactoring to remove duplicate code (`getSortOption` => `getSortOptionByKey`, moved to the file about `SortOption` definition)
- Improve the layout making the `Best of JS` logo less big, giving more space to the real content (since the vertical space is very limited!)

## How to test

Check the image generated at `/api/og/projects?tags=component&tags=react&sort=yearly`:

- it should include the current sort "By stars added the 12 last months"
- the right column of the table should show the number of stars added over the 12 last months, instead of the total number of stars

## Screenshots

![image](https://github.com/bestofjs/bestofjs/assets/5546996/1afe72dc-f23d-4e00-9940-80a5af459dd9)

