### PR TITLE
Fix theme toggle

### DIFF
--- a/apps/bestofjs-nextjs/src/components/theme-toggle.tsx
+++ b/apps/bestofjs-nextjs/src/components/theme-toggle.tsx
@@ -8,13 +8,13 @@ import { Button } from "@/components/ui/button";
 import { MoonIcon, SunIcon } from "./core";
 
 export function ThemeToggle() {
-  const { setTheme, theme } = useTheme();
+  const { setTheme, resolvedTheme } = useTheme();
 
   return (
     <Button
       variant="ghost"
       size="sm"
-      onClick={() => setTheme(theme === "light" ? "dark" : "light")}
+      onClick={() => setTheme(resolvedTheme === "light" ? "dark" : "light")}
     >
       <SunIcon className="rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
       <MoonIcon className="absolute rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />


### PR DESCRIPTION
## Goal
The `theme` field returned by the `useTheme` hook of [next-themes](https://github.com/pacocoursey/next-themes?tab=readme-ov-file#usetheme-1) has the literal value `system` if it has not been manually modified.
So if the user has `light` as the system preference, on the first click the handler 
```ts
onClick={() => setTheme(theme === "light" ? "dark" : "light")}
```
will set the theme to `light` again, since `"system" !== "light"`.

## How to test
Go to https://bestofjs.org/ from an incognito tab with system preference set as light and click the theme toggle icon. On the first click the theme will not change.

## Screenshots
![image](https://github.com/bestofjs/bestofjs/assets/9802152/14c81104-4d92-4b4b-9844-32b8dcb80dcb)

