### PR TITLE
Restore end-to-end test suite with Playwright

### DIFF
--- a/apps/bestofjs-nextjs/playwright.config.ts
+++ b/apps/bestofjs-nextjs/playwright.config.ts
@@ -1,0 +1,72 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = process.env.PORT || 3000;
+const BASE_URL = process.env.BASE_URL || `http://localhost:${PORT}`;
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './tests/e2e',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: BASE_URL,
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    }
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your production server with built assets before starting the tests */
+  /* On CI we're using the vercel deployment so no need to run a server. */
+  webServer: process.env.CI ? undefined : {
+    command: 'pnpm start',
+    url: BASE_URL,
+    timeout: 120 * 1000,
+    reuseExistingServer: true,
+  },
+});

--- a/apps/bestofjs-nextjs/tsconfig.json
+++ b/apps/bestofjs-nextjs/tsconfig.json
@@ -24,6 +24,11 @@
     ],
     "strictNullChecks": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": [
+    "next-env.d.ts",
+    "./src/**/*.ts",
+    "./src/**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Goal

Restore the E2E test suite that I had to disable 2 weeks ago, when the build was broken on Vercel.

I'm not too sure what happened at the time, there was no change from our side but one day the project was not building anymore: 

the error was a TypeScript error because of `playwright.config.ts` file, the package `@playwright/test` was not found (which is normal since we run in production mode on Vercel, devDependencies are not installed as we want the test suite to run on GitHub actions only)

So this PR restores the test suite by:

- restoring the config file
- ensure the TS compiler only compiles files from the `src` folder (maybe I should exclude `playwright.config.ts` instead?)

## How to test

Ensure all the checks pass on GitHub actions!

## Screenshots

![image](https://github.com/bestofjs/bestofjs/assets/5546996/0041d73c-4120-4f60-b65b-1d4e0983bb75)

