### PR TITLE
Add tag description in tag list page

### DIFF
--- a/apps/bestofjs-nextjs/package.json
+++ b/apps/bestofjs-nextjs/package.json
@@ -33,6 +33,7 @@
     "@radix-ui/react-popover": "^1.0.6",
     "@radix-ui/react-separator": "^1.0.3",
     "@radix-ui/react-slot": "^1.0.2",
+    "@radix-ui/react-tooltip": "^1.0.7",
     "@t3-oss/env-nextjs": "^0.7.1",
     "@types/debug": "^4.1.8",
     "@types/fs-extra": "^11.0.1",

--- a/apps/bestofjs-nextjs/src/app/layout.tsx
+++ b/apps/bestofjs-nextjs/src/app/layout.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/config/site";
 import { fontSans, fontSerif } from "@/lib/fonts";
 import { cn } from "@/lib/utils";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { Footer } from "@/components/footer/footer";
 import { SiteHeader } from "@/components/header/site-header";
 import { TailwindIndicator } from "@/components/tailwind-indicator";
@@ -68,14 +69,16 @@ export default function RootLayout({ children }: RootLayoutProps) {
           )}
         >
           <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-            <div className="relative flex min-h-screen flex-col">
-              <SiteHeader />
-              <main className="flex-1 bg-[var(--app-background)]">
-                <div className="container pb-8 pt-6 md:py-8">{children}</div>
-              </main>
-              <Footer />
-            </div>
-            <TailwindIndicator />
+            <TooltipProvider>
+              <div className="relative flex min-h-screen flex-col">
+                <SiteHeader />
+                <main className="flex-1 bg-[var(--app-background)]">
+                  <div className="container pb-8 pt-6 md:py-8">{children}</div>
+                </main>
+                <Footer />
+              </div>
+              <TailwindIndicator />
+            </TooltipProvider>
           </ThemeProvider>
           <Analytics />
         </body>

--- a/apps/bestofjs-nextjs/src/components/tag-list/tag-list.tsx
+++ b/apps/bestofjs-nextjs/src/components/tag-list/tag-list.tsx
@@ -1,8 +1,9 @@
 import NextLink from "next/link";
 
+import { Badge } from "@/components/ui/badge";
+import { buttonVariants } from "@/components/ui/button";
+import { linkVariants } from "@/components/ui/link";
 import { ChevronRightIcon, ProjectAvatar } from "@/components/core";
