### PR TITLE
Cleanup CSS variables, add missing `:hover` effect

### DIFF
--- a/apps/bestofjs-nextjs/src/app/globals.css
+++ b/apps/bestofjs-nextjs/src/app/globals.css
@@ -49,8 +49,6 @@
     --muted-foreground: var(--sand-11);
     --accent: var(--sand-2);
     --accent-foreground: black;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 60 9.1% 97.8%;
     --border: var(--sand-4);
     --input: var(--border);
     --ring: var(--orange-3);
@@ -109,8 +107,6 @@
 
     --accent: var(--sand-3);
     --accent-foreground: white;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 85.7% 97.3%;
 
     --logo-color: var(--orange-11);
     --icon-color: var(--orange-10);

--- a/apps/bestofjs-nextjs/src/app/globals.css
+++ b/apps/bestofjs-nextjs/src/app/globals.css
@@ -42,8 +42,9 @@
     --primary: var(--orange-9);
     --primary-hover: var(--orange-10);
     --primary-foreground: white;
-    --secondary: 60 4.8% 95.9%;
-    --secondary-foreground: 24 9.8% 10%;
+    --secondary: var(--sand-3);
+    --secondary-hover: var(--sand-4);
+    --secondary-foreground: var(--sand-11);
     --muted: var(--sand-5);
     --muted-foreground: var(--sand-11);
     --accent: var(--sand-2);
@@ -105,10 +106,6 @@
 
     /* Make popover less dark to match the card bg (original L=3.9%;) */
     --popover: var(--sand-2);
-
-    /* Make secondary badges more visible when used in cards (default L=15.9%) */
-    --secondary: 240 3.7% 25%;
-    --secondary-foreground: 0 0% 98%;
 
     --accent: var(--sand-3);
     --accent-foreground: white;

--- a/apps/bestofjs-nextjs/src/app/globals.css
+++ b/apps/bestofjs-nextjs/src/app/globals.css
@@ -39,8 +39,9 @@
     --card-foreground: var(--foreground);
     --popover: white;
     --popover-foreground: var(--foreground);
-    --primary: var(--orange-10);
-    --primary-foreground: var(--orange-1);
+    --primary: var(--orange-9);
+    --primary-hover: var(--orange-10);
+    --primary-foreground: white;
     --secondary: 60 4.8% 95.9%;
     --secondary-foreground: 24 9.8% 10%;
     --muted: var(--sand-5);
@@ -53,6 +54,9 @@
     --input: var(--border);
     --ring: var(--orange-3);
     --radius: 0.5rem;
+
+    --link-foreground: var(--orange-11);
+    --link-underline: var(--orange-8);
 
     --graphBackgroundColor1: var(--orange-6);
     --graphBackgroundColor2: var(--orange-7);

--- a/apps/bestofjs-nextjs/src/app/globals.css
+++ b/apps/bestofjs-nextjs/src/app/globals.css
@@ -52,7 +52,7 @@
     --accent-foreground: black;
     --border: var(--sand-4);
     --input: var(--border);
-    --ring: var(--orange-3);
+    --ring: var(--primary);
     --radius: 0.5rem;
 
     --link-foreground: var(--orange-11);

--- a/apps/bestofjs-nextjs/src/app/globals.css
+++ b/apps/bestofjs-nextjs/src/app/globals.css
@@ -33,6 +33,7 @@
     --sand-12: #21201c;
 
     --background: white;
+    --overlay: rgba(255, 255, 255, 0.8);
     --app-background: var(--sand-2);
     --foreground: var(--sand-12);
     --card: white;
@@ -94,6 +95,7 @@
     --sand-12: #eeeeec;
 
     --background: var(--sand-1);
+    --overlay: rgba(17, 17, 16, 0.8);
     --app-background: var(--sand-1);
 
     --card: var(--sand-2);

--- a/apps/bestofjs-nextjs/src/app/hall-of-fame/hall-of-member-list.tsx
+++ b/apps/bestofjs-nextjs/src/app/hall-of-fame/hall-of-member-list.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils";
 import { badgeVariants } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
 import { ProjectAvatar } from "@/components/core";
