### PR TITLE
Migration backend / Fix TS errors, fix static API build on Vercel

### DIFF
--- a/.github/workflows/update-github-data.yml
+++ b/.github/workflows/update-github-data.yml
@@ -28,7 +28,7 @@ on:
         type: number
         default: 1
 jobs:
-  update-package-data:
+  update-github-data:
     runs-on: ubuntu-latest
     steps:
       - name: Code Checkout

--- a/.github/workflows/update-github-data.yml
+++ b/.github/workflows/update-github-data.yml
@@ -27,6 +27,11 @@ on:
         required: false
         type: number
         default: 1
+      throttleInterval:
+        description: "Interval in milliseconds to wait between requests, to avoid rate limit errors"
+        required: false
+        type: number
+        default: 750
 jobs:
   update-github-data:
     runs-on: ubuntu-latest
@@ -43,7 +48,8 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: pnpm -F backend install
-      - run: pnpm -F backend daily-update-github-data --loglevel ${{ inputs.logLevel || 3 }} --limit ${{ inputs.limit || 0 }} --skip ${{ inputs.skip || 0 }} --concurrency ${{ inputs.concurrency || 5 }}
+      - name: Update GitHub Data and take snapshots
+        run: pnpm -F backend daily-update-github-data --loglevel ${{ inputs.logLevel || 3 }} --limit ${{ inputs.limit || 0 }} --skip ${{ inputs.skip || 0 }} --concurrency ${{ inputs.concurrency || 5 }} --throttleInterval ${{ inputs.throttleInterval || 5 }}
         env:
           POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
           # caution: `GITHUB_` is not a valid prefix for secrets!

--- a/apps/backend/.gitignore
+++ b/apps/backend/.gitignore
@@ -1,1 +1,2 @@
 build
+tsconfig.tsbuildinfo

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -6,7 +6,9 @@
   "type": "module",
   "scripts": {
     "daily-update-github-data": "dotenv -e ../../.env tsx ./src/cli.ts update-github-data -- --logLevel 3",
-    "build-static-api": "dotenv -e ../../.env tsx ./src/cli.ts build-static-api -- --logLevel 3"
+    "build-static-api": "dotenv -e ../../.env tsx ./src/cli.ts build-static-api -- --logLevel 2 --limit 1000 --concurrency 10",
+    "typecheck": "tsc --noEmit",
+    "typecheck:watch": "tsc --noEmit --incremental --watch"
   },
   "keywords": [],
   "author": "",
@@ -23,6 +25,7 @@
     "pretty-bytes": "^6.1.1",
     "tasuku": "^2.0.1",
     "tiny-invariant": "^1.3.1",
-    "tsx": "^4.16.2"
+    "tsx": "^4.16.2",
+    "typescript": "^5.5.4"
   }
 }

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -22,6 +22,7 @@
     "drizzle-orm": "^0.31.2",
     "fs-extra": "^11.1.1",
     "p-map": "^7.0.2",
+    "p-throttle": "^6.1.0",
     "pretty-bytes": "^6.1.1",
     "tasuku": "^2.0.1",
     "tiny-invariant": "^1.3.1",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "daily-update-github-data": "dotenv -e ../../.env tsx ./src/cli.ts update-github-data -- --logLevel 3",
-    "build-static-api": "dotenv -e ../../.env tsx ./src/cli.ts build-static-api -- --logLevel 2 --limit 1000 --concurrency 10",
+    "build-static-api": "dotenv -e ../../.env tsx ./src/cli.ts build-static-api -- --logLevel 3 --concurrency 10",
     "typecheck": "tsc --noEmit",
     "typecheck:watch": "tsc --noEmit --incremental --watch"
   },

--- a/apps/backend/src/cli.ts
+++ b/apps/backend/src/cli.ts
@@ -4,6 +4,7 @@ import { TaskRunner } from "./task-runner";
 import { helloProjectsTask, helloWorldTask } from "./tasks/hello-world.task";
 import { updateGitHubDataTask } from "./tasks/update-github-data.task";
 import { buildStaticApiTask } from "./tasks/build-static-api.task";
