### PR TITLE
Cleanup project logo component

### DIFF
--- a/apps/bestofjs-nextjs/src/app/api/og/og-utils.tsx
+++ b/apps/bestofjs-nextjs/src/app/api/og/og-utils.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { ImageResponse } from "next/og";
 
 import { APP_CANONICAL_URL } from "@/config/site";
-import { getProjectAvatarUrl } from "@/components/core/project-utils";
+import { getProjectLogoUrl } from "@/components/core/project-utils";
 
 export const mutedColor = `rgba(255, 255, 255, 0.7)`;
 export const borderColor = `rgba(255, 255, 255, 0.2)`;
@@ -45,9 +45,7 @@ export function ProjectLogo({
   project: BestOfJS.Project;
   size: number;
 }) {
-  const imageURL = getImageAbsoluteURL(
-    getProjectAvatarUrl(project, 100, "dark")
-  );
+  const imageURL = getImageAbsoluteURL(getProjectLogoUrl(project, 100, "dark"));
   return <img src={imageURL} width={size} height={size} alt={project.name} />;
 }
 

--- a/apps/bestofjs-nextjs/src/app/globals.css
+++ b/apps/bestofjs-nextjs/src/app/globals.css
@@ -132,6 +132,11 @@
   }
 }
 
+.project-logo {
+  max-width: initial;
+  height: revert-layer; /* override `height: auto` from Tailwind base layer */
+}
+
 /* Override the behavior provided by reset CSS to display correctly badges in projects README */
 .markdown-body img,
 .markdown-body svg {

--- a/apps/bestofjs-nextjs/src/app/hall-of-fame/hall-of-member-list.tsx
+++ b/apps/bestofjs-nextjs/src/app/hall-of-fame/hall-of-member-list.tsx
@@ -3,7 +3,7 @@ import NextLink from "next/link";
 import { cn } from "@/lib/utils";
 import { badgeVariants } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
-import { ProjectAvatar } from "@/components/core";
+import { ProjectLogo } from "@/components/core";
 import { ExternalLink } from "@/components/core/typography";
 
 type Props = {
@@ -61,7 +61,7 @@ function HallOfFameMember({ member }: { member: BestOfJS.HallOfFameMember }) {
                 )}
               >
                 {project.icon && (
-                  <ProjectAvatar project={project} size={20} className="mr-2" />
+                  <ProjectLogo project={project} size={20} className="mr-2" />
                 )}
                 {project.name}
               </NextLink>

--- a/apps/bestofjs-nextjs/src/app/projects/[slug]/project-header.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/[slug]/project-header.tsx
@@ -3,7 +3,7 @@ import { ImNpm } from "react-icons/im";
 
 import { formatUrl } from "@/helpers/url";
 import { buttonVariants } from "@/components/ui/button";
-import { GitHubIcon, HomeIcon, ProjectAvatar } from "@/components/core";
+import { GitHubIcon, HomeIcon, ProjectLogo } from "@/components/core";
 import { ProjectTagGroup } from "@/components/tags/project-tag";
 
 import { getProjectDetails } from "./get-project-details";
@@ -16,7 +16,7 @@ export function ProjectHeader({ project }: Props) {
     <div className="flex flex-col space-y-4 sm:flex-row sm:space-y-0 sm:divide-x">
       <div className="flex min-h-[120px] grow items-center divide-x">
         <div className="pr-4">
-          <ProjectAvatar project={project} size={75} />
+          <ProjectLogo project={project} size={75} />
         </div>
         <div className="flex flex-col space-y-4 pl-4">
           <h2 className="font-serif text-4xl">{project.name}</h2>

--- a/apps/bestofjs-nextjs/src/components/core/index.tsx
+++ b/apps/bestofjs-nextjs/src/components/core/index.tsx
@@ -1,3 +1,3 @@
 export * from "./icons";
 export * from "./project";
-export * from "./project-avatar";
+export * from "./project-logo";

--- a/apps/bestofjs-nextjs/src/components/core/project-avatar.tsx
+++ b/apps/bestofjs-nextjs/src/components/core/project-avatar.tsx
@@ -27,7 +27,7 @@ export const ProjectAvatar = ({ project, size = 100, className }: Props) => {
       width={size}
       height={size}
       alt={project.name}
-      className={cn(className, `w-[${size}px] h-[${size}px] max-w-none`)}
+      className={cn(className, "project-logo")}
     />
   );
 };

--- a/apps/bestofjs-nextjs/src/components/core/project-logo.tsx
+++ b/apps/bestofjs-nextjs/src/components/core/project-logo.tsx
@@ -5,14 +5,14 @@ import { useTheme } from "next-themes";
 
 import { cn } from "@/lib/utils";
 
-import { getProjectAvatarUrl } from "./project-utils";
+import { getProjectLogoUrl } from "./project-utils";
 
 type Props = {
   project: Pick<BestOfJS.Project, "name" | "owner_id" | "icon">;
   size: number;
   className?: string;
 };
-export const ProjectAvatar = ({ project, size = 100, className }: Props) => {
+export const ProjectLogo = ({ project, size = 100, className }: Props) => {
   const { resolvedTheme } = useTheme();
 
   const { src } = getProjectImageProps({
@@ -42,10 +42,10 @@ function getProjectImageProps({
   colorMode: "dark" | "light";
 }) {
   const retinaURL =
-    !project.icon && getProjectAvatarUrl(project, size * 2, colorMode);
+    !project.icon && getProjectLogoUrl(project, size * 2, colorMode);
 
   return {
-    src: getProjectAvatarUrl(project, size, colorMode),
+    src: getProjectLogoUrl(project, size, colorMode),
     srcSet: retinaURL ? `${retinaURL} 2x` : undefined, // to display correctly GitHub avatars on Retina screens
   };
 }

--- a/apps/bestofjs-nextjs/src/components/core/project-utils.ts
+++ b/apps/bestofjs-nextjs/src/components/core/project-utils.ts
@@ -4,7 +4,7 @@
  * - the GitHub owner avatar (by default if no `icon` property is specified)
  * - A custom SVG file if project's `icon`property is specified.
  */
-export function getProjectAvatarUrl(
+export function getProjectLogoUrl(
   project: Pick<BestOfJS.Project, "name" | "owner_id" | "icon">,
   size: number,
   colorMode: "dark" | "light"

--- a/apps/bestofjs-nextjs/src/components/home/featured-project-list.tsx
+++ b/apps/bestofjs-nextjs/src/components/home/featured-project-list.tsx
@@ -1,7 +1,7 @@
 import NextLink from "next/link";
 
 import { Skeleton } from "@/components/ui/skeleton";
-import { ProjectAvatar, StarDelta, getDeltaByDay } from "@/components/core";
+import { ProjectLogo, StarDelta, getDeltaByDay } from "@/components/core";
 import { SortOptionKey } from "@/components/project-list/sort-order-options";
 import { ProjectTag } from "@/components/tags/project-tag";
 
@@ -35,7 +35,7 @@ function FeaturedProject({
         href={`/projects/${project.slug}`}
         className="display-block w-[80px] overflow-hidden text-muted-foreground"
       >
-        <ProjectAvatar project={project} size={80} />
+        <ProjectLogo project={project} size={80} />
       </NextLink>
       <div className="flex-1 space-y-2 overflow-hidden text-center">
         <NextLink

--- a/apps/bestofjs-nextjs/src/components/project-list/project-table.tsx
+++ b/apps/bestofjs-nextjs/src/components/project-list/project-table.tsx
@@ -9,7 +9,7 @@ import {
   DownloadCount,
   GitHubIcon,
   HomeIcon,
-  ProjectAvatar,
+  ProjectLogo,
   StarDelta,
   StarTotal,
   getDeltaByDay,
@@ -69,7 +69,7 @@ const ProjectTableRow = ({
     <tr data-testid="project-card" className="border-b">
       <Cell className="w-[50px] pl-4 sm:p-4">
         <NextLink href={path}>
-          <ProjectAvatar project={project} size={48} />
+          <ProjectLogo project={project} size={48} />
         </NextLink>
       </Cell>
 

--- a/apps/bestofjs-nextjs/src/components/search-palette/search-palette-results.tsx
+++ b/apps/bestofjs-nextjs/src/components/search-palette/search-palette-results.tsx
@@ -8,7 +8,7 @@ import { CommandItem } from "@/components/ui/command";
 import {
   GitHubIcon,
   HomeIcon,
-  ProjectAvatar,
+  ProjectLogo,
   SearchIcon,
   StarTotal,
   TagIcon,
@@ -76,7 +76,7 @@ function ProjectSummary({ project }: { project: BestOfJS.SearchIndexProject }) {
   return (
     <div className="flex w-full min-w-0 items-center gap-4">
       <div className="flex h-12 w-12 items-center justify-center">
-        <ProjectAvatar project={project} size={32} />
+        <ProjectLogo project={project} size={32} />
       </div>
       <div className="group-aria-[selected]:text-accent-foreground] flex-1 truncate">
         {project.name}

--- a/apps/bestofjs-nextjs/src/components/search-palette/search-palette.tsx
+++ b/apps/bestofjs-nextjs/src/components/search-palette/search-palette.tsx
@@ -16,7 +16,7 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
-  ProjectAvatar,
+  ProjectLogo,
   StarTotal,
   TagIcon,
   TagsIcons,
@@ -340,7 +340,7 @@ function LoadingProject({ project }: { project: BestOfJS.SearchIndexProject }) {
     <div className="p-4">
       <div className="grid grid-cols-[75px_1fr_100px]">
         <div className="items-center justify-center">
-          <ProjectAvatar project={project} size={50} />
+          <ProjectLogo project={project} size={50} />
         </div>
         <div className="space-y-2">
           <div className="text-lg">

--- a/apps/bestofjs-nextjs/src/components/tag-list/tag-list.tsx
+++ b/apps/bestofjs-nextjs/src/components/tag-list/tag-list.tsx
@@ -8,7 +8,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { ChevronRightIcon, ProjectAvatar } from "@/components/core";
+import { ChevronRightIcon, ProjectLogo } from "@/components/core";
 
 type Props = {
   tags: BestOfJS.TagWithProjects[];
@@ -44,7 +44,7 @@ export const TagList = ({ tags }: Props) => {
               >
                 <Tooltip>
                   <TooltipTrigger>
-                    <ProjectAvatar project={project} size={32} />
+                    <ProjectLogo project={project} size={32} />
                   </TooltipTrigger>
                   <TooltipContent>{project.name}</TooltipContent>
                 </Tooltip>

--- a/apps/bestofjs-nextjs/src/components/tags/project-tag-hover-card.tsx
+++ b/apps/bestofjs-nextjs/src/components/tags/project-tag-hover-card.tsx
@@ -9,7 +9,7 @@ import {
   HoverCardTrigger,
 } from "@/components/ui/hover-card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ProjectAvatar, TagIcon } from "@/components/core";
+import { ProjectLogo, TagIcon } from "@/components/core";
 
 const NUMBER_OF_PROJECTS = 5;
 
@@ -85,7 +85,7 @@ const TagProjectList = ({ projects }: { projects: BestOfJS.Project[] }) => (
         href={`/projects/${project.slug}`}
         className="flex h-5 items-center gap-2 text-sm text-muted-foreground hover:text-primary-foreground"
       >
-        <ProjectAvatar project={project} size={20} />
+        <ProjectLogo project={project} size={20} />
         <span>{project.name}</span>
       </Link>
     ))}


### PR DESCRIPTION
## Goal

Cleanup `ProjectLogo` component

- ensure the logo is always displayed as a square, overriding `height: auto` coming from Tailwind CSS (I noticed the problem after Astro logo was updated by this PR #263 )
- remove classes that have no effect
- Rename `ProjectAvatar` => `ProjectLogo`
 
About TailwindCSS reset: https://tailwindcss.com/docs/preflight

## How to test

Check the logo for projects that have a custom SVG file whose `viewPort` is not a square 
Examples:

- Astro
- Nuxt

## Screenshots

#### Before

![image](https://github.com/bestofjs/bestofjs/assets/5546996/0529b9ce-e900-4dbe-a3f8-aeac1da3f305)

#### After

![image](https://github.com/bestofjs/bestofjs/assets/5546996/36536a9e-9573-45a0-8234-25e158e867ca)