-
-import { buttonVariants } from "../ui/button";
 
 type Props = {
   tags: BestOfJS.TagWithProjects[];
@@ -15,16 +16,17 @@ export const TagList = ({ tags }: Props) => {
           key={tag.code}
           className="flex w-full flex-col justify-between gap-4 p-4 md:flex-row"
         >
-          <div className="">
+          <div className="flex flex-col gap-2">
             <NextLink
               href={`/projects?tags=${tag.code}`}
-              className="text-secondary-foreground hover:underline"
+              className={linkVariants({ variant: "project" })}
             >
               {tag.name}
+              <Badge className="ml-2" variant="outline">
+                {tag.counter}
+              </Badge>
             </NextLink>
-            <span className="ml-2 text-muted-foreground">
-              {tag.counter} projects
-            </span>
+            <div className="text-muted-foreground">{tag.description}</div>
           </div>
           <div className="flex items-center gap-4">
             {tag.projects.map((project) => (

--- a/apps/bestofjs-nextjs/src/components/tag-list/tag-list.tsx
+++ b/apps/bestofjs-nextjs/src/components/tag-list/tag-list.tsx
@@ -19,7 +19,7 @@ export const TagList = ({ tags }: Props) => {
           <div className="flex flex-col gap-2">
             <NextLink
               href={`/projects?tags=${tag.code}`}
-              className={linkVariants({ variant: "project" })}
+              className={linkVariants({ variant: "tag" })}
             >
               {tag.name}
               <Badge className="ml-2" variant="outline">

--- a/apps/bestofjs-nextjs/src/components/tag-list/tag-list.tsx
+++ b/apps/bestofjs-nextjs/src/components/tag-list/tag-list.tsx
@@ -3,6 +3,11 @@ import NextLink from "next/link";
 import { Badge } from "@/components/ui/badge";
 import { buttonVariants } from "@/components/ui/button";
 import { linkVariants } from "@/components/ui/link";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { ChevronRightIcon, ProjectAvatar } from "@/components/core";
 
 type Props = {
@@ -14,7 +19,7 @@ export const TagList = ({ tags }: Props) => {
       {tags.map((tag) => (
         <div
           key={tag.code}
-          className="flex w-full flex-col justify-between gap-4 p-4 md:flex-row"
+          className="flex w-full flex-col items-center justify-between gap-4 p-4 md:flex-row"
         >
           <div className="flex flex-col gap-2">
             <NextLink
@@ -26,7 +31,9 @@ export const TagList = ({ tags }: Props) => {
                 {tag.counter}
               </Badge>
             </NextLink>
-            <div className="text-muted-foreground">{tag.description}</div>
+            {tag.description && (
+              <div className="text-muted-foreground">{tag.description}</div>
+            )}
           </div>
           <div className="flex items-center gap-4">
             {tag.projects.map((project) => (
@@ -35,7 +42,12 @@ export const TagList = ({ tags }: Props) => {
                 href={`/projects/${project.slug}`}
                 prefetch={false}
               >
-                <ProjectAvatar project={project} size={32} />
+                <Tooltip>
+                  <TooltipTrigger>
+                    <ProjectAvatar project={project} size={32} />
+                  </TooltipTrigger>
+                  <TooltipContent>{project.name}</TooltipContent>
+                </Tooltip>
               </NextLink>
             ))}
             <NextLink
@@ -45,7 +57,14 @@ export const TagList = ({ tags }: Props) => {
                 "h-[32px] w-[32px]"
               )}
             >
-              <ChevronRightIcon className="h-6 w-6" />
+              <Tooltip>
+                <TooltipTrigger>
+                  <ChevronRightIcon className="h-6 w-6" />
+                </TooltipTrigger>
+                <TooltipContent>
+                  View all projects ({tag.counter})
+                </TooltipContent>
+              </Tooltip>
             </NextLink>
           </div>
         </div>

--- a/apps/bestofjs-nextjs/src/components/ui/link.tsx
+++ b/apps/bestofjs-nextjs/src/components/ui/link.tsx
@@ -8,6 +8,7 @@ export const linkVariants = klass({
   variants: {
     variant: {
       project: "hover:underline-offset-8",
+      tag: "hover:underline-offset-8",
     },
   },
 });

--- a/apps/bestofjs-nextjs/src/components/ui/tooltip.tsx
+++ b/apps/bestofjs-nextjs/src/components/ui/tooltip.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import * as React from "react";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+
+import { cn } from "@/lib/utils";
+
+const TooltipProvider = TooltipPrimitive.Provider;
+
+const Tooltip = TooltipPrimitive.Root;
+
+const TooltipTrigger = TooltipPrimitive.Trigger;
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Content
+    ref={ref}
+    sideOffset={sideOffset}
+    className={cn(
+      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className
+    )}
+    {...props}
+  />
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/apps/bestofjs-nextjs/src/server/api-utils.tsx
+++ b/apps/bestofjs-nextjs/src/server/api-utils.tsx
@@ -65,7 +65,12 @@ export function getTagsByKey(
   const byKey = {} as { [tag: string]: BestOfJS.Tag };
 
   tags.forEach((tag) => {
-    byKey[tag.code] = { name: tag.name, code: tag.code, counter: 0 };
+    byKey[tag.code] = {
+      code: tag.code,
+      counter: 0,
+      description: tag.description,
+      name: tag.name,
+    };
   });
 
   projects.forEach(({ tags }) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.0.2
         version: 1.0.2(@types/react@18.2.18)(react@18.2.0)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.0.7
+        version: 1.0.7(@types/react-dom@18.2.7)(@types/react@18.2.18)(react-dom@18.2.0)(react@18.2.0)
       '@t3-oss/env-nextjs':
         specifier: ^0.7.1
         version: 0.7.1(typescript@5.2.2)(zod@3.22.4)
@@ -2605,6 +2608,31 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
+  /@radix-ui/react-dismissable-layer@1.0.5(@types/react-dom@18.2.7)(@types/react@18.2.18)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-aJeDjQhywg9LBu2t/At58hCvr7pEm0o2Ke1x33B+MhjNmmZ17sy4KImo0KPLgsnc/zN7GPdce8Cnn0SWvwZO7g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.6
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.18)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.18)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.18)(react@18.2.0)
+      '@radix-ui/react-use-escape-keydown': 1.0.3(@types/react@18.2.18)(react@18.2.0)
+      '@types/react': 18.2.18
+      '@types/react-dom': 18.2.7
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
   /@radix-ui/react-dropdown-menu@2.0.5(@types/react-dom@18.2.7)(@types/react@18.2.18)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-xdOrZzOTocqqkCkYo8yRPCib5OkTkqN7lqNCdxwPOdE466DOaNl4N8PkUIlsXthQvW5Wwkd+aEmWpfWlBoDPEw==}
     peerDependencies:
@@ -2820,6 +2848,36 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
+  /@radix-ui/react-popper@1.1.3(@types/react-dom@18.2.7)(@types/react@18.2.18)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-cKpopj/5RHZWjrbF2846jBNacjQVwkP068DfmgrNJXpvVWrOvlAmE9xSiy5OqeE+Gi8D9fP+oDhUnPqNMY8/5w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.6
+      '@floating-ui/react-dom': 2.0.1(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-arrow': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.18)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.18)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.18)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.18)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.18)(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.18)(react@18.2.0)
+      '@radix-ui/react-use-rect': 1.0.1(@types/react@18.2.18)(react@18.2.0)
+      '@radix-ui/react-use-size': 1.0.1(@types/react@18.2.18)(react@18.2.0)
+      '@radix-ui/rect': 1.0.1
+      '@types/react': 18.2.18
+      '@types/react-dom': 18.2.7
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
   /@radix-ui/react-portal@1.0.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-a8qyFO/Xb99d8wQdu4o7qnigNjTPG123uADNecz0eX4usnQEj7o+cG4ZX4zkqq98NYekT7UoEQIjxBNWIFuqTA==}
     peerDependencies:
@@ -2834,6 +2892,27 @@ packages:
 
   /@radix-ui/react-portal@1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.18)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-xLYZeHrWoPmA5mEKEfZZevoVRK/Q43GfzRXkWV6qawIWWK8t6ifIiLQdd7rmQ4Vk1bmI21XhqF9BN3jWf+phpA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.6
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.18)(react-dom@18.2.0)(react@18.2.0)
+      '@types/react': 18.2.18
+      '@types/react-dom': 18.2.7
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-portal@1.0.4(@types/react-dom@18.2.7)(@types/react@18.2.18)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-Qki+C/EuGUVCQTOTD5vzJzJuMUlewbzuKyUy+/iHM2uwGiru9gZeBJtHAPKAEkB5KWGi9mP/CHKcY0wt1aW45Q==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2996,6 +3075,38 @@ packages:
       react: 18.2.0
     dev: false
 
+  /@radix-ui/react-tooltip@1.0.7(@types/react-dom@18.2.7)(@types/react@18.2.18)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-lPh5iKNFVQ/jav/j6ZrWq3blfDJ0OH9R6FlNUHPMqdLuQ9vwDgFsRxvl8b7Asuy5c8xmoojHUxKHQSOAvMHxyw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.6
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.18)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.18)(react@18.2.0)
+      '@radix-ui/react-dismissable-layer': 1.0.5(@types/react-dom@18.2.7)(@types/react@18.2.18)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.2.18)(react@18.2.0)
+      '@radix-ui/react-popper': 1.1.3(@types/react-dom@18.2.7)(@types/react@18.2.18)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-portal': 1.0.4(@types/react-dom@18.2.7)(@types/react@18.2.18)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.2.7)(@types/react@18.2.18)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.18)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.18)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.18)(react@18.2.0)
+      '@radix-ui/react-visually-hidden': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.18)(react-dom@18.2.0)(react@18.2.0)
+      '@types/react': 18.2.18
+      '@types/react-dom': 18.2.7
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
   /@radix-ui/react-use-callback-ref@1.0.0(react@18.2.0):
     resolution: {integrity: sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==}
     peerDependencies:
@@ -3134,6 +3245,27 @@ packages:
       '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.18)(react@18.2.0)
       '@types/react': 18.2.18
       react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-visually-hidden@1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.18)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-D4w41yN5YRKtu464TLnByKzMDG/JlMPHtfZgQAu9v6mNakUqGUI9vUrfQKz8NK41VMm/xbZbh76NUTVtIYqOMA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.6
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.18)(react-dom@18.2.0)(react@18.2.0)
+      '@types/react': 18.2.18
+      '@types/react-dom': 18.2.7
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /@radix-ui/rect@1.0.1:
@@ -11353,7 +11485,7 @@ packages:
       '@types/node': 17.0.45
       esbuild: 0.15.18
       postcss: 8.4.31
-      resolve: 1.22.3
+      resolve: 1.22.2
       rollup: 2.79.1
     optionalDependencies:
       fsevents: 2.3.2


### PR DESCRIPTION
## Goal

Add tag's description in the tags list page.

This is the commit that made the description available in the static API (the huge JSON file queried by the Next.js app, in the server-side): https://github.com/bestofjs/bestofjs-backend/commit/06e6c856ee50555f4a9aec5c1e167b561e4827ae

Note: not all tags have a description.

In addition: a tooltip is added on project's icons, to show the project's  name

## How to test

- Go to `/tags` page 
- Check a description is displayed
- Mouse `:hover` the project's icons: a tooltip with the project name should be displayed.

## Screenshots

![image](https://github.com/bestofjs/bestofjs/assets/5546996/a518de39-0205-4648-87d6-beb3509eeffc)

