### PR TITLE
Fix broken layout because of truncated text

### DIFF
--- a/apps/bestofjs-nextjs/src/components/project-list/project-table.tsx
+++ b/apps/bestofjs-nextjs/src/components/project-list/project-table.tsx
@@ -72,7 +72,7 @@ const ProjectTableRow = ({
         </NextLink>
       </Cell>
 
-      <Cell className="w-auto py-4 pl-4 md:pl-2">
+      <Cell className="max-w-0 py-4 pl-4 md:pl-2">
         <div className="relative flex items-center space-x-2">
           <NextLink
             href={path}


### PR DESCRIPTION
## Goal

Following the change made here #238 to truncate the description of the projects with CSS, the table is wider than its container and it breaks the layout!

So we need `max-width: 0` actually 😅 

![image](https://github.com/bestofjs/bestofjs/assets/5546996/6b89ff7f-160c-4f39-bca9-0dc5f1c343b7)


## How to test

Ensure everything is aligned properly in the top page!
