### PR TITLE
Backend trigger static api build

### DIFF
--- a/.github/workflows/update-github-data.yml
+++ b/.github/workflows/update-github-data.yml
@@ -31,7 +31,11 @@ on:
         description: "Interval in milliseconds to wait between requests, to avoid rate limit errors"
         required: false
         type: number
-        default: 750
+env:
+  POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
+  # caution: `GITHUB_` is not a valid prefix for secrets!
+  GITHUB_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+  API_TRIGGER_BUILD_WEBHOOK_URL: ${{ secrets.API_TRIGGER_BUILD_WEBHOOK_URL }}
 jobs:
   update-github-data:
     runs-on: ubuntu-latest
@@ -50,11 +54,5 @@ jobs:
         run: pnpm -F backend install
       - name: Update GitHub Data and take snapshots
         run: pnpm -F backend daily-update-github-data --loglevel ${{ inputs.logLevel || 3 }} --limit ${{ inputs.limit || 0 }} --skip ${{ inputs.skip || 0 }} --concurrency ${{ inputs.concurrency || 5 }} --throttleInterval ${{ inputs.throttleInterval || 5 }}
-        env:
-          POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
-          # caution: `GITHUB_` is not a valid prefix for secrets!
-          GITHUB_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
       - name: Send Webhook to Vercel
         run: pnpm -F backend trigger-build-static-api
-        env:
-          API_TRIGGER_BUILD_WEBHOOK_URL: ${{ secrets.API_TRIGGER_BUILD_WEBHOOK_URL }}

--- a/.github/workflows/update-github-data.yml
+++ b/.github/workflows/update-github-data.yml
@@ -54,3 +54,7 @@ jobs:
           POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
           # caution: `GITHUB_` is not a valid prefix for secrets!
           GITHUB_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+      - name: Send Webhook to Vercel
+        run: pnpm -F backend trigger-build-static-api
+        env:
+          API_TRIGGER_BUILD_WEBHOOK_URL: ${{ secrets.API_TRIGGER_BUILD_WEBHOOK_URL }}

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "daily-update-github-data": "dotenv -e ../../.env tsx ./src/cli.ts update-github-data -- --logLevel 3",
-    "build-static-api": "dotenv -e ../../.env tsx ./src/cli.ts build-static-api -- --logLevel 3 --concurrency 10",
+    "trigger-build-static-api": "dotenv -e ../../.env tsx ./src/cli.ts trigger-build-static-api",
     "typecheck": "tsc --noEmit",
     "typecheck:watch": "tsc --noEmit --incremental --watch"
   },

--- a/apps/backend/src/cli.ts
+++ b/apps/backend/src/cli.ts
@@ -1,114 +1,42 @@
 import { cli, command } from "cleye";
 
-import { TaskRunner } from "./task-runner";
-import { helloProjectsTask, helloWorldTask } from "./tasks/hello-world.task";
+import { Task, TaskRunner } from "./task-runner";
+import {
+  helloWorldProjectsTask,
+  helloWorldReposTask,
+} from "./tasks/hello-world.task";
 import { updateGitHubDataTask } from "./tasks/update-github-data.task";
 import { buildStaticApiTask } from "./tasks/build-static-api.task";
 import { triggerBuildStaticApiTask } from "./tasks/trigger-build-static-api";
 
