### PR TITLE
Feat(backend) Add `concurrency` parameter for DB scripts

### DIFF
--- a/.github/workflows/update-github-data.yml
+++ b/.github/workflows/update-github-data.yml
@@ -17,6 +17,11 @@ on:
         required: false
         type: number
         default: 0
+      skip:
+        description: "Number of projects to skip (when paginating)"
+        required: false
+        type: number
+        default: 0
       concurrency:
         description: "Number of projects to process concurrently"
         required: false
@@ -38,7 +43,7 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: pnpm -F backend install
-      - run: pnpm -F backend daily-update-github-data --limit ${{ inputs.limit || 0 }} --loglevel ${{ inputs.logLevel || 3 }} --concurrency ${{ inputs.concurrency || 1 }}
+      - run: pnpm -F backend daily-update-github-data --loglevel ${{ inputs.logLevel || 3 }} --limit ${{ inputs.limit || 0 }} --skip ${{ inputs.skip || 0 }} --concurrency ${{ inputs.concurrency || 1 }}
         env:
           POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
           # caution: `GITHUB_` is not a valid prefix for secrets!

--- a/.github/workflows/update-github-data.yml
+++ b/.github/workflows/update-github-data.yml
@@ -17,6 +17,11 @@ on:
         required: false
         type: number
         default: 0
+      concurrency:
+        description: "Number of projects to process concurrently"
+        required: false
+        type: number
+        default: 1
 jobs:
   update-package-data:
     runs-on: ubuntu-latest
@@ -33,7 +38,7 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: pnpm -F backend install
-      - run: pnpm -F backend daily-update-github-data --limit ${{ inputs.limit || 0 }} --loglevel ${{ inputs.logLevel || 3 }}
+      - run: pnpm -F backend daily-update-github-data --limit ${{ inputs.limit || 0 }} --loglevel ${{ inputs.logLevel || 3 }} --concurrency ${{ inputs.concurrency || 1 }}
         env:
           POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
           # caution: `GITHUB_` is not a valid prefix for secrets!

--- a/apps/backend/src/cli.ts
+++ b/apps/backend/src/cli.ts
@@ -5,6 +5,10 @@ import { updateGitHubDataTask } from "./tasks/update-github-data.task";
 import { buildStaticApiTask } from "./tasks/build-static-api";
 
 const flags = {
+  concurrency: {
+    type: Number,
+    default: 1,
+  },
   logLevel: {
     type: Number,
     description:

--- a/apps/backend/src/cli.ts
+++ b/apps/backend/src/cli.ts
@@ -20,6 +20,11 @@ const flags = {
     description: "Records to process",
     default: 0,
   },
+  skip: {
+    type: Number,
+    description: "Records to skip (when paginating)",
+    default: 0,
+  },
   name: {
     type: String,
     description: "Full name of the GitHub repo to process",

--- a/apps/backend/src/iteration-helpers/process-projects.ts
+++ b/apps/backend/src/iteration-helpers/process-projects.ts
@@ -18,7 +18,7 @@ export function processProjects(context: TaskContext) {
     callback: (project: Project, index: number) => Promise<CallbackResult<T>>,
     options?: LoopOptions
   ) {
-    const { limit = 0, offset = 0, name, throwOnError = false } = options || {};
+    const { limit = 0, skip = 0, name, throwOnError = false } = options || {};
 
     const ids = await findAllIds();
     const results = await pMap(
@@ -54,7 +54,7 @@ export function processProjects(context: TaskContext) {
         .from(schema.projects)
         .orderBy(desc(schema.projects.createdAt))
         .limit(limit)
-        .offset(offset);
+        .offset(skip);
 
       if (name) {
         query.where(eq(schema.projects.slug, name));

--- a/apps/backend/src/iteration-helpers/process-projects.ts
+++ b/apps/backend/src/iteration-helpers/process-projects.ts
@@ -1,7 +1,7 @@
 import { desc, eq } from "drizzle-orm";
 import pMap from "p-map";
 
-import { DB, schema } from "@repo/db";
+import { schema } from "@repo/db";
 import { ProjectService } from "@repo/db/projects";
 
 import { LoopOptions, TaskContext } from "@/task-runner";
@@ -40,7 +40,7 @@ export function processProjects(context: TaskContext) {
         }
       },
       {
-        concurrency: 1,
+        concurrency: options?.concurrency || 1,
       }
     );
 

--- a/apps/backend/src/iteration-helpers/process-repos.ts
+++ b/apps/backend/src/iteration-helpers/process-repos.ts
@@ -19,7 +19,7 @@ export function processRepos(context: TaskContext) {
   ) {
     const {
       limit = 0,
-      offset = 0,
+      skip = 0,
       name,
       throwOnError = false,
       concurrency = 1,
@@ -59,7 +59,7 @@ export function processRepos(context: TaskContext) {
         .from(schema.repos)
         .orderBy(desc(schema.repos.added_at))
         .limit(limit)
-        .offset(offset);
+        .offset(skip);
 
       if (name) {
         query.where(eq(schema.repos.full_name, name));

--- a/apps/backend/src/iteration-helpers/process-repos.ts
+++ b/apps/backend/src/iteration-helpers/process-repos.ts
@@ -17,7 +17,13 @@ export function processRepos(context: TaskContext) {
     callback: (repo: Repo, index: number) => Promise<CallbackResult<T>>,
     options?: LoopOptions
   ) {
-    const { limit = 0, offset = 0, name, throwOnError = false } = options || {};
+    const {
+      limit = 0,
+      offset = 0,
+      name,
+      throwOnError = false,
+      concurrency = 1,
+    } = options || {};
 
     const ids = await findAllIds();
     const results = await pMap(
@@ -39,7 +45,7 @@ export function processRepos(context: TaskContext) {
         }
       },
       {
-        concurrency: 1,
+        concurrency,
       }
     );
 


### PR DESCRIPTION
## Goal

Add a `concurrency` parameter to the backend apps to speed up the daily build process on GitHub actions.
The goal is to be able to run the task `update-github-data` in a reasonable time (less than 30 minutes)

## How to test

Use the dummy task `hello-world` to check the effect of the concurrency.

```sh
 bun run apps/backend/src/cli.ts hello-world --limit 100 --logLevel 4 --concurrency 10 
```

