### PR TITLE
Improve search UX merging projects and tags

### DIFF
--- a/apps/bestofjs-nextjs/src/app/globals.css
+++ b/apps/bestofjs-nextjs/src/app/globals.css
@@ -6,6 +6,34 @@
   /* Light values come from the "stone" theme, except for the primary colors */
   /* https://ui.shadcn.com/themes */
   :root {
+    /* `orange` scale */
+    --orange-1: #fefcfb;
+    --orange-2: #fff7ed;
+    --orange-3: #ffefd6;
+    --orange-4: #ffdfb5;
+    --orange-5: #ffd19a;
+    --orange-6: #ffc182;
+    --orange-7: #f5ae73;
+    --orange-8: #ec9455;
+    --orange-9: #f76b15;
+    --orange-10: #ef5f00;
+    --orange-11: #cc4e00;
+    --orange-12: #582d1d;
+
+    /* `crimson` scale from Radix colors */
+    --crimson-1: #fffcfd;
+    --crimson-2: #fef7f9;
+    --crimson-3: #ffe9f0;
+    --crimson-4: #fedce7;
+    --crimson-5: #facedd;
+    --crimson-6: #f3bed1;
+    --crimson-7: #eaacc3;
+    --crimson-8: #e093b2;
+    --crimson-9: #e93d82;
+    --crimson-10: #df3478;
+    --crimson-11: #cb1d63;
+    --crimson-12: #621639;
+
     --background: 0 0% 100%;
     --foreground: 20 14.3% 4.1%;
     --card: 0 0% 100%;
@@ -17,7 +45,8 @@
     --secondary: 60 4.8% 95.9%;
     --secondary-foreground: 24 9.8% 10%;
     --muted: 60 4.8% 95.9%;
-    --muted-foreground: 25 5.3% 44.7%;
+    /* --muted-foreground: 25 5.3% 44.7%; */
+    --muted-foreground: 20 14.3% 4.1% / 0.7;
     --accent: 60 4.8% 95.9%;
     --accent-foreground: 24 9.8% 10%;
     --destructive: 0 84.2% 60.2%;
@@ -29,9 +58,43 @@
 
     --graphBackgroundColor1: #fbd38d;
     --graphBackgroundColor2: #feebc8;
+
+    /* Colors used to differentiate results in search palette */
+    --project-bg: var(--orange-3);
+    --project-border: var(--orange-9);
+    --tag-bg: var(--crimson-3);
+    --tag-border: var(--crimson-9);
   }
 
   .dark {
+    /* orangeDark scale */
+    --orange-1: #17120e;
+    --orange-2: #1e160f;
+    --orange-3: #331e0b;
+    --orange-4: #462100;
+    --orange-5: #562800;
+    --orange-6: #66350c;
+    --orange-7: #7e451d;
+    --orange-8: #a35829;
+    --orange-9: #f76b15;
+    --orange-10: #ff801f;
+    --orange-11: #ffa057;
+    --orange-12: #ffe0c2;
+
+    /* crimsonDark scale */
+    --crimson-1: #191114;
+    --crimson-2: #201318;
+    --crimson-3: #381525;
+    --crimson-4: #4d122f;
+    --crimson-5: #5c1839;
+    --crimson-6: #6d2545;
+    --crimson-7: #873356;
+    --crimson-8: #b0436e;
+    --crimson-9: #e93d82;
+    --crimson-10: #ee518a;
+    --crimson-11: #ff92ad;
+    --crimson-12: #fdd3e8;
+
     --background: 240 10% 3.9%;
     --foreground: 0 0% 98%;
 
@@ -56,7 +119,8 @@
 
     /* Make skeleton more visible (default L=15.9%) */
     --muted: 240 3.7% 25%;
-    --muted-foreground: 240 5% 64.9%;
+    /* --muted-foreground: 240 5% 64.9%; */
+    --muted-foreground: 255 100% 100% / 0.7;
 
     /* Increase contrast when tags are hovered (original L=15.9%) */
     --accent: 240 3.7% 20%;

--- a/apps/bestofjs-nextjs/src/app/globals.css
+++ b/apps/bestofjs-nextjs/src/app/globals.css
@@ -6,7 +6,7 @@
   /* Light values come from the "stone" theme, except for the primary colors */
   /* https://ui.shadcn.com/themes */
   :root {
-    /* `orange` scale */
+    /* `orange` scale from Radix colors */
     --orange-1: #fefcfb;
     --orange-2: #fff7ed;
     --orange-3: #ffefd6;
@@ -20,7 +20,7 @@
     --orange-11: #cc4e00;
     --orange-12: #582d1d;
 
-    /* `crimson` scale from Radix colors */
+    /* `crimson` scale */
     --crimson-1: #fffcfd;
     --crimson-2: #fef7f9;
     --crimson-3: #ffe9f0;
@@ -34,18 +34,30 @@
     --crimson-11: #cb1d63;
     --crimson-12: #621639;
 
-    --background: 0 0% 100%;
-    --foreground: 20 14.3% 4.1%;
+    --sand-1: #fdfdfc;
+    --sand-2: #f9f9f8;
+    --sand-3: #f1f0ef;
+    --sand-4: #e9e8e6;
+    --sand-5: #e2e1de;
+    --sand-6: #dad9d6;
+    --sand-7: #cfceca;
+    --sand-8: #bcbbb5;
+    --sand-9: #8d8d86;
+    --sand-10: #82827c;
+    --sand-11: #63635e;
+    --sand-12: #21201c;
+
+    --background: white;
+    --foreground: var(--sand-12);
     --card: 0 0% 100%;
     --card-foreground: 20 14.3% 4.1%;
     --popover: 0 0% 100%;
     --popover-foreground: 20 14.3% 4.1%;
-    --primary: 24 100% 46.5%;
-    --primary-foreground: 210 40% 98%;
+    --primary: var(--orange-10);
+    --primary-foreground: var(--orange-11);
     --secondary: 60 4.8% 95.9%;
     --secondary-foreground: 24 9.8% 10%;
-    --muted: 60 4.8% 95.9%;
-    /* --muted-foreground: 25 5.3% 44.7%; */
+    --muted: var(--sand-2);
     --muted-foreground: 20 14.3% 4.1% / 0.7;
     --accent: 60 4.8% 95.9%;
     --accent-foreground: 24 9.8% 10%;
@@ -59,11 +71,18 @@
     --graphBackgroundColor1: #fbd38d;
     --graphBackgroundColor2: #feebc8;
 
+    --logo-color: var(--primary);
+
     /* Colors used to differentiate results in search palette */
-    --project-bg: var(--orange-3);
-    --project-border: var(--orange-9);
-    --tag-bg: var(--crimson-3);
-    --tag-border: var(--crimson-9);
+    --project-bg: var(--orange-2);
+    --project-border: var(--orange-8);
+    --project-color: var(--orange-11);
+
+    --tag-bg: var(--crimson-2);
+    --tag-border: var(--crimson-8);
+    --tag-color: var(--crimson-12);
+
+    --icon-color: var(--orange-8);
   }
 
   .dark {
@@ -95,8 +114,20 @@
     --crimson-11: #ff92ad;
     --crimson-12: #fdd3e8;
 
-    --background: 240 10% 3.9%;
-    --foreground: 0 0% 98%;
+    --sand-1: #111110;
+    --sand-2: #191918;
+    --sand-3: #222221;
+    --sand-4: #2a2a28;
+    --sand-5: #31312e;
+    --sand-6: #3b3a37;
+    --sand-7: #494844;
+    --sand-8: #62605b;
+    --sand-9: #6f6d66;
+    --sand-10: #7c7b74;
+    --sand-11: #b5b3ad;
+    --sand-12: #eeeeec;
+
+    --background: var(--sand-1);
 
     /* Less dark cards to make them stand up from the black bg (original: 240 10% 3.9%) */
     --card: 240 10% 15%;
@@ -108,10 +139,6 @@
     /* Make popover less dark to match the card bg (original L=3.9%;) */
     --popover: 240 10% 15%;
     --popover-foreground: 0 0% 98%;
-
-    /* Setup orange as the primary color instead of 0 0% 98% */
-    --primary: 25 100% 70%;
-    --primary-foreground: 240 5.9% 10%;
 
     /* Make secondary badges more visible when used in cards (default L=15.9%) */
     --secondary: 240 3.7% 25%;
@@ -138,6 +165,10 @@
     --graphBackgroundColor2: #7b341e;
 
     --link-foreground: 24 100% 75.3%;
+
+    /* Make the logo lighter by using the primary text color instead of the bg color */
+    --logo-color: var(--primary-foreground);
+    --icon-color: var(--orange-9);
   }
 }
 

