### PR TITLE
Fix(external-link): add / to github project link

### DIFF
--- a/apps/bestofjs-nextjs/src/app/projects/[slug]/project-details-github/github-card.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/[slug]/project-details-github/github-card.tsx
@@ -63,7 +63,7 @@ const GitHubData = ({ project }: { project: ProjectDetails }) => {
   const {
     repo: { commit_count, contributor_count, created_at, full_name, pushed_at },
   } = project;
-  const url = `https://github.com${full_name}`;
+  const url = `https://github.com/${full_name}`;
 
   return (
     <div className="grid grid-cols-2 gap-4">


### PR DESCRIPTION
## Goal
- The goal of this PR is to add a forward slash (/) to the end of the GitHub project link in the README file.
## How to test
- Check out the branch with this PR.
- Start nextjs app
- Navigate to 'projects page'. e.v `/projects/nodejs`
- Click on github repository external link 

## Screenshots

![Screenshot 2024-08-12 at 15 57 31](https://github.com/user-attachments/assets/69c62b6d-0a27-4385-8685-583c6e18e97d)
