### PR TITLE
Fix open a tag from the search palette when the current page is > 1

### DIFF
--- a/apps/bestofjs-nextjs/src/components/search-palette/search-palette-state.ts
+++ b/apps/bestofjs-nextjs/src/components/search-palette/search-palette-state.ts
@@ -102,7 +102,7 @@ export function useSearchPaletteState() {
     const selectedTagCode = itemValue.slice("tag/".length);
     const tagCodes = [...currentTagCodes, selectedTagCode];
     const tags = tagCodes.map(lookupTag).filter(Boolean) as BestOfJS.Tag[];
-    const nextState = { ...searchState, tags: tagCodes };
+    const nextState = { ...searchState, page: 1, tags: tagCodes };
     const queryString = stateToQueryString(nextState);
     setSelectedItem({ type: "tag", value: tags });
     goToURL(`/projects/?${queryString}`);


### PR DESCRIPTION
## Goal

Fix the bug about the search palette mentioned here: https://github.com/michaelrambeau/bestofjs/issues/938

Cause: the page parameter should be reset when opening a tag from the search palette.

Note: we try to keep the search parameters to maintain the search order picked by the user (E.g. "by number of stars")

## How to test

- Go to "All projects" page
- Scroll and go to the next page to open http://localhost:3000/projects?sort=total&page=2
- Press Cmd K to Open the search palette
- Search for a tag, select it, and check the tag page open correctly

## Screenshots

![image](https://github.com/bestofjs/bestofjs/assets/5546996/66ea590b-bc4d-45e5-98c8-c8eb4a4aaeac)