--- a/apps/bestofjs-nextjs/src/components/core/section.tsx
+++ b/apps/bestofjs-nextjs/src/components/core/section.tsx
@@ -11,9 +11,7 @@ type Props = {
 export const SectionHeading = ({ className, icon, title, subtitle }: Props) => {
   return (
     <div className={cn("flex w-full items-center", className)}>
-      {icon && (
-        <div className="pr-2 text-yellow-500 dark:text-yellow-600">{icon}</div>
-      )}
+      {icon && <div className="pr-2 text-[var(--icon-color)]">{icon}</div>}
       <div className="grow">
         <h2 className="font-serif text-2xl">{title}</h2>
         {subtitle && <div className="text-muted-foreground">{subtitle}</div>}

--- a/apps/bestofjs-nextjs/src/components/core/typography.tsx
+++ b/apps/bestofjs-nextjs/src/components/core/typography.tsx
@@ -10,7 +10,7 @@ type Props = {
 export const PageHeading = ({ icon, subtitle, title }: Props) => {
   return (
     <div className="mb-6 flex items-center">
-      {icon && <div className="pr-2 text-yellow-500">{icon}</div>}
+      {icon && <div className="pr-2 text-[var(--icon-color)]">{icon}</div>}
       <div className="grow font-serif">
         <h1 className="text-3xl">{title}</h1>
         {subtitle && (

--- a/apps/bestofjs-nextjs/src/components/header/desktop-nav.tsx
+++ b/apps/bestofjs-nextjs/src/components/header/desktop-nav.tsx
@@ -40,7 +40,7 @@ export function MainNav() {
           <BestOfJSLogo
             width={130}
             height={37.15}
-            className="h-[37.15px] w-[130px] text-primary"
+            className="h-[37.15px] w-[130px] text-[var(--logo-color)]"
           />
         </Link>
         <div className="hidden gap-4 lg:flex">

--- a/apps/bestofjs-nextjs/src/components/home/featured-project-list.tsx
+++ b/apps/bestofjs-nextjs/src/components/home/featured-project-list.tsx
@@ -38,7 +38,7 @@ function FeaturedProject({
       <div className="flex-1 space-y-2 overflow-hidden text-center">
         <NextLink
           href={`/projects/${project.slug}`}
-          className="block truncate text-primary hover:underline"
+          className="block truncate text-primary-foreground hover:underline"
         >
           {project.name}
         </NextLink>

--- a/apps/bestofjs-nextjs/src/components/project-list/project-table.tsx
+++ b/apps/bestofjs-nextjs/src/components/project-list/project-table.tsx
@@ -76,7 +76,7 @@ const ProjectTableRow = ({
         <div className="relative flex items-center space-x-2">
           <NextLink
             href={path}
-            className="whitespace-nowrap text-primary hover:underline"
+            className="whitespace-nowrap text-primary-foreground hover:underline"
           >
             {project.name}
           </NextLink>

--- a/apps/bestofjs-nextjs/src/components/search-palette/search-palette-results.tsx
+++ b/apps/bestofjs-nextjs/src/components/search-palette/search-palette-results.tsx
@@ -6,8 +6,6 @@ import { cn } from "@/lib/utils";
 import { buttonVariants } from "@/components/ui/button";
 import { CommandItem } from "@/components/ui/command";
 
-// import { Skeleton } from "@/components/ui/skeleton";
-
 import {
   GitHubIcon,
   HomeIcon,

--- a/apps/bestofjs-nextjs/src/components/search-palette/search-palette-results.tsx
+++ b/apps/bestofjs-nextjs/src/components/search-palette/search-palette-results.tsx
@@ -26,7 +26,7 @@ export function ProjectSearchResult({
     <CommandItem
       value={`project/` + project.slug}
       onSelect={onSelectProject}
-      className="border-l-2 border-[transparent] data-[selected]:border-[var(--project-border)] data-[selected]:bg-[var(--project-bg)]"
+      className="border-l-1 border-[transparent] data-[selected]:border-[var(--project-border)] data-[selected]:bg-[var(--project-bg)] group"
     >
       <div className="w-full gap-2 md:grid md:grid-cols-[1fr_40px_40px]">
         <ProjectSummary project={project} />
@@ -43,7 +43,11 @@ export function ProjectSearchResult({
               "rounded-full",
               "w-10",
               "h-10",
-              "p-0"
+              "p-0",
+              "text-muted-foreground",
+              "group-aria-[selected]:hover:text-[var(--project-color)]",
+              "group-aria-[selected]:hover:bg-[var(--project-bg)]"
+              // "group-aria-[selected]:bg-[var(--orange-6)]"
             )}
           >
             <GitHubIcon size={24} />
@@ -62,7 +66,11 @@ export function ProjectSearchResult({
                 "rounded-full",
                 "w-10",
                 "h-10",
-                "p-0"
+                "p-0",
+                // "group-aria-[selected]:text-[var(--project-color)]",
+                "text-muted-foreground",
+                "group-aria-[selected]:hover:text-[var(--project-color)]",
+                "group-aria-[selected]:hover:bg-[var(--project-bg)]"
               )}
             >
               <HomeIcon size={24} />
@@ -80,7 +88,7 @@ function ProjectSummary({ project }: { project: BestOfJS.SearchIndexProject }) {
       <div className="flex h-12 w-12 items-center justify-center">
         <ProjectAvatar project={project} size={32} />
       </div>
-      <div className="flex-1 truncate">
+      <div className="flex-1 truncate group-aria-[selected]:text-[var(--project-color)]">
         {project.name}
         <div className="truncate pt-2 text-muted-foreground">
           {project.description}
@@ -104,14 +112,21 @@ export function TagSearchResult({
     <CommandItem
       value={"tag/" + tag.code}
       onSelect={onSelectTag}
-      className="group border-l-2 border-[transparent] data-[selected]:border-[var(--tag-border)] data-[selected]:bg-[var(--tag-bg)]"
+      className="group border-l-1 border-[transparent] data-[selected]:border-[var(--tag-border)] data-[selected]:bg-[var(--tag-bg)]"
     >
       <div className="flex min-h-[50px] items-center">
-        <div className="flex h-12 w-12 items-center justify-center">
+        <div
+          className={cn(
+            "flex h-12 w-12 items-center justify-center",
+            "text-muted-foreground group-aria-[selected]:text-[var(--tag-color)]"
+          )}
+        >
           <TagIcon size={32} />
         </div>
         <div className="text-md pl-4">
-          <span className="group-[data-[selected]]:uppercase">{tag.name}</span>
+          <span className="group-aria-[selected]:text-[var(--tag-color)]">
+            {tag.name}
+          </span>
           <div className="pt-2 text-muted-foreground">
             {tag.counter} projects
           </div>

--- a/apps/bestofjs-nextjs/src/components/search-palette/search-palette-results.tsx
+++ b/apps/bestofjs-nextjs/src/components/search-palette/search-palette-results.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+import { buttonVariants } from "@/components/ui/button";
+import { CommandItem } from "@/components/ui/command";
+import { Skeleton } from "@/components/ui/skeleton";
+
+import {
+  GitHubIcon,
+  HomeIcon,
+  ProjectAvatar,
+  SearchIcon,
+  StarTotal,
+  TagIcon,
+  XMarkIcon,
+} from "../core";
+
+export function ProjectSearchResult({
+  project,
+  onSelectProject,
+}: {
+  project: BestOfJS.SearchIndexProject;
+  onSelectProject: (itemValue: string) => void;
+}) {
+  return (
+    <div className="gap-2 md:grid md:grid-cols-[1fr_40px_40px]">
+      <CommandItem value={`project/` + project.slug} onSelect={onSelectProject}>
+        <ProjectSummary project={project} />
+      </CommandItem>
+      <div className="hidden items-center md:flex">
+        <a
+          href={`https://github.com/` + project.full_name}
+          aria-label="GitHub repository"
+          rel="noopener noreferrer"
+          target="_blank"
+          className={cn(
+            buttonVariants({ variant: "ghost" }),
+            "rounded-full",
+            "w-10",
+            "h-10",
+            "p-0"
+          )}
+        >
+          <GitHubIcon size={24} />
+        </a>
+      </div>
+      {project.url && (
+        <div className="hidden items-center md:flex">
+          <a
+            href={project.url}
+            aria-label="Project's homepage"
+            rel="noopener noreferrer"
+            target="_blank"
+            className={cn(
+              buttonVariants({ variant: "ghost" }),
+              "rounded-full",
+              "w-10",
+              "h-10",
+              "p-0"
+            )}
+          >
+            <HomeIcon size={24} />
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ProjectSummary({ project }: { project: BestOfJS.SearchIndexProject }) {
+  return (
+    <div className="flex w-full min-w-0 items-center gap-4">
+      <div className="items-center justify-center">
+        <ProjectAvatar project={project} size={32} />
+      </div>
+      <div className="flex-1 truncate">
+        {project.name}
+        <div className="truncate pt-2 text-muted-foreground">
+          {project.description}
+        </div>
+      </div>
+      <div className="hidden text-right md:block">
+        <StarTotal value={project.stars} />
+      </div>
+    </div>
+  );
+}
+
+export function TagSearchResult({
+  tag,
+  onSelectTag,
+}: {
+  tag: BestOfJS.Tag;
+  onSelectTag: (itemValue: string) => void;
+}) {
+  return (
+    <CommandItem value={"tag/" + tag.code} onSelect={onSelectTag}>
+      <div className="flex min-h-[50px] items-center">
+        <div className="flex w-8 items-center justify-center">
+          <TagIcon size={32} />
+        </div>
+        <span className="pl-4 pr-2">{tag.name}</span>
+        <div className="text-muted-foreground">({tag.counter})</div>
+      </div>
+    </CommandItem>
+  );
+}
+
+export function SearchForTextCommand({
+  searchQuery,
+  onSelectSearchForText,
+}: {
+  searchQuery: string;
+  onSelectSearchForText: (itemValue: string) => void;
+}) {
+  return (
+    <CommandItem
+      onSelect={onSelectSearchForText}
+      value={`search/${searchQuery}`}
+      className="grid w-full grid-cols-[32px_1fr] items-center gap-4"
+    >
+      <div className="flex justify-center">
+        <SearchIcon />
+      </div>
+      <div>
+        Search for
+        <span className="ml-1 font-bold italic">{searchQuery}</span>
+      </div>
+    </CommandItem>
+  );
+}

--- a/apps/bestofjs-nextjs/src/components/search-palette/search-palette-results.tsx
+++ b/apps/bestofjs-nextjs/src/components/search-palette/search-palette-results.tsx
@@ -5,7 +5,8 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 import { buttonVariants } from "@/components/ui/button";
 import { CommandItem } from "@/components/ui/command";
-import { Skeleton } from "@/components/ui/skeleton";
+
+// import { Skeleton } from "@/components/ui/skeleton";
 
 import {
   GitHubIcon,
@@ -14,7 +15,6 @@ import {
   SearchIcon,
   StarTotal,
   TagIcon,
-  XMarkIcon,
 } from "../core";
 
 export function ProjectSearchResult({
@@ -25,32 +25,19 @@ export function ProjectSearchResult({
   onSelectProject: (itemValue: string) => void;
 }) {
   return (
-    <div className="gap-2 md:grid md:grid-cols-[1fr_40px_40px]">
-      <CommandItem value={`project/` + project.slug} onSelect={onSelectProject}>
+    <CommandItem
+      value={`project/` + project.slug}
+      onSelect={onSelectProject}
+      className="border-l-2 border-[transparent] data-[selected]:border-[var(--project-border)] data-[selected]:bg-[var(--project-bg)]"
+    >
+      <div className="w-full gap-2 md:grid md:grid-cols-[1fr_40px_40px]">
         <ProjectSummary project={project} />
-      </CommandItem>
-      <div className="hidden items-center md:flex">
-        <a
-          href={`https://github.com/` + project.full_name}
-          aria-label="GitHub repository"
-          rel="noopener noreferrer"
-          target="_blank"
-          className={cn(
-            buttonVariants({ variant: "ghost" }),
-            "rounded-full",
-            "w-10",
-            "h-10",
-            "p-0"
-          )}
-        >
-          <GitHubIcon size={24} />
-        </a>
-      </div>
-      {project.url && (
+
         <div className="hidden items-center md:flex">
           <a
-            href={project.url}
-            aria-label="Project's homepage"
+            href={`https://github.com/` + project.full_name}
+            onClick={(event) => event.stopPropagation()}
+            aria-label="GitHub repository"
             rel="noopener noreferrer"
             target="_blank"
             className={cn(
@@ -61,18 +48,38 @@ export function ProjectSearchResult({
               "p-0"
             )}
           >
-            <HomeIcon size={24} />
+            <GitHubIcon size={24} />
           </a>
         </div>
-      )}
-    </div>
+        {project.url && (
+          <div className="hidden items-center md:flex">
+            <a
+              href={project.url}
+              onClick={(event) => event.stopPropagation()}
+              aria-label="Project's homepage"
+              rel="noopener noreferrer"
+              target="_blank"
+              className={cn(
+                buttonVariants({ variant: "ghost" }),
+                "rounded-full",
+                "w-10",
+                "h-10",
+                "p-0"
+              )}
+            >
+              <HomeIcon size={24} />
+            </a>
+          </div>
+        )}
+      </div>
+    </CommandItem>
   );
 }
 
 function ProjectSummary({ project }: { project: BestOfJS.SearchIndexProject }) {
   return (
     <div className="flex w-full min-w-0 items-center gap-4">
-      <div className="items-center justify-center">
+      <div className="flex h-12 w-12 items-center justify-center">
         <ProjectAvatar project={project} size={32} />
       </div>
       <div className="flex-1 truncate">
@@ -96,13 +103,21 @@ export function TagSearchResult({
   onSelectTag: (itemValue: string) => void;
 }) {
   return (
-    <CommandItem value={"tag/" + tag.code} onSelect={onSelectTag}>
+    <CommandItem
+      value={"tag/" + tag.code}
+      onSelect={onSelectTag}
+      className="group border-l-2 border-[transparent] data-[selected]:border-[var(--tag-border)] data-[selected]:bg-[var(--tag-bg)]"
+    >
       <div className="flex min-h-[50px] items-center">
-        <div className="flex w-8 items-center justify-center">
+        <div className="flex h-12 w-12 items-center justify-center">
           <TagIcon size={32} />
         </div>
-        <span className="pl-4 pr-2">{tag.name}</span>
-        <div className="text-muted-foreground">({tag.counter})</div>
+        <div className="text-md pl-4">
+          <span className="group-[data-[selected]]:uppercase">{tag.name}</span>
+          <div className="pt-2 text-muted-foreground">
+            {tag.counter} projects
+          </div>
+        </div>
       </div>
     </CommandItem>
   );
@@ -119,10 +134,10 @@ export function SearchForTextCommand({
     <CommandItem
       onSelect={onSelectSearchForText}
       value={`search/${searchQuery}`}
-      className="grid w-full grid-cols-[32px_1fr] items-center gap-4"
+      className="group grid w-full grid-cols-[32px_1fr] items-center gap-4"
     >
-      <div className="flex justify-center">
-        <SearchIcon />
+      <div className="flex h-12 w-12 items-center justify-center">
+        <SearchIcon size={24} />
       </div>
       <div>
         Search for

--- a/apps/bestofjs-nextjs/src/components/search-palette/search-palette.tsx
+++ b/apps/bestofjs-nextjs/src/components/search-palette/search-palette.tsx
@@ -207,20 +207,17 @@ export function SearchPalette({ allProjects, allTags }: SearchProps) {
                 <CommandEmpty>No results found.</CommandEmpty>
               )}
               {combinedResults.map((result) => {
+                const key =
+                  "stars" in result ? result.slug : "tags/" + result.code;
                 return (
-                  <div className="border-b border-dashed">
+                  <div key={key} className="border-b border-dashed">
                     {"stars" in result ? (
                       <ProjectSearchResult
-                        key={result.slug}
                         project={result}
                         onSelectProject={onSelectProject}
                       />
                     ) : (
-                      <TagSearchResult
-                        key={`tag/` + result.code}
-                        tag={result}
-                        onSelectTag={onSelectTag}
-                      />
+                      <TagSearchResult tag={result} onSelectTag={onSelectTag} />
                     )}
                   </div>
                 );
@@ -238,6 +235,11 @@ export function SearchPalette({ allProjects, allTags }: SearchProps) {
     </>
   );
 }
+
+// TODO
+// function isProject(result: CombinedSearchResult | BestOfJS.Tag): result is BestOfJS.SearchIndexProject {
+//   return "stars" in result
+// }
 
 function lookUpTag(tagCode: string, allTags: BestOfJS.Tag[]) {
   return allTags.find((tag) => tag.code === tagCode);

--- a/apps/bestofjs-nextjs/src/components/search-palette/search-palette.tsx
+++ b/apps/bestofjs-nextjs/src/components/search-palette/search-palette.tsx
@@ -8,28 +8,16 @@ import {
   filterTagsByQueryWithRank,
   mergeSearchResults,
 } from "@/lib/search-utils";
-import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
-import { buttonVariants } from "@/components/ui/button";
 import {
   CommandDialog,
   CommandEmpty,
-  CommandGroup,
   CommandInput,
-  CommandItem,
   CommandList,
 } from "@/components/ui/command";
 import { Skeleton } from "@/components/ui/skeleton";
 
-import {
-  GitHubIcon,
-  HomeIcon,
-  ProjectAvatar,
-  SearchIcon,
-  StarTotal,
-  TagIcon,
-  XMarkIcon,
-} from "../core";
+import { ProjectAvatar, StarTotal, TagIcon, XMarkIcon } from "../core";
 import { stateToQueryString } from "../project-list/navigation-state";
 import { useSearchState } from "../project-list/search-state";
 import { filterProjectsByTagsAndQuery } from "./find-projects";
@@ -136,16 +124,14 @@ export function SearchPalette({ allProjects, allTags }: SearchProps) {
 
   const popularTags = allTags.slice(0, 20);
 
-  const filteredTags = searchQuery
-    ? filterTagsByQuery(allTags, searchQuery)
-    : popularTags;
+  // const filteredTags = searchQuery
+  //   ? filterTagsByQuery(allTags, searchQuery)
+  //   : popularTags;
 
   const foundTagsWithRank = filterTagsByQueryWithRank(allTags, searchQuery);
-  const combinedResults: CombinedSearchResult[] = mergeSearchResults(
-    filteredProjects,
-    foundTagsWithRank
-  );
-  console.log({ combinedResults });
+  const combinedResults: CombinedSearchResult[] | BestOfJS.Tag[] = searchQuery
+    ? mergeSearchResults(filteredProjects, foundTagsWithRank)
+    : popularTags;
 
   const onSelectProject = (itemValue: string) => {
     const projectSlug = itemValue.slice("project/".length);
@@ -184,9 +170,7 @@ export function SearchPalette({ allProjects, allTags }: SearchProps) {
     });
   };
 
-  const isEmptyProjects = filteredProjects.length == 0;
-  const isEmptyTags = filteredTags.length == 0;
-  const isEmptySearchResults = isEmptyProjects && isEmptyTags;
+  const isEmptySearchResults = combinedResults.length === 0;
 
   return (
     <>
@@ -223,66 +207,35 @@ export function SearchPalette({ allProjects, allTags }: SearchProps) {
                 <CommandEmpty>No results found.</CommandEmpty>
               )}
               {combinedResults.map((result) => {
-                if ("stars" in result) {
-                  return (
-                    <ProjectSearchResult
-                      key={result.slug}
-                      project={result}
-                      onSelectProject={onSelectProject}
-                    />
-                  );
-                }
                 return (
-                  <TagSearchResult
-                    key={`tag/` + result.code}
-                    tag={result}
-                    onSelectTag={onSelectTag}
-                  />
+                  <div className="border-b border-dashed">
+                    {"stars" in result ? (
+                      <ProjectSearchResult
+                        key={result.slug}
+                        project={result}
+                        onSelectProject={onSelectProject}
+                      />
+                    ) : (
+                      <TagSearchResult
+                        key={`tag/` + result.code}
+                        tag={result}
+                        onSelectTag={onSelectTag}
+                      />
+                    )}
+                  </div>
                 );
               })}
-              {/* {searchQuery.length > 0 && !isEmptyProjects && (
-                <CommandGroup heading="Projects">
-                  {filteredProjects.map((project) => (
-                    <ProjectSearchResult
-                      key={project.slug}
-                      project={project}
-                      onSelectProject={onSelectProject}
-                    />
-                  ))}
-                  {searchQuery.length > 2 && (
-                    <SearchForTextCommand
-                      searchQuery={searchQuery}
-                      onSelectSearchForText={onSelectSearchForText}
-                    />
-                  )}
-                </CommandGroup>
+              {!isEmptySearchResults && searchQuery.length > 1 && (
+                <SearchForTextCommand
+                  searchQuery={searchQuery}
+                  onSelectSearchForText={onSelectSearchForText}
+                />
               )}
-              {!isEmptyTags && (
-                <CommandGroup heading="Tags">
-                  {filteredTags.slice(0, 20).map((tag) => (
-                    <TagSearchResult
-                      key={tag.code}
-                      tag={tag}
-                      onSelectTag={onSelectTag}
-                    />
-                  ))}
-                </CommandGroup>
-              )} */}
             </CommandList>
           </>
         )}
       </CommandDialog>
     </>
-  );
-}
-
-function filterTagsByQuery(tags: BestOfJS.Tag[], searchQuery: string) {
-  const normalizedQuery = searchQuery.toLowerCase();
-
-  return tags.filter(
-    (tag) =>
-      tag.code.includes(normalizedQuery) ||
-      tag.name.toLowerCase().includes(normalizedQuery)
   );
 }
 

--- a/apps/bestofjs-nextjs/src/components/search-palette/search-palette.tsx
+++ b/apps/bestofjs-nextjs/src/components/search-palette/search-palette.tsx
@@ -52,7 +52,7 @@ type SelectedItem =
 
 type CombinedSearchResult =
   | (BestOfJS.SearchIndexProject & { rank: number })
-  | (BestOfJS.Tag & { rank: number });
+  | (BestOfJS.Tag & { rank?: number });
 
 export function SearchPalette({ allProjects, allTags }: SearchProps) {
   const router = useRouter();
@@ -124,12 +124,8 @@ export function SearchPalette({ allProjects, allTags }: SearchProps) {
 
   const popularTags = allTags.slice(0, 20);
 
-  // const filteredTags = searchQuery
-  //   ? filterTagsByQuery(allTags, searchQuery)
-  //   : popularTags;
-
   const foundTagsWithRank = filterTagsByQueryWithRank(allTags, searchQuery);
-  const combinedResults: CombinedSearchResult[] | BestOfJS.Tag[] = searchQuery
+  const combinedResults: CombinedSearchResult[] = searchQuery
     ? mergeSearchResults(filteredProjects, foundTagsWithRank)
     : popularTags;
 
@@ -207,11 +203,12 @@ export function SearchPalette({ allProjects, allTags }: SearchProps) {
                 <CommandEmpty>No results found.</CommandEmpty>
               )}
               {combinedResults.map((result) => {
-                const key =
-                  "stars" in result ? result.slug : "tags/" + result.code;
+                const key = isProject(result)
+                  ? result.slug
+                  : "tags/" + result.code;
                 return (
                   <div key={key} className="border-b border-dashed">
-                    {"stars" in result ? (
+                    {isProject(result) ? (
                       <ProjectSearchResult
                         project={result}
                         onSelectProject={onSelectProject}
@@ -236,10 +233,11 @@ export function SearchPalette({ allProjects, allTags }: SearchProps) {
   );
 }
 
-// TODO
-// function isProject(result: CombinedSearchResult | BestOfJS.Tag): result is BestOfJS.SearchIndexProject {
-//   return "stars" in result
-// }
+function isProject(
+  result: CombinedSearchResult
+): result is BestOfJS.SearchIndexProject & { rank: number } {
+  return "stars" in result;
+}
 
 function lookUpTag(tagCode: string, allTags: BestOfJS.Tag[]) {
   return allTags.find((tag) => tag.code === tagCode);

--- a/apps/bestofjs-nextjs/src/components/ui/command.tsx
+++ b/apps/bestofjs-nextjs/src/components/ui/command.tsx
@@ -31,7 +31,7 @@ const CommandDialog = ({ children, ...props }: DialogProps) => {
       <DialogContent className="overflow-hidden p-0 shadow-2xl xl:max-w-[800px]">
         <Command
           shouldFilter={false}
-          className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5"
+          className="[&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:py-3"
         >
           {children}
         </Command>
@@ -123,7 +123,7 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none aria-selected:bg-accent aria-selected:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-pointer select-none items-center rounded-sm px-4 py-1.5 text-sm outline-none aria-selected:bg-accent aria-selected:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     {...props}

--- a/apps/bestofjs-nextjs/src/components/ui/command.tsx
+++ b/apps/bestofjs-nextjs/src/components/ui/command.tsx
@@ -44,8 +44,13 @@ const CommandInput = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Input>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
 >(({ className, ...props }, ref) => (
-  <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
-    <SearchIcon className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+  <div
+    className="flex min-h-[60px] items-center border-b px-3"
+    cmdk-input-wrapper=""
+  >
+    <div className="mr-6 flex h-12 w-12 items-center justify-center">
+      <SearchIcon className="h-8 w-8 shrink-0 opacity-50" />
+    </div>
     <CommandPrimitive.Input
       ref={ref}
       className={cn(

--- a/apps/bestofjs-nextjs/src/components/ui/command.tsx
+++ b/apps/bestofjs-nextjs/src/components/ui/command.tsx
@@ -49,7 +49,7 @@ const CommandInput = React.forwardRef<
     <CommandPrimitive.Input
       ref={ref}
       className={cn(
-        "flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-11 w-full rounded-md bg-transparent py-3 outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}
@@ -66,7 +66,7 @@ const CommandList = React.forwardRef<
   <CommandPrimitive.List
     ref={ref}
     className={cn(
-      "h-[100vh] overflow-y-auto overflow-x-hidden sm:h-[80vh] lg:h-[80vh] xl:h-[70vh]",
+      "[&_[cmdk-list-sizer]]space-y-4 h-[100vh] space-y-4 overflow-y-auto overflow-x-hidden sm:h-[80vh] lg:h-[80vh] xl:h-[70vh]",
       className
     )}
     {...props}
@@ -79,11 +79,7 @@ const CommandEmpty = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Empty>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
 >((props, ref) => (
-  <CommandPrimitive.Empty
-    ref={ref}
-    className="py-6 text-center text-sm"
-    {...props}
-  />
+  <CommandPrimitive.Empty ref={ref} className="py-6 text-center" {...props} />
 ));
 
 CommandEmpty.displayName = CommandPrimitive.Empty.displayName;
@@ -123,7 +119,7 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-pointer select-none items-center rounded-sm px-4 py-1.5 text-sm outline-none aria-selected:bg-accent aria-selected:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "text relative flex cursor-pointer select-none items-center px-4 py-1.5 outline-none aria-selected:bg-accent aria-selected:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     {...props}

--- a/apps/bestofjs-nextjs/src/components/ui/link.tsx
+++ b/apps/bestofjs-nextjs/src/components/ui/link.tsx
@@ -1,6 +1,3 @@
 import { cva } from "class-variance-authority";
 
-export const linkVariants = cva(
-  // "text-orange-700 hover:underline dark:text-orange-300"
-  "text-primary hover:underline"
-);
+export const linkVariants = cva("text-primary-foreground hover:underline");

--- a/apps/bestofjs-nextjs/tailwind.config.js
+++ b/apps/bestofjs-nextjs/tailwind.config.js
@@ -17,11 +17,11 @@ module.exports = {
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",
-        background: "hsl(var(--background))",
-        foreground: "hsl(var(--foreground))",
+        background: "var(--background)",
+        foreground: "var(--foreground)",
         primary: {
-          DEFAULT: "hsl(var(--primary))",
-          foreground: "hsl(var(--primary-foreground))",
+          DEFAULT: "var(--primary)",
+          foreground: "var(--primary-foreground)",
         },
         secondary: {
           DEFAULT: "hsl(var(--secondary))",
@@ -32,7 +32,7 @@ module.exports = {
           foreground: "hsl(var(--destructive-foreground))",
         },
         muted: {
-          DEFAULT: "hsl(var(--muted))",
+          DEFAULT: "var(--muted)",
           foreground: "hsl(var(--muted-foreground))",
         },
         accent: {


### PR DESCRIPTION
## Goal

Improve the UX when searching, to fix #246 by combining projects and tags in the same list, sorted by relevance, instead of separating them.

To help differentiate them, 2 colors were assigned, from the `Radix Colors` scales:

- orange for projects
- pink "crimson" for tags

We could generalize the use of these colors in other places?

About colors and web apps, I love the `Radix Colors` project: https://www.radix-ui.com/colors/docs/palette-composition/scales

## How to test

Search for "WebRTC" and tell me if you are confused or not 😄 

## Screenshots

![image](https://github.com/bestofjs/bestofjs/assets/5546996/b1e2de03-2860-4f71-9904-8eb257e833e4)

![image](https://github.com/bestofjs/bestofjs/assets/5546996/b6809f8b-2446-4d2c-86d4-ba3dee09ee70)

