### PR TITLE
Migration backend / add `update-package-task`

### DIFF
--- a/.github/workflows/update-package-data.yml
+++ b/.github/workflows/update-package-data.yml
@@ -1,0 +1,54 @@
+name: Update Package Data
+on:
+  schedule:
+    - cron: "00 1 * * *"
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: "Log level: 3 => info, 4 => debug"
+        required: true
+        default: 3
+        type: choice
+        options:
+          - 3
+          - 4
+      limit:
+        description: "Number of projects to process (mainly for debugging, keep the default value of 0 to process everything)"
+        required: false
+        type: number
+        default: 0
+      skip:
+        description: "Number of projects to skip (when paginating)"
+        required: false
+        type: number
+        default: 0
+      concurrency:
+        description: "Number of projects to process concurrently"
+        required: false
+        type: number
+        default: 1
+      throttleInterval:
+        description: "Interval in milliseconds to wait between requests, to avoid rate limit errors"
+        required: false
+        type: number
+        default: 750
+env:
+  POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
+jobs:
+  update-package-data:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install PNPM
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.4.0
+      - name: Install Dependencies
+        shell: bash
+        run: pnpm -F backend install
+      - name: Update GitHub Data and take snapshots
+        run: pnpm -F backend daily-update-package-data --loglevel ${{ inputs.logLevel || 3 }} --limit ${{ inputs.limit || 0 }} --skip ${{ inputs.skip || 0 }} --concurrency ${{ inputs.concurrency || 5 }} --throttleInterval ${{ inputs.throttleInterval || 750 }}

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "daily-update-github-data": "dotenv -e ../../.env tsx ./src/cli.ts update-github-data -- --logLevel 3",
     "trigger-build-static-api": "dotenv -e ../../.env tsx ./src/cli.ts trigger-build-static-api",
+    "build-static-api": "dotenv -e ../../.env tsx ./src/cli.ts build-static-api -- --logLevel 3 --concurrency 20",
     "typecheck": "tsc --noEmit",
     "typecheck:watch": "tsc --noEmit --incremental --watch"
   },

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -24,10 +24,12 @@
     "fs-extra": "^11.1.1",
     "p-map": "^7.0.2",
     "p-throttle": "^6.1.0",
+    "package-json": "^6.4.0",
     "pretty-bytes": "^6.1.1",
     "tasuku": "^2.0.1",
     "tiny-invariant": "^1.3.1",
     "tsx": "^4.16.2",
-    "typescript": "^5.5.4"
+    "typescript": "^5.5.4",
+    "zod": "^3.22.4"
   }
 }

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -8,6 +8,7 @@
     "daily-update-github-data": "dotenv -e ../../.env tsx ./src/cli.ts update-github-data -- --logLevel 3",
     "trigger-build-static-api": "dotenv -e ../../.env tsx ./src/cli.ts trigger-build-static-api",
     "build-static-api": "dotenv -e ../../.env tsx ./src/cli.ts build-static-api -- --logLevel 3 --concurrency 20",
+    "daily-update-package-data": "dotenv -e ../../.env tsx ./src/cli.ts update-package-data -- --logLevel 3 --concurrency 5",
     "typecheck": "tsc --noEmit",
     "typecheck:watch": "tsc --noEmit --incremental --watch"
   },

