### PR TITLE
Improve cache busting technique for OG images to avoid caching issues

### DIFF
--- a/apps/bestofjs-nextjs/src/app/api/og/projects/[slug]/route.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/projects/[slug]/route.tsx
@@ -14,7 +14,7 @@ export const runtime = "edge";
 
 type Context = { params: { slug: string } };
 export async function GET(_req: Request, { params: { slug } }: Context) {
-  const project = await api.projects.getProjectBySlug(slug);
+  const { project } = await api.projects.getProjectBySlug(slug);
   if (!project)
     return generateImageResponse(
       <ImageLayout>

--- a/apps/bestofjs-nextjs/src/app/layout.tsx
+++ b/apps/bestofjs-nextjs/src/app/layout.tsx
@@ -31,7 +31,6 @@ export const metadata: Metadata = {
   },
   metadataBase: getMetadataRootURL(),
   openGraph: {
-    images: [`/api/og?date=${new Date().toISOString().slice(0, 10)}`], // to avoid caching issues as the image is supposed to change every day
     url: APP_CANONICAL_URL,
     title: APP_DISPLAY_NAME,
     description: APP_DESCRIPTION,

--- a/apps/bestofjs-nextjs/src/app/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/page.tsx
@@ -1,8 +1,11 @@
+import { Metadata } from "next";
 import NextLink from "next/link";
 import { GoFlame, GoGift, GoHeart, GoPlus } from "react-icons/go";
 
 import {
   ADD_PROJECT_REQUEST_URL,
+  APP_CANONICAL_URL,
+  APP_DESCRIPTION,
   APP_DISPLAY_NAME,
   APP_REPO_FULL_NAME,
   APP_REPO_URL,
@@ -10,6 +13,7 @@ import {
 } from "@/config/site";
 import { cn } from "@/lib/utils";
 import { formatNumber } from "@/helpers/numbers";
+import { addCacheBustingParam } from "@/helpers/url";
 import { buttonVariants } from "@/components/ui/button";
 import { Card, CardHeader } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
@@ -29,6 +33,27 @@ import {
   getHotProjectsRequest,
   getLatestProjects,
 } from "./backend-search-requests";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const data = await getData();
+
+  const urlSearchParams = new URLSearchParams();
+  addCacheBustingParam(urlSearchParams, data.lastUpdateDate);
+
+  const title = APP_DISPLAY_NAME;
+  const description = APP_DESCRIPTION;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      images: [`api/og/?${urlSearchParams.toString()}`],
+      url: APP_CANONICAL_URL,
+      title,
+      description,
+    },
+  };
+}
 
 export default async function IndexPage() {
   const {

--- a/apps/bestofjs-nextjs/src/app/projects/[slug]/project-header.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/[slug]/project-header.tsx
@@ -2,7 +2,7 @@ import React, { Suspense } from "react";
 import { ImNpm } from "react-icons/im";
 
 import { cn } from "@/lib/utils";
-import formatUrl from "@/helpers/url";
+import { formatUrl } from "@/helpers/url";
 import { buttonVariants } from "@/components/ui/button";
 import { GitHubIcon, HomeIcon, ProjectAvatar } from "@/components/core";
 import { ProjectTagGroup } from "@/components/tags/project-tag";

--- a/apps/bestofjs-nextjs/src/app/projects/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/page.tsx
@@ -4,6 +4,7 @@ import NextLink from "next/link";
 import { APP_CANONICAL_URL, APP_DISPLAY_NAME } from "@/config/site";
 import { cn } from "@/lib/utils";
 import { formatNumber } from "@/helpers/numbers";
+import { addCacheBustingParam } from "@/helpers/url";
 import { badgeVariants } from "@/components/ui/badge";
 import { PlusIcon, TagIcon, XMarkIcon } from "@/components/core";
 import { PageHeading } from "@/components/core/typography";
@@ -36,6 +37,7 @@ type ProjectsPageData = {
   relevantTags: BestOfJS.Tag[];
   allTags: BestOfJS.Tag[];
   sortOptionId: SortOptionKey;
+  lastUpdateDate: Date;
 };
 
 type PageProps = {
@@ -52,16 +54,14 @@ export async function generateMetadata({
   const description = getPageDescription(data, searchState.query);
 
   const queryString = stateToQueryString(searchState);
+  const urlSearchParams = new URLSearchParams(queryString);
+  addCacheBustingParam(urlSearchParams, data.lastUpdateDate);
 
   return {
     title,
     description,
     openGraph: {
-      images: [
-        `/api/og/projects/?${queryString}&date=${new Date()
-          .toISOString()
-          .slice(0, 10)}`,
-      ],
+      images: [`api/og/projects/?${urlSearchParams.toString()}`],
       url: `${APP_CANONICAL_URL}/projects/?${queryString}`,
       title: `${title} • ${APP_DISPLAY_NAME}`,
       description,
@@ -298,7 +298,7 @@ async function getData(
   const { tags, sort, page, limit, query } = parseSearchParams(searchParams);
   const sortOption = getSortOptionByKey(sort);
 
-  const { projects, selectedTags, relevantTags, total } =
+  const { projects, selectedTags, relevantTags, total, lastUpdateDate } =
     await api.projects.findProjects({
       criteria: tags.length > 0 ? { tags: { $all: tags } } : {},
       query,
@@ -319,5 +319,6 @@ async function getData(
     relevantTags,
     tags,
     allTags,
+    lastUpdateDate,
   };
 }

--- a/apps/bestofjs-nextjs/src/helpers/url.ts
+++ b/apps/bestofjs-nextjs/src/helpers/url.ts
@@ -3,3 +3,16 @@ export default function formatUrl(url: string) {
   const result = url.replace(/\/$/, "").toLowerCase();
   return result.replace(/^https?:\/\/(.*)$/, "$1");
 }
+
+/**
+ * Add `&t=2024-01-01T06-00` to the URL search params
+ * Some URL need to reflect the date when JSON data is updated,
+ * to avoid caching issues (E.g. OG images)
+ */
+export function addCacheBustingParam(
+  searchParams: URLSearchParams,
+  date: Date
+) {
+  const dateParam = date.toISOString().slice(0, 16).replace(":", "-"); // 2020-01-01T00:00 => 2020-01-01T00-00
+  searchParams.set("t", dateParam);
+}

--- a/apps/bestofjs-nextjs/src/helpers/url.ts
+++ b/apps/bestofjs-nextjs/src/helpers/url.ts
@@ -1,12 +1,12 @@
 // Format a URL to be displayed, removing `http://` and trailing `/`
-export default function formatUrl(url: string) {
+export function formatUrl(url: string) {
   const result = url.replace(/\/$/, "").toLowerCase();
   return result.replace(/^https?:\/\/(.*)$/, "$1");
 }
 
 /**
  * Add `&t=2024-01-01T06-00` to the URL search params
- * Some URL need to reflect the date when JSON data is updated,
+ * Some URLs need to reflect the date when JSON data is updated,
  * to avoid caching issues (E.g. OG images)
  */
 export function addCacheBustingParam(

--- a/apps/bestofjs-nextjs/src/server/api-projects.tsx
+++ b/apps/bestofjs-nextjs/src/server/api-projects.tsx
@@ -93,8 +93,11 @@ export function createProjectsAPI({ getData }: APIContext) {
     },
 
     async getProjectBySlug(slug: string) {
-      const { populate, projectsBySlug } = await getData();
-      return projectsBySlug[slug] ? populate(projectsBySlug[slug]) : undefined;
+      const { populate, projectsBySlug, lastUpdateDate } = await getData();
+      const project = projectsBySlug[slug]
+        ? populate(projectsBySlug[slug])
+        : undefined;
+      return { project, lastUpdateDate };
     },
 
     async findRandomFeaturedProjects({


### PR DESCRIPTION
## Goal

OG images for project list pages are supposed to reflect the exact content of the web page (see #233 ).
However I noticed some caching issues when using the current "cache busting" technique that adds a date parameter to the image URL.
In the OG image, I got the data from the previous day instead of the fresh data I expected (screenshots below)

Instead of only adding the current date (`2023-10-29`) I think it would work better if we update the URL with a parameter that includes the date and the time when JSON was generated: `/api/og/?t=2023-10-29T21-19` E.g.

Another change related to OG image: instead of making the home page's OG image the default OG image for all pages of the app, we assign the image only for the home page, using `page.tsx` instead of `layout.tsx`.

## How to test

Share URLs such as `/projects?sort=daily` and ensure data is correct, comparing the image content with the web page.

Ideally we should check before and after JSON data is updated and the app automatically re-built on Vercel (around 21:00 GMT)

## Screenshots

The bug happening in production when I checked on Slack: the image does not match the text above (the text reflects the latest data but not the image content!)

<img width="588" alt="image" src="https://github.com/bestofjs/bestofjs/assets/5546996/ebc409fc-7805-4de7-a082-95eff339149f">

The right image for today:

<img width="590" alt="image" src="https://github.com/bestofjs/bestofjs/assets/5546996/3010c561-56a0-4432-92ea-eb335a53622b">