-const flags = {
-  concurrency: {
-    type: Number,
-    default: 1,
-  },
-  logLevel: {
-    type: Number,
-    description:
-      "Log level: 0 => error, 1 => warn, 2 => log, 3 => info, 4 => debug...",
-    default: 3,
-  },
-  limit: {
-    type: Number,
-    description: "Records to process",
-    default: 0,
-  },
-  skip: {
-    type: Number,
-    description: "Records to skip (when paginating)",
-    default: 0,
-  },
-  name: {
-    type: String,
-    description: "Full name of the GitHub repo to process",
-  },
-  throttleInterval: {
-    type: Number,
-    description: "Throttle interval in milliseconds",
-  },
-};
+import { cliFlags as flags } from "./flags";
+
+const commands = [
+  updateGitHubDataTask,
+  triggerBuildStaticApiTask,
+  buildStaticApiTask,
+  helloWorldProjectsTask,
+  helloWorldReposTask,
+].map(getCommand);
 
 cli({
   name: "bestofjs-cli",
-  commands: [
-    command(
-      {
-        name: "hello-world",
-        help: {
-          description: "A simple hello world task",
-        },
-        flags,
-      },
-      (argv) => {
-        const runner = new TaskRunner(argv.flags);
-        runner.addTask(helloWorldTask);
-        runner.run();
-      }
-    ),
-    command(
-      {
-        name: helloProjectsTask.name,
-        help: {
-          description: "A simple hello world task",
-        },
-        flags,
-      },
-      (argv) => {
-        const runner = new TaskRunner(argv.flags);
-        runner.addTask(helloProjectsTask);
-        runner.run();
-      }
-    ),
-    command(
-      {
-        name: updateGitHubDataTask.name,
-        flags,
-        help: {
-          description:
-            "Update GitHub data for all repos and take a snapshot. To be run run every day",
-        },
-      },
-      (argv) => {
-        const runner = new TaskRunner(argv.flags);
-        runner.addTask(updateGitHubDataTask);
-        runner.run();
-      }
-    ),
-    command(
-      {
-        name: buildStaticApiTask.name,
-        flags,
-        help: {
-          description:
-            "Build a static API from the database, to be used by the frontend app.",
-        },
-      },
-      (argv) => {
-        const runner = new TaskRunner(argv.flags);
-        runner.addTask(buildStaticApiTask);
-        runner.run();
-      }
-    ),
-
-    command(
-      {
-        name: triggerBuildStaticApiTask.name,
-        flags,
-      },
-      (argv) => {
-        const runner = new TaskRunner(argv.flags);
-        runner.addTask(triggerBuildStaticApiTask);
-        runner.run();
-      }
-    ),
-  ],
+  commands,
 });
+
+function getCommand(task: Task) {
+  return command(
+    {
+      name: task.name,
+      flags,
+      help: {
+        description: task.description,
+      },
+    },
+    (argv) => {
+      const runner = new TaskRunner(argv.flags);
+      runner.addTask(task);
+      runner.run();
+    }
+  );
+}

--- a/apps/backend/src/cli.ts
+++ b/apps/backend/src/cli.ts
@@ -4,7 +4,7 @@ import { TaskRunner } from "./task-runner";
 import { helloProjectsTask, helloWorldTask } from "./tasks/hello-world.task";
 import { updateGitHubDataTask } from "./tasks/update-github-data.task";
 import { buildStaticApiTask } from "./tasks/build-static-api.task";
