### PR TITLE
Improve OG images layout

### DIFF
--- a/apps/bestofjs-nextjs/src/app/api/og/hall-of-fame/route.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/hall-of-fame/route.tsx
@@ -14,11 +14,13 @@ export async function GET() {
 
   return generateImageResponse(
     <ImageLayout>
-      <Box style={{ fontSize: 64 }}>JavaScript Hall of Fame</Box>
-      <Box style={{ flexDirection: "row", gap: 32, flexWrap: "wrap" }}>
-        {members.map((member) => (
-          <MemberBox key={member.username} member={member} size={110} />
-        ))}
+      <Box style={{ flexDirection: "column", gap: 48 }}>
+        <Box style={{ fontSize: 64 }}>JavaScript Hall of Fame</Box>
+        <Box style={{ flexDirection: "row", gap: 32, flexWrap: "wrap" }}>
+          {members.map((member) => (
+            <MemberBox key={member.username} member={member} size={110} />
+          ))}
+        </Box>
       </Box>
     </ImageLayout>
   );

--- a/apps/bestofjs-nextjs/src/app/api/og/og-image-layout.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/og-image-layout.tsx
@@ -9,6 +9,7 @@ export function ImageLayout({ children }: Props) {
         fontSize: 40,
         color: "white",
         background: "#09090b",
+        backgroundImage: "linear-gradient(to bottom right, #313131, #09090b)",
         width: "100%",
         height: "100%",
         flexDirection: "column",
@@ -16,9 +17,8 @@ export function ImageLayout({ children }: Props) {
     >
       <div
         style={{
-          borderBottom: "2px solid #3d3d42",
           display: "flex",
-          padding: `24px 64px 16px`,
+          padding: `24px 48px 8px`,
         }}
       >
         <AppLogo />

--- a/apps/bestofjs-nextjs/src/app/api/og/og-image-layout.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/og-image-layout.tsx
@@ -15,20 +15,14 @@ export function ImageLayout({ children }: Props) {
         flexDirection: "column",
       }}
     >
+      <AppLogo />
       <div
         style={{
-          display: "flex",
-          padding: `24px 48px 8px`,
-        }}
-      >
-        <AppLogo />
-      </div>
-      <div
-        style={{
+          flexGrow: 1,
           display: "flex",
           flexDirection: "column",
-          gap: 32,
           padding: "24px 48px",
+          justifyContent: "center",
         }}
       >
         {children}
@@ -40,7 +34,15 @@ export function ImageLayout({ children }: Props) {
 
 function AppLogo() {
   return (
-    <div style={{ color: "#ffa666", display: "flex" }}>
+    <div
+      style={{
+        color: "#ffa666",
+        display: "flex",
+        position: "absolute",
+        top: 32,
+        right: 64,
+      }}
+    >
       <svg xmlns="http://www.w3.org/2000/svg" width="200" viewBox="0 0 700 200">
         <g transform="translate(-40 -30)">
           <path

--- a/apps/bestofjs-nextjs/src/app/api/og/og-utils.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/og-utils.tsx
@@ -7,6 +7,7 @@ import { APP_CANONICAL_URL } from "@/config/site";
 import { getProjectAvatarUrl } from "@/components/core/project-utils";
 
 export const mutedColor = "#a1a1aa";
+export const borderColor = "#484848";
 
 export function generateImageResponse(
   content: ConstructorParameters<typeof ImageResponse>[0]
@@ -31,8 +32,7 @@ export function getProjectRowStyles({ isFirst }: { isFirst: boolean }) {
     gap: 24,
     alignItems: "center",
     borderBottom: "1px",
-    borderColor: "#3d3d42",
-    borderStyle: "dashed",
+    borderColor,
     borderTopWidth: isFirst ? 1 : 0,
     padding: "12px 0",
   };

--- a/apps/bestofjs-nextjs/src/app/api/og/og-utils.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/og-utils.tsx
@@ -6,8 +6,8 @@ import { ImageResponse } from "next/server";
 import { APP_CANONICAL_URL } from "@/config/site";
 import { getProjectAvatarUrl } from "@/components/core/project-utils";
 
-export const mutedColor = "#a1a1aa";
-export const borderColor = "#484848";
+export const mutedColor = `rgba(255, 255, 255, 0.7)`;
+export const borderColor = `rgba(255, 255, 255, 0.2)`;
 
 export function generateImageResponse(
   content: ConstructorParameters<typeof ImageResponse>[0]

--- a/apps/bestofjs-nextjs/src/app/api/og/projects/[slug]/route.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/projects/[slug]/route.tsx
@@ -40,19 +40,26 @@ export async function GET(_req: Request, { params: { slug } }: Context) {
             flex: 1,
             flexDirection: "column",
             position: "relative",
-            height: 360,
-            justifyContent: "space-between",
+            gap: 32,
             borderLeft: `3px solid ${borderColor}`,
             padding: "8px 32px 24px",
           }}
         >
-          <Box style={{ gap: 32, fontSize: 80 }}>{project.name}</Box>
+          <Box style={{ fontSize: getTitleFontSize(project.name) }}>
+            {project.name}
+          </Box>
           <div style={{ color: mutedColor }}>{project.description}</div>
           <Trend project={project} />
         </Box>
       </Box>
     </ImageLayout>
   );
+}
+
+function getTitleFontSize(title: string) {
+  if (title.length < 16) return 72;
+  if (title.length < 25) return 52;
+  return 44;
 }
 
 function ShowStarsTotal({ value }: { value: number }) {
@@ -70,16 +77,20 @@ function Trend({ project }: { project: BestOfJS.Project }) {
   const value = project.trends.weekly;
   const sign = value && value > 0 ? "+" : "";
   return value !== undefined ? (
-    <Box style={{ gap: 32 }}>
-      <div>This week</div>
-      <Box style={{ alignItems: "center" }}>
-        {sign}
-        {formatNumber(value, "compact")}
-        <StarIcon />
+    <Box style={{ justifyContent: "space-between" }}>
+      <Box>
+        <div style={{ marginRight: 8 }}>This week:</div>
+        <Box style={{ alignItems: "center" }}>
+          {sign}
+          {formatNumber(value, "compact")}
+          <StarIcon />
+        </Box>
       </Box>
-      <div style={{ color: mutedColor }}>•</div>
-      <div style={{ color: mutedColor }}>Total</div>
-      <ShowStarsTotal value={project.stars} />
+      {/* <div style={{ color: mutedColor }}>•</div> */}
+      <Box>
+        <div style={{ color: mutedColor, marginRight: 8 }}>Total:</div>
+        <ShowStarsTotal value={project.stars} />
+      </Box>
     </Box>
   ) : (
     <ShowStarsTotal value={project.stars} />

--- a/apps/bestofjs-nextjs/src/app/api/og/projects/[slug]/route.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/projects/[slug]/route.tsx
@@ -4,6 +4,7 @@ import {
   Box,
   ProjectLogo,
   StarIcon,
+  borderColor,
   generateImageResponse,
   mutedColor,
 } from "@/app/api/og/og-utils";
@@ -24,7 +25,15 @@ export async function GET(_req: Request, { params: { slug } }: Context) {
 
   return generateImageResponse(
     <ImageLayout>
-      <Box style={{ alignItems: "center", gap: 48 }}>
+      <Box
+        style={{
+          alignItems: "center",
+          gap: 48,
+          border: `3px solid ${borderColor}`,
+          padding: "0 48px 0",
+          borderRadius: 32,
+        }}
+      >
         <ProjectLogo project={project} size={200} />
         <Box
           style={{
@@ -33,6 +42,8 @@ export async function GET(_req: Request, { params: { slug } }: Context) {
             position: "relative",
             height: 360,
             justifyContent: "space-between",
+            borderLeft: `3px solid ${borderColor}`,
+            padding: "8px 32px 24px",
           }}
         >
           <Box style={{ gap: 32, fontSize: 80 }}>{project.name}</Box>

--- a/apps/bestofjs-nextjs/src/app/api/og/projects/route.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/projects/route.tsx
@@ -38,16 +38,22 @@ export async function GET(req: Request) {
 
   return generateImageResponse(
     <ImageLayout>
-      <ImageCaption tags={selectedTags} query={query} sortOption={sortOption} />
-      <Box style={{ flexDirection: "column" }}>
-        {projects.map((project, index) => (
-          <ProjectRow
-            key={project.slug}
-            project={project}
-            index={index}
-            sortOption={sortOption}
-          />
-        ))}
+      <Box style={{ gap: 32, flexDirection: "column" }}>
+        <ImageCaption
+          tags={selectedTags}
+          query={query}
+          sortOption={sortOption}
+        />
+        <Box style={{ flexDirection: "column" }}>
+          {projects.map((project, index) => (
+            <ProjectRow
+              key={project.slug}
+              project={project}
+              index={index}
+              sortOption={sortOption}
+            />
+          ))}
+        </Box>
       </Box>
     </ImageLayout>
   );

--- a/apps/bestofjs-nextjs/src/app/api/og/projects/route.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/projects/route.tsx
@@ -85,11 +85,11 @@ function ImageCaption({
     <Box style={{ gap: 16, alignItems: "center" }}>
       {tags.length > 0 && !query && (
         <Box style={{ paddingLeft: 5, color: "#F59E0B" }}>
-          <TagIcon />
+          <TagIcon size="1.75em" />
         </Box>
       )}
-      <Box style={{ flexDirection: "column", paddingLeft: 25 }}>
-        <Box style={{}}>{getImageTitle(tags, query)}</Box>
+      <Box style={{ flexDirection: "column", paddingLeft: 0 }}>
+        <Box style={{ fontSize: 48 }}>{getImageTitle(tags, query)}</Box>
         <Box style={{ fontSize: 32, color: mutedColor }}>
           {sortOption.label}
         </Box>

--- a/apps/bestofjs-nextjs/src/app/api/og/route.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/route.tsx
@@ -21,16 +21,18 @@ export async function GET() {
 
   return generateImageResponse(
     <ImageLayout>
-      <Box style={{ gap: 16, fontSize: 48 }}>
-        <div>Hot Projects Today</div>
-        <div style={{ color: mutedColor }}>
-          {" • " + formatDate(new Date())}
-        </div>
-      </Box>
-      <Box style={{ flexDirection: "column" }}>
-        {projects.map((project, index) => (
-          <ProjectRow key={project.slug} project={project} index={index} />
-        ))}
+      <Box style={{ gap: 32, flexDirection: "column" }}>
+        <Box style={{ gap: 16, fontSize: 48 }}>
+          <div>Hot Projects Today</div>
+          <div style={{ color: mutedColor }}>
+            {" • " + formatDate(new Date())}
+          </div>
+        </Box>
+        <Box style={{ flexDirection: "column" }}>
+          {projects.map((project, index) => (
+            <ProjectRow key={project.slug} project={project} index={index} />
+          ))}
+        </Box>
       </Box>
     </ImageLayout>
   );

--- a/apps/bestofjs-nextjs/src/app/api/og/route.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/route.tsx
@@ -21,10 +21,10 @@ export async function GET() {
 
   return generateImageResponse(
     <ImageLayout>
-      <Box style={{ gap: 16 }}>
-        <div>Hottest projects today</div>
+      <Box style={{ gap: 16, fontSize: 48 }}>
+        <div>Hot Projects Today</div>
         <div style={{ color: mutedColor }}>
-          {"(" + formatDate(new Date()) + ")"}
+          {" • " + formatDate(new Date())}
         </div>
       </Box>
       <Box style={{ flexDirection: "column" }}>
@@ -66,9 +66,7 @@ function ProjectRow({
 
 function ShowStars({ project }: { project: BestOfJS.Project }) {
   return (
-    <Box
-      style={{ flexDirection: "row", alignItems: "center", color: mutedColor }}
-    >
+    <Box style={{ flexDirection: "row", alignItems: "center" }}>
       <Box>{`+${project.trends.daily}`}</Box>
       <StarIcon />
     </Box>

--- a/apps/bestofjs-nextjs/src/app/projects/[slug]/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/[slug]/page.tsx
@@ -7,7 +7,7 @@ import { ProjectDetailsGitHubCard } from "./project-details-github/github-card";
 import { ProjectHeader } from "./project-header";
 import { ReadmeCard } from "./project-readme/project-readme";
 import "./project-readme/readme.css";
-import { APP_CANONICAL_URL } from "@/config/site";
+import { APP_CANONICAL_URL, APP_DISPLAY_NAME } from "@/config/site";
 import { addCacheBustingParam } from "@/helpers/url";
 import { Card, CardContent } from "@/components/ui/card";
 import { api } from "@/server/api";
@@ -39,7 +39,7 @@ export async function generateMetadata({
     openGraph: {
       images: [`/api/og/projects/${slug}?${urlSearchParams.toString()}`],
       url: `${APP_CANONICAL_URL}/projects/${slug}`,
-      title,
+      title: `#${title} on ${APP_DISPLAY_NAME}`,
       description,
     },
   };


### PR DESCRIPTION
## Goal

Improve the layout of OG images

- Add a gradient for the background 
- Adjust spacing
- For project's details page, show project inside a card, adjust font size depending on the length of the project's name

## How to test

Check the different OG images:

- home page: `/api/og/`
- tag search: `/api/og/projects?sort=daily&tags=component&tags=react`
- list of all projects: `/api/og/projects`
- project's page: `/api/og/projects/react`
- hall of fame: `/api/og/hall-of-fame`

## Screenshots

![image](https://github.com/bestofjs/bestofjs/assets/5546996/de1b654c-bd2d-448f-bc78-092b0017d57a)

![image](https://github.com/bestofjs/bestofjs/assets/5546996/9818f863-9023-4524-a977-4e52a015e04b)

![image](https://github.com/bestofjs/bestofjs/assets/5546996/1b216f0f-073d-4880-9e93-93f704cee025)

![image](https://github.com/bestofjs/bestofjs/assets/5546996/f2f614bc-68c6-4707-987e-420cceae26ae)