+import { ExternalLink } from "@/components/core/typography";
 
 type Props = {
   members: BestOfJS.HallOfFameMember[];
@@ -36,12 +37,9 @@ function HallOfFameMember({ member }: { member: BestOfJS.HallOfFameMember }) {
             <span className="font-serif text-xl">{member.name}</span>
           </div>
           <div className="text-muted-foreground">
-            <a
-              href={`https://github.com/${member.username}`}
-              className="text-primary hover:underline"
-            >
+            <ExternalLink url={`https://github.com/${member.username}`}>
               {member.username}
-            </a>{" "}
+            </ExternalLink>{" "}
             on GitHub
           </div>
         </div>

--- a/apps/bestofjs-nextjs/src/app/projects/[slug]/project-readme/readme.css
+++ b/apps/bestofjs-nextjs/src/app/projects/[slug]/project-readme/readme.css
@@ -138,7 +138,7 @@
 }
 
 .markdown-body a {
-  color: var(--orange-11);
+  color: var(--link-foreground);
   text-decoration: none;
 }
 

--- a/apps/bestofjs-nextjs/src/app/projects/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/page.tsx
@@ -283,7 +283,7 @@ function CurrentTags({
       {textQuery && (
         <NextLink
           href={buildPageURL((state) => ({ ...state, page: 1, query: "" }))}
-          className={cn(badgeVariants({ variant: "destructive" }), "text-md")}
+          className={cn(badgeVariants({ variant: "default" }), "text-md")}
         >
           “{textQuery}”
           <XMarkIcon size={20} />

--- a/apps/bestofjs-nextjs/src/components/header/mobile-nav.tsx
+++ b/apps/bestofjs-nextjs/src/components/header/mobile-nav.tsx
@@ -67,7 +67,7 @@ function SidebarContent({
                   "flex items-center",
                   item.isActive(pathname)
                     ? "text-foreground"
-                    : "text-foreground/70",
+                    : "text-secondary-foreground",
                   item.disabled && "cursor-not-allowed opacity-80"
                 )}
                 onClick={() => onOpenChange(false)}
@@ -82,7 +82,7 @@ function SidebarContent({
             href={DISCORD_URL}
             target="_blank"
             rel="noreferrer"
-            className="block text-foreground/70"
+            className="block text-secondary-foreground"
           >
             Discord
           </a>
@@ -90,7 +90,7 @@ function SidebarContent({
             href={APP_REPO_URL}
             target="_blank"
             rel="noreferrer"
-            className="block text-foreground/70"
+            className="block text-secondary-foreground"
           >
             GitHub
           </a>

--- a/apps/bestofjs-nextjs/src/components/ui/alert.tsx
+++ b/apps/bestofjs-nextjs/src/components/ui/alert.tsx
@@ -14,10 +14,6 @@ const alertVariants = klass({
   variants: {
     variant: {
       default: "bg-background text-foreground",
-      destructive: [
-        "border-destructive/50 dark:border-destructive",
-        "text-destructive [&>svg]:text-destructive",
-      ],
     },
   },
   defaultVariants: {

--- a/apps/bestofjs-nextjs/src/components/ui/badge.tsx
+++ b/apps/bestofjs-nextjs/src/components/ui/badge.tsx
@@ -13,7 +13,7 @@ const badgeVariants = klass({
   variants: {
     variant: {
       default:
-        "bg-primary hover:bg-[var(--orange-11)] border-transparent text-primary-foreground",
+        "bg-primary hover:bg-primary-hover border-transparent text-primary-foreground",
       secondary:
         "bg-secondary hover:bg-secondary/80 border-transparent text-secondary-foreground",
       destructive:

--- a/apps/bestofjs-nextjs/src/components/ui/badge.tsx
+++ b/apps/bestofjs-nextjs/src/components/ui/badge.tsx
@@ -15,7 +15,7 @@ const badgeVariants = klass({
       default:
         "bg-primary hover:bg-primary-hover border-transparent text-primary-foreground",
       secondary:
-        "bg-secondary hover:bg-secondary/80 border-transparent text-secondary-foreground",
+        "bg-secondary hover:bg-secondary-hover border-transparent text-secondary-foreground",
       destructive:
         "bg-destructive hover:bg-destructive/80 border-transparent text-destructive-foreground",
       outline: "text-foreground",

--- a/apps/bestofjs-nextjs/src/components/ui/badge.tsx
+++ b/apps/bestofjs-nextjs/src/components/ui/badge.tsx
@@ -16,8 +16,6 @@ const badgeVariants = klass({
         "bg-primary hover:bg-primary-hover border-transparent text-primary-foreground",
       secondary:
         "bg-secondary hover:bg-secondary-hover border-transparent text-secondary-foreground",
-      destructive:
-        "bg-destructive hover:bg-destructive/80 border-transparent text-destructive-foreground",
       outline: "text-foreground",
     },
   },

--- a/apps/bestofjs-nextjs/src/components/ui/button.tsx
+++ b/apps/bestofjs-nextjs/src/components/ui/button.tsx
@@ -14,7 +14,7 @@ const Button = klassed(
     ],
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default: "bg-primary text-primary-foreground hover:bg-primary-hover",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline: "border bg-card hover:bg-accent hover:text-accent-foreground",

--- a/apps/bestofjs-nextjs/src/components/ui/button.tsx
+++ b/apps/bestofjs-nextjs/src/components/ui/button.tsx
@@ -15,8 +15,6 @@ const Button = klassed(
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary-hover",
-        destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline: "border bg-card hover:bg-accent hover:text-accent-foreground",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary-hover",

--- a/apps/bestofjs-nextjs/src/components/ui/button.tsx
+++ b/apps/bestofjs-nextjs/src/components/ui/button.tsx
@@ -19,7 +19,7 @@ const Button = klassed(
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline: "border bg-card hover:bg-accent hover:text-accent-foreground",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+          "bg-secondary text-secondary-foreground hover:bg-secondary-hover",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },

--- a/apps/bestofjs-nextjs/src/components/ui/dialog.tsx
+++ b/apps/bestofjs-nextjs/src/components/ui/dialog.tsx
@@ -29,7 +29,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-background/80 backdrop-blur-sm transition-all duration-100 data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in",
+      "fixed inset-0 z-50 bg-[var(--overlay)] backdrop-blur-sm transition-all duration-100 data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in",
       className
     )}
     {...props}

--- a/apps/bestofjs-nextjs/src/components/ui/link.tsx
+++ b/apps/bestofjs-nextjs/src/components/ui/link.tsx
@@ -2,8 +2,8 @@ import { klass } from "@klass/core";
 
 export const linkVariants = klass({
   base: [
-    "whitespace-nowrap text-[var(--orange-11)] font-sans",
-    "decoration-[var(--orange-8)] hover:underline",
+    "whitespace-nowrap text-[var(--link-foreground)] font-sans",
+    "decoration-[var(--link-underline)] hover:underline",
   ],
   variants: {
     variant: {

--- a/apps/bestofjs-nextjs/src/components/ui/sheet.tsx
+++ b/apps/bestofjs-nextjs/src/components/ui/sheet.tsx
@@ -24,7 +24,7 @@ const SheetOverlay = React.forwardRef<
 >(({ ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-background/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
+      "fixed inset-0 z-50 bg-[var(--overlay)] backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
     )}
     {...props}
     ref={ref}

--- a/apps/bestofjs-nextjs/tailwind.config.js
+++ b/apps/bestofjs-nextjs/tailwind.config.js
@@ -21,6 +21,7 @@ module.exports = {
         foreground: "var(--foreground)",
         primary: {
           DEFAULT: "var(--primary)",
+          hover: "var(--primary-hover)",
           foreground: "var(--primary-foreground)",
         },
         secondary: {

--- a/apps/bestofjs-nextjs/tailwind.config.js
+++ b/apps/bestofjs-nextjs/tailwind.config.js
@@ -25,8 +25,9 @@ module.exports = {
           foreground: "var(--primary-foreground)",
         },
         secondary: {
-          DEFAULT: "hsl(var(--secondary))",
-          foreground: "hsl(var(--secondary-foreground))",
+          DEFAULT: "var(--secondary)",
+          hover: "var(--secondary-hover)",
+          foreground: "var(--secondary-foreground)",
         },
         destructive: {
           DEFAULT: "hsl(var(--destructive))",


### PR DESCRIPTION
## Goal

Cleanup following the introduction of Radix Colors tokens #250 , taking into account the comment from @flamrdevs as there was a miss about the `:hover` color effect of some buttons.

- The 2 variants `primary` use  `secondary` use tokens from the `orange` and the `sand` scales respectively
- The `destructive` variant was removed
 
Also new CSS variables are introduced for links:

- `link-foreground`
- `link-underline`

## How to test

- Go to the Hall of Fame `/hall-of-fame`
- Check the `:hover`effect of the Search button, in both light and dark mode

## Screenshots

![image](https://github.com/bestofjs/bestofjs/assets/5546996/99142421-baab-4ab9-83fe-1679e0ff89eb)