-import { desc } from "drizzle-orm";
+import { triggerBuildStaticApiTask } from "./tasks/trigger-build-static-api";
 
 const flags = {
   concurrency: {
@@ -95,6 +95,18 @@ cli({
       (argv) => {
         const runner = new TaskRunner(argv.flags);
         runner.addTask(buildStaticApiTask);
+        runner.run();
+      }
+    ),
+
+    command(
+      {
+        name: triggerBuildStaticApiTask.name,
+        flags,
+      },
+      (argv) => {
+        const runner = new TaskRunner(argv.flags);
+        runner.addTask(triggerBuildStaticApiTask);
         runner.run();
       }
     ),

--- a/apps/backend/src/flags.ts
+++ b/apps/backend/src/flags.ts
@@ -1,0 +1,30 @@
+export const cliFlags = {
+  concurrency: {
+    type: Number,
+    default: 1,
+  },
+  logLevel: {
+    type: Number,
+    description:
+      "Log level: 0 => error, 1 => warn, 2 => log, 3 => info, 4 => debug...",
+    default: 3,
+  },
+  limit: {
+    type: Number,
+    description: "Records to process",
+    default: 0,
+  },
+  skip: {
+    type: Number,
+    description: "Records to skip (when paginating)",
+    default: 0,
+  },
+  name: {
+    type: String,
+    description: "Full name of the GitHub repo to process",
+  },
+  throttleInterval: {
+    type: Number,
+    description: "Throttle interval in milliseconds",
+  },
+};

--- a/apps/backend/src/task-runner.ts
+++ b/apps/backend/src/task-runner.ts
@@ -22,6 +22,7 @@ export interface TaskContext extends RunnerContext {
 
 export type Task = {
   name: string;
+  description?: string;
   run: (ctx: TaskContext) => Promise<{
     data: unknown;
     meta: MetaResult;

--- a/apps/backend/src/tasks/build-static-api.task.ts
+++ b/apps/backend/src/tasks/build-static-api.task.ts
@@ -33,6 +33,8 @@ type ProjectItem = {
 
 export const buildStaticApiTask: Task = {
   name: "build-static-api",
+  description:
+    "Build a static API from the database, to be used by the frontend app.",
   run: async ({ db, logger, processProjects, saveJSON }) => {
     const results = await processProjects(async (project) => {
       const repo = project.repo;

--- a/apps/backend/src/tasks/hello-world.task.ts
+++ b/apps/backend/src/tasks/hello-world.task.ts
@@ -1,7 +1,8 @@
 import { Task } from "@/task-runner";
 
-export const helloWorldTask: Task = {
-  name: "hello-world",
+export const helloWorldReposTask: Task = {
+  name: "hello-world-repos",
+  description: "A simple `hello world` task to, looping through all repos",
   run: async ({ processRepos }) => {
     return await processRepos(async (repo, i) => {
       const isDeprecated = repo.projects.every(
@@ -15,8 +16,9 @@ export const helloWorldTask: Task = {
   },
 };
 
-export const helloProjectsTask: Task = {
-  name: "hello-projects",
+export const helloWorldProjectsTask: Task = {
+  name: "hello-world-projects",
+  description: "A simple `hello world` task, looping through all projects",
   run: async ({ processProjects }) => {
     return await processProjects(async (project) => {
       const isDeprecated = project.status === "deprecated";

--- a/apps/backend/src/tasks/trigger-build-static-api.ts
+++ b/apps/backend/src/tasks/trigger-build-static-api.ts
@@ -1,0 +1,18 @@
+import { Task } from "@/task-runner";
+
+export const triggerBuildStaticApiTask: Task = {
+  name: "trigger-build-static-api",
+  run: async ({ logger }) => {
+    const url = process.env.API_TRIGGER_BUILD_WEBHOOK_URL;
+    if (!url) {
+      throw new Error("API_TRIGGER_BUILD_WEBHOOK_URL is not set");
+    }
+    logger.log(`Triggering build for static API, sending webhook to Vercel...`);
+    const result = await fetch(url, { method: "POST" }).then((res) =>
+      res.json()
+    );
+    logger.log(`Build triggered!`, result);
+
+    return { data: null, meta: { sent: true } };
+  },
+};

--- a/apps/backend/src/tasks/trigger-build-static-api.ts
+++ b/apps/backend/src/tasks/trigger-build-static-api.ts
@@ -2,6 +2,8 @@ import { Task } from "@/task-runner";
 
 export const triggerBuildStaticApiTask: Task = {
   name: "trigger-build-static-api",
+  description:
+    "Trigger a build for the static API, sending a webhook to Vercel",
   run: async ({ logger }) => {
     const url = process.env.API_TRIGGER_BUILD_WEBHOOK_URL;
     if (!url) {

--- a/apps/backend/src/tasks/update-github-data.task.ts
+++ b/apps/backend/src/tasks/update-github-data.task.ts
@@ -8,6 +8,8 @@ import { Repo } from "@/iteration-helpers/process-repos";
 
 export const updateGitHubDataTask: Task = {
   name: "update-github-data",
+  description:
+    "Update GitHub data for all repos and take a snapshot. To be run run every day",
   run: async ({ db, processRepos, logger }) => {
     const accessToken = process.env.GITHUB_ACCESS_TOKEN;
     if (!accessToken) throw new Error("GITHUB_ACCESS_TOKEN is required!");


### PR DESCRIPTION
## Goal

We need to orchestrate the flow between the 2 daily tasks:

- step 1: `update-github-data` runs on GitHub actions
- step 2: `build-static-api` runs on Vercel 

The solution is to send a webhook from GitHub action, after `update-github-data` script completed, to trigger the build on Vercel.

This PR introduces a new task called `trigger-build-static-api` that pings the webhook URL setup in Vercel.

Other changes:

- refactor the CLI tasks to avoid too much boilerplate
- share env variables between all steps in the GitHub action pipeline

## How to test

To send the webhook:

```
bun run apps/backend/src/cli.ts trigger-build-static-api 
```

## TODOs

- Do not trigger the webhook if the `update-github-data` script fails (trigger an exit code different than 0 under some conditions to define)
- Instead of a separate step, we could use a single step made of 2 tasks (to avoid closing and opening a new DB connection for nothing)