--- a/apps/backend/src/apis/npm-api-client.ts
+++ b/apps/backend/src/apis/npm-api-client.ts
@@ -7,9 +7,9 @@ const monthlyDownloadsSchema = z.object({
 
 const packageJsonSchema = z.object({
   version: z.string(),
-  dependencies: z.record(z.string()),
-  devDependencies: z.record(z.string()),
-  deprecated: z.boolean(),
+  dependencies: z.record(z.string()).optional(),
+  devDependencies: z.record(z.string()).optional(),
+  deprecated: z.boolean().optional(),
 });
 
 export function createNpmClient() {

--- a/apps/backend/src/apis/npm-api-client.ts
+++ b/apps/backend/src/apis/npm-api-client.ts
@@ -1,0 +1,34 @@
+import packageJson from "package-json";
+import { z } from "zod";
+
+const monthlyDownloadsSchema = z.object({
+  downloads: z.number(),
+});
+
+const packageJsonSchema = z.object({
+  version: z.string(),
+  dependencies: z.record(z.string()),
+  devDependencies: z.record(z.string()),
+  deprecated: z.boolean(),
+});
+
+export function createNpmClient() {
+  return {
+    async fetchPackageInfo(packageName: string) {
+      const data = await packageJson(packageName).catch((err) => {
+        throw new Error(`Invalid response from npm registry "${packageName}"`, {
+          cause: err,
+        });
+      });
+      const parsedData = packageJsonSchema.parse(data);
+      return parsedData;
+    },
+
+    async fetchMonthlyDownloadCount(packageName: string) {
+      const url = `https://api.npmjs.org/downloads/point/last-month/${packageName}`;
+      const data = await fetch(url).then((res) => res.json());
+      const parsedData = monthlyDownloadsSchema.parse(data);
+      return parsedData.downloads;
+    },
+  };
+}

--- a/apps/backend/src/cli.ts
+++ b/apps/backend/src/cli.ts
@@ -8,6 +8,7 @@ import {
 import { updateGitHubDataTask } from "./tasks/update-github-data.task";
 import { buildStaticApiTask } from "./tasks/build-static-api.task";
 import { triggerBuildStaticApiTask } from "./tasks/trigger-build-static-api";
+import { updatePackageDataTask } from "./tasks/update-package-data.task";
 
 import { cliFlags as flags } from "./flags";
 
@@ -17,6 +18,7 @@ const commands = [
   buildStaticApiTask,
   helloWorldProjectsTask,
   helloWorldReposTask,
+  updatePackageDataTask,
 ].map(getCommand);
 
 cli({

--- a/apps/backend/src/iteration-helpers/process-projects.ts
+++ b/apps/backend/src/iteration-helpers/process-projects.ts
@@ -32,6 +32,7 @@ export function processProjects(context: RunnerContext) {
           return result;
         } catch (error) {
           logger.error(`Error processing repo ${project.slug}`, error);
+          if (error instanceof Error && error.cause) logger.debug(error.cause);
           if (throwOnError)
             throw new Error(`Error processing repo ${project.slug}`, {
               cause: error,

--- a/apps/backend/src/tasks/build-static-api.task.ts
+++ b/apps/backend/src/tasks/build-static-api.task.ts
@@ -41,7 +41,7 @@ export const buildStaticApiTask: Task = {
 
       if (!repo) throw new Error("No repo found");
       if (!repo.snapshots?.length)
-        return { data: null, meta: { "no snapshot": true, included: false } };
+        return { data: null, meta: { "no snapshot": true } };
 
       const trends = getProjectTrends(repo.snapshots);
       const tags = project.projectsToTags.map((ptt) => ptt.tag.code);

--- a/apps/backend/src/tasks/update-package-data.task.ts
+++ b/apps/backend/src/tasks/update-package-data.task.ts
@@ -35,7 +35,7 @@ export const updatePackageDataTask: Task = {
       logger.trace(`Fetched package data for ${packageName}`, data);
 
       if (data.version === previousVersion) {
-        logger.debug(`No new version for ${packageName}`);
+        logger.debug(`No new version for ${packageName} (${previousVersion})`);
         return false;
       }
 

--- a/apps/backend/src/tasks/update-package-data.task.ts
+++ b/apps/backend/src/tasks/update-package-data.task.ts
@@ -1,0 +1,68 @@
+import { createNpmClient } from "@/apis/npm-api-client";
+import { Task } from "@/task-runner";
+import { schema } from "@repo/db";
+import { ProjectDetails } from "@repo/db/projects";
+import { eq } from "drizzle-orm";
+
+const npmClient = createNpmClient();
+
+export const updatePackageDataTask: Task = {
+  name: "update-package-data",
+  description: "Update package data from NPM",
+  run: async ({ db, logger, processProjects }) => {
+    const results = await processProjects(async (project) => {
+      let updatedCount = 0;
+
+      for (const packageData of project.packages) {
+        const updated = await processPackage(packageData);
+        if (updated) updatedCount++;
+      }
+
+      return {
+        data: null,
+        meta: { processed: project.packages.length, updated: updatedCount },
+      };
+    });
+
+    return results;
+
+    async function processPackage(
+      packageData: ProjectDetails["packages"][number]
+    ) {
+      const packageName = packageData.name;
+      const previousVersion = packageData.version;
+      const data = await npmClient.fetchPackageInfo(packageName);
+      logger.trace(`Fetched package data for ${packageName}`, data);
+
+      if (data.version === previousVersion) {
+        logger.debug(`No new version for ${packageName}`);
+        return false;
+      }
+
+      const monthlyDownloads = await npmClient.fetchMonthlyDownloadCount(
+        packageName
+      );
+
+      const updatedData = {
+        version: data.version,
+        dependencies: formatDependencies(data.dependencies),
+        deprecated: !!data.deprecated,
+        monthlyDownloads,
+        devDependencies: formatDependencies(data.devDependencies),
+        updatedAt: new Date(),
+      };
+
+      await db
+        .update(schema.packages)
+        .set(updatedData)
+        .where(eq(schema.packages.name, packageName));
+
+      logger.debug("Repo record updated", updatedData);
+      return true;
+    }
+  },
+};
+
+function formatDependencies(dependencies?: { [key: string]: string }) {
+  return dependencies ? Object.keys(dependencies) : [];
+}

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -11,7 +11,11 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["src/*"]
+    }
   },
   "include": ["**/*.ts"],
   "exclude": ["node_modules"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,6 +195,9 @@ importers:
       p-throttle:
         specifier: ^6.1.0
         version: 6.1.0
+      package-json:
+        specifier: ^6.4.0
+        version: 6.5.0
       pretty-bytes:
         specifier: ^6.1.1
         version: 6.1.1
@@ -210,6 +213,9 @@ importers:
       typescript:
         specifier: ^5.5.4
         version: 5.5.4
+      zod:
+        specifier: ^3.22.4
+        version: 3.23.8
 
   apps/bestofjs-nextjs:
     dependencies:
@@ -6724,6 +6730,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.6.3:
+    resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   serve-handler@6.1.5:
     resolution: {integrity: sha512-ijPFle6Hwe8zfmBxJdE+5fta53fdIY0lHISJvuikXB3VYFafRjMRpOffSPvCYsbKyBA7pvy9oYr/BT1O3EArlg==}
 
@@ -10232,7 +10243,7 @@ snapshots:
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 20.11.10
 
   '@types/lodash.mergewith@4.6.6':
     dependencies:
@@ -10295,7 +10306,7 @@ snapshots:
 
   '@types/responselike@1.0.0':
     dependencies:
-      '@types/node': 14.18.54
+      '@types/node': 20.11.10
 
   '@types/scheduler@0.16.3': {}
 
@@ -13196,7 +13207,7 @@ snapshots:
       jest-util: 27.5.1
       natural-compare: 1.4.0
       pretty-format: 27.5.1
-      semver: 7.5.4
+      semver: 7.6.3
     transitivePeerDependencies:
       - supports-color
 
@@ -13479,7 +13490,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.5.4
+      semver: 7.6.3
 
   makeerror@1.0.12:
     dependencies:
@@ -13697,7 +13708,7 @@ snapshots:
 
   node-abi@3.45.0:
     dependencies:
-      semver: 7.5.4
+      semver: 7.6.3
 
   node-addon-api@6.1.0: {}
 
@@ -14613,6 +14624,8 @@ snapshots:
     dependencies:
       lru-cache: 6.0.0
 
+  semver@7.6.3: {}
+
   serve-handler@6.1.5:
     dependencies:
       bytes: 3.0.0
@@ -15464,7 +15477,7 @@ snapshots:
   vscode-languageclient@7.0.0:
     dependencies:
       minimatch: 3.1.2
-      semver: 7.5.4
+      semver: 7.6.3
       vscode-languageserver-protocol: 3.16.0
 
   vscode-languageserver-protocol@3.16.0:


### PR DESCRIPTION
## Goal

Add the task to update package data (`packages` table in the new database)
For each package, we store the following data:

- version number
- dependencies
- deprecated
- monthly downloads

To be run everyday.

## How to test

To run the script locally on a limited amount of projects

```sh
bun run apps/backend/src/cli.ts update-package-data  --limit 10
```

![image](https://github.com/user-attachments/assets/5c5a105c-35bb-44b7-95f7-41a02a839f6f)