+import { desc } from "drizzle-orm";
 
 const flags = {
   concurrency: {
@@ -29,6 +30,10 @@ const flags = {
   name: {
     type: String,
     description: "Full name of the GitHub repo to process",
+  },
+  throttleInterval: {
+    type: Number,
+    description: "Throttle interval in milliseconds",
   },
 };
 

--- a/apps/backend/src/iteration-helpers/process-projects.ts
+++ b/apps/backend/src/iteration-helpers/process-projects.ts
@@ -4,12 +4,12 @@ import pMap from "p-map";
 import { schema } from "@repo/db";
 import { ProjectService } from "@repo/db/projects";
 
-import { LoopOptions, TaskContext } from "@/task-runner";
+import { LoopOptions, RunnerContext } from "@/task-runner";
 import { CallbackResult, aggregateResults } from "./utils";
 
 export type Project = Awaited<ReturnType<ProjectService["getProjectById"]>>;
 
-export function processProjects(context: TaskContext) {
+export function processProjects(context: RunnerContext) {
   const { db, logger } = context;
 
   const service = new ProjectService(db);

--- a/apps/backend/src/iteration-helpers/process-repos.ts
+++ b/apps/backend/src/iteration-helpers/process-repos.ts
@@ -41,15 +41,15 @@ export function processRepos(context: RunnerContext) {
       ids,
       async (id, index) => {
         const repo = await findRepoById(db, id);
-        const data = await throttledCallback(repo, index);
         try {
           logger.debug(`Processing repo #${index + 1}`, repo.full_name);
-          logger.info(`Processed repo ${repo.full_name}`, data);
+          const data = await throttledCallback(repo, index);
+          logger.info(`Processed repo #${index + 1} ${repo.full_name}`, data);
           return data;
         } catch (error) {
-          logger.error(`Error processing repo ${repo.name}`, error);
+          logger.error(`Error processing repo ${repo.full_name}`, error);
           if (throwOnError)
-            throw new Error(`Error processing repo ${repo.name}`, {
+            throw new Error(`Error processing repo ${repo.full_name}`, {
               cause: error,
             });
           return { meta: { error: true }, data: null };

--- a/apps/backend/src/iteration-helpers/process-repos.ts
+++ b/apps/backend/src/iteration-helpers/process-repos.ts
@@ -4,13 +4,13 @@ import pMap from "p-map";
 
 import { DB, schema } from "@repo/db";
 
-import { LoopOptions, TaskContext } from "@/task-runner";
+import { LoopOptions, RunnerContext } from "@/task-runner";
 import { CallbackResult, aggregateResults } from "./utils";
 
 // type Repo = typeof schema.repos.$inferSelect;
 export type Repo = Awaited<ReturnType<typeof findRepoById>>;
 
-export function processRepos(context: TaskContext) {
+export function processRepos(context: RunnerContext) {
   const { db, logger } = context;
 
   return async function <T>(

--- a/apps/backend/src/iteration-helpers/process-repos.ts
+++ b/apps/backend/src/iteration-helpers/process-repos.ts
@@ -77,7 +77,9 @@ export function processRepos(context: RunnerContext) {
       }
 
       const repos = await query;
-      if (!repos.length) logger.error("No repos found");
+      if (!repos.length) {
+        logger.error(`No repos found with full_name: ${name}`);
+      }
 
       const ids = repos.map((repo) => repo.id);
       return ids;

--- a/apps/backend/src/iteration-helpers/utils.ts
+++ b/apps/backend/src/iteration-helpers/utils.ts
@@ -1,5 +1,7 @@
+export type MetaResult = { [key: string]: boolean | number | undefined };
+
 export type CallbackResult<T> = {
-  meta: { [key: string]: boolean | number | undefined };
+  meta: MetaResult;
   data: T | null;
 };
 
@@ -18,9 +20,12 @@ export function aggregateResults<T>(results: CallbackResult<T>[]) {
   );
 }
 
-function sumMetaReducer(acc: Meta, [key, value]: [string, boolean | number]) {
-  function convertResultToNumber(result: number | boolean) {
-    if (result === false) return 0;
+function sumMetaReducer(
+  acc: Meta,
+  [key, value]: [string, MetaResult[keyof MetaResult]]
+) {
+  function convertResultToNumber(result: number | boolean | undefined) {
+    if (!result) return 0;
     if (result === true) return 1;
     return result;
   }

--- a/apps/backend/src/task-runner.ts
+++ b/apps/backend/src/task-runner.ts
@@ -109,7 +109,10 @@ export class TaskRunner {
     callback: (
       project: Project,
       index: number
-    ) => Promise<{ data: T; meta: { [key: string]: boolean | number } }>
+    ) => Promise<{
+      data: T;
+      meta: MetaResult;
+    }>
   ) {
     invariant(this.db, "DB connection is required");
     const results = await processProjects({
@@ -125,7 +128,7 @@ export class TaskRunner {
     });
     const filePath = path.join(process.cwd(), "build", fileName); // to be run from app/backend, not from the root!
     await fs.outputJson(filePath, json); // does not return anything
-    this.logger.info("JSON file saved!", { fileName, filePath });
+    this.logger.info("JSON file saved!", filePath);
   }
 }
 function stringifyOptions(runner: TaskRunner) {

--- a/apps/backend/src/task-runner.ts
+++ b/apps/backend/src/task-runner.ts
@@ -35,6 +35,7 @@ export type LoopOptions = {
   logLevel?: number;
   name?: string;
   throwOnError?: boolean;
+  throttleInterval?: number;
 };
 
 export class TaskRunner {
@@ -45,6 +46,7 @@ export class TaskRunner {
     concurrency: number;
     limit: number;
     skip: number;
+    throttleInterval: number;
     throwOnError?: boolean;
     // Optional query to filter items to process
     name?: string;
@@ -60,6 +62,7 @@ export class TaskRunner {
       skip: options.skip || 0,
       concurrency: options.concurrency || 1,
       name: options.name,
+      throttleInterval: options.throttleInterval || 0,
       throwOnError: options.throwOnError,
     };
   }
@@ -126,18 +129,19 @@ export class TaskRunner {
     this.logger.info(`Saving ${fileName}`, {
       size: prettyBytes(JSON.stringify(json).length),
     });
-    const filePath = path.join(process.cwd(), "build", fileName); // to be run from app/backend, not from the root!
-    await fs.outputJson(filePath, json); // does not return anything
+    const filePath = path.join(process.cwd(), "build", fileName); // to be run from app/backend because of monorepo setup on Vercel, not from the root!
+    await fs.outputJson(filePath, json);
     this.logger.info("JSON file saved!", filePath);
   }
 }
 function stringifyOptions(runner: TaskRunner) {
-  const { limit, skip, concurrency } = runner.options;
+  const { limit, skip, concurrency, throttleInterval } = runner.options;
   return [
     `logLevel: ${runner.logger.level}`,
     limit ? `limit: ${limit}` : "",
     skip ? `skip: ${skip}` : "",
     `concurrency: ${concurrency}`,
+    throttleInterval ? `throttleInterval: ${throttleInterval}` : "",
   ]
     .filter(Boolean)
     .join(", ");

--- a/apps/backend/src/task-runner.ts
+++ b/apps/backend/src/task-runner.ts
@@ -123,12 +123,7 @@ export class TaskRunner {
     this.logger.info(`Saving ${fileName}`, {
       size: prettyBytes(JSON.stringify(json).length),
     });
-    const filePath = path.join(
-      process.cwd(),
-      "apps/backend",
-      "build",
-      fileName
-    );
+    const filePath = path.join(process.cwd(), "build", fileName); // to be run from app/backend, not from the root!
     await fs.outputJson(filePath, json); // does not return anything
     this.logger.info("JSON file saved!", { fileName, filePath });
   }

--- a/apps/backend/src/tasks/build-static-api.task.ts
+++ b/apps/backend/src/tasks/build-static-api.task.ts
@@ -72,15 +72,15 @@ export const buildStaticApiTask: Task = {
       };
     });
 
-    await buildMainList(results.data);
-    await buildFullList(results.data);
+    const data = results.data.filter((item) => !!item);
+    await buildMainList(data);
+    await buildFullList(data);
     return results;
 
     async function buildMainList(allProjects: ProjectItem[]) {
       const allTags = await fetchTags();
 
       const projects = allProjects
-        .filter((item) => !!item) // remove null items that might be created if error occurred
         .filter((project) => project.trends.daily !== undefined) // new projects need to include at least the daily trend
         .filter(
           (project) => isPromotedProject(project) || !isColdProject(project)
@@ -101,10 +101,7 @@ export const buildStaticApiTask: Task = {
       await saveJSON({ date, tags, projects }, "projects.json");
     }
 
-    async function buildFullList(allProjects: ProjectItem[]) {
-      const projects = allProjects.filter((item) => !!item); // remove null items that might be created if error occurred
-      // .map(getFullProjectData);
-
+    async function buildFullList(projects: ProjectItem[]) {
       logger.info(`${projects.length} projects to include in the full list`);
       const date = new Date();
 

--- a/apps/backend/src/tasks/build-static-api.task.ts
+++ b/apps/backend/src/tasks/build-static-api.task.ts
@@ -130,10 +130,14 @@ export const buildStaticApiTask: Task = {
 
 function isColdProject(project: ProjectItem) {
   const delta = project.trends.yearly;
-  const monthlyDownloads = project.downloads;
   if (delta === undefined || delta === null) return false; // only consider projects with data covering 1 year
-  if (Boolean(monthlyDownloads) && monthlyDownloads > 100000) return false; // exclude projects with a lots of downloads (E.g. `Testem`)
+  if (!isPopularPackage(project)) return false; // exclude projects with a lots of downloads (E.g. `Testem`)
   return delta < 50;
+}
+
+function isPopularPackage(project: ProjectItem) {
+  if (!project.downloads) return false;
+  return project.downloads > 100000;
 }
 
 function isInactiveProject(project: ProjectItem) {

--- a/apps/backend/vercel.json
+++ b/apps/backend/vercel.json
@@ -13,8 +13,5 @@
         "value": "*"
       }
     }
-  ],
-  "git": {
-    "deploymentEnabled": false
-  }
+  ]
 }

--- a/packages/db/src/github/github-api-client.ts
+++ b/packages/db/src/github/github-api-client.ts
@@ -30,6 +30,10 @@ export function createClient(accessToken: string) {
   const fetchRepoInfoFallback = async (fullName: string) => {
     debug("Fetch repo info using the REST API", fullName);
     const repoInfo = await gitHubRequest(`repos/${fullName}`, accessToken);
+    debug(repoInfo);
+    if (repoInfo.status === 404) throw new Error(`Repo not found!`);
+
+    // TODO validate API response
     const { name, full_name, description, stargazers_count, owner } = repoInfo;
     return {
       name,

--- a/packages/db/src/projects/tags.ts
+++ b/packages/db/src/projects/tags.ts
@@ -1,6 +1,9 @@
 import { and, asc, eq, inArray } from "drizzle-orm";
 
-import { Tag } from "@/components/ui/tags/tag-input";
+type Tag = {
+  id: string;
+  name: string;
+};
 
 import { getDatabase } from "..";
 import * as schema from "../schema";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
       p-map:
         specifier: ^7.0.2
         version: 7.0.2
+      p-throttle:
+        specifier: ^6.1.0
+        version: 6.1.0
       pretty-bytes:
         specifier: ^6.1.1
         version: 6.1.1
@@ -6057,6 +6060,10 @@ packages:
 
   p-map@7.0.2:
     resolution: {integrity: sha512-z4cYYMMdKHzw4O5UkWJImbZynVIo0lSGTXc7bzB1e/rrDqkgGUNysK/o4bTr+0+xKvvLoTyGqYC4Fgljy9qe1Q==}
+    engines: {node: '>=18'}
+
+  p-throttle@6.1.0:
+    resolution: {integrity: sha512-eQMdGTxk2+047La67wefUtt0tEHh7D+C8Jl7QXoFCuIiNYeQ9zWs2AZiJdIAs72rSXZ06t11me2bgalRNdy3SQ==}
     engines: {node: '>=18'}
 
   p-try@1.0.0:
@@ -13878,6 +13885,8 @@ snapshots:
       p-limit: 3.1.0
 
   p-map@7.0.2: {}
+
+  p-throttle@6.1.0: {}
 
   p-try@1.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,9 @@ importers:
       tsx:
         specifier: ^4.16.2
         version: 4.16.2
+      typescript:
+        specifier: ^5.5.4
+        version: 5.5.4
 
   apps/bestofjs-nextjs:
     dependencies:
@@ -589,7 +592,7 @@ importers:
         version: 0.7.0
       '@t3-oss/env-nextjs':
         specifier: ^0.7.1
-        version: 0.7.1(typescript@5.2.2)(zod@3.23.8)
+        version: 0.7.1(typescript@5.5.4)(zod@3.23.8)
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12
@@ -7256,6 +7259,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@5.5.4:
+    resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typpy@2.3.13:
     resolution: {integrity: sha512-vOxIcQz9sxHi+rT09SJ5aDgVgrPppQjwnnayTrMye1ODaU8gIZTDM19t9TxmEElbMihx2Nq/0/b/MtyKfayRqA==}
 
@@ -10058,11 +10066,11 @@ snapshots:
     optionalDependencies:
       typescript: 5.2.2
 
-  '@t3-oss/env-core@0.7.1(typescript@5.2.2)(zod@3.23.8)':
+  '@t3-oss/env-core@0.7.1(typescript@5.5.4)(zod@3.23.8)':
     dependencies:
       zod: 3.23.8
     optionalDependencies:
-      typescript: 5.2.2
+      typescript: 5.5.4
 
   '@t3-oss/env-nextjs@0.7.1(typescript@5.2.2)(zod@3.22.4)':
     dependencies:
@@ -10071,12 +10079,12 @@ snapshots:
     optionalDependencies:
       typescript: 5.2.2
 
-  '@t3-oss/env-nextjs@0.7.1(typescript@5.2.2)(zod@3.23.8)':
+  '@t3-oss/env-nextjs@0.7.1(typescript@5.5.4)(zod@3.23.8)':
     dependencies:
-      '@t3-oss/env-core': 0.7.1(typescript@5.2.2)(zod@3.23.8)
+      '@t3-oss/env-core': 0.7.1(typescript@5.5.4)(zod@3.23.8)
       zod: 3.23.8
     optionalDependencies:
-      typescript: 5.2.2
+      typescript: 5.5.4
 
   '@tanstack/react-table@8.13.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
@@ -15161,6 +15169,8 @@ snapshots:
   typescript@4.9.5: {}
 
   typescript@5.2.2: {}
+
+  typescript@5.5.4: {}
 
   typpy@2.3.13:
     dependencies:


### PR DESCRIPTION
## Goal

- Fix TS errors in `backend` app
- Fix deploy of `build-static-api` on Vercel, allowing deploys when commits are pushed
- Add `throttleInterval` parameter to `update-github-data` to avoid hitting rate limit from GitHub API

From the GitHub API docs https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28, there is a limit of 5000 requests by hours (720 ms between requests)

The throttling is done with [p-throttle](https://github.com/sindresorhus/p-throttle) package.

## How to test

No errors when launching this command

```sh
p -F backend typecheck:watch  
```

To check the effect of concurrency, the following script, with an interval of 1 second, should take one minute

```
bun run apps/backend/src/cli.ts hello-world --limit 60  --concurrency 1 --throttle-interval 1000 
```

