### PR TITLE
Backend: Trigger Next.js rebuild after static API is generated

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "daily-update-github-data": "dotenv -e ../../.env tsx ./src/cli.ts update-github-data -- --logLevel 3",
     "trigger-build-static-api": "dotenv -e ../../.env tsx ./src/cli.ts trigger-build-static-api",
-    "build-static-api": "dotenv -e ../../.env tsx ./src/cli.ts build-static-api -- --logLevel 3 --concurrency 20",
+    "static-api-daily": "dotenv -e ../../.env tsx ./src/cli.ts static-api-daily -- --logLevel 3 --concurrency 20",
     "daily-update-package-data": "dotenv -e ../../.env tsx ./src/cli.ts update-package-data -- --logLevel 3 --concurrency 5",
     "typecheck": "tsc --noEmit",
     "typecheck:watch": "tsc --noEmit --incremental --watch"
@@ -20,6 +20,7 @@
     "@types/fs-extra": "^11.0.1",
     "cleye": "^1.3.2",
     "consola": "^3.2.3",
+    "debug": "^4.3.4",
     "dotenv-cli": "^7.4.2",
     "drizzle-orm": "^0.31.2",
     "fs-extra": "^11.1.1",
@@ -32,5 +33,8 @@
     "tsx": "^4.16.2",
     "typescript": "^5.5.4",
     "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@types/debug": "^4.1.12"
   }
 }

--- a/apps/backend/src/cli.ts
+++ b/apps/backend/src/cli.ts
@@ -11,19 +11,39 @@ import { triggerBuildStaticApiTask } from "./tasks/trigger-build-static-api";
 import { updatePackageDataTask } from "./tasks/update-package-data.task";
 
 import { cliFlags as flags } from "./flags";
+import { notifyDailyTask } from "./tasks/notify-daily.task";
+import { triggerBuildWebappTask } from "./tasks/trigger-build-webapp.task";
 
 const commands = [
+  notifyDailyTask,
   updateGitHubDataTask,
   triggerBuildStaticApiTask,
+  triggerBuildWebappTask,
   buildStaticApiTask,
   helloWorldProjectsTask,
   helloWorldReposTask,
   updatePackageDataTask,
 ].map(getCommand);
 
+const staticApiDailyTask = command(
+  {
+    name: "static-api-daily",
+    description:
+      "Build command on Vercel: build static API, trigger Next.js rebuild and send notification",
+    flags,
+  },
+  (argv) => {
+    const runner = new TaskRunner(argv.flags);
+    runner.addTask(buildStaticApiTask);
+    runner.addTask(triggerBuildWebappTask);
+    runner.addTask(notifyDailyTask);
+    runner.run();
+  }
+);
+
 cli({
   name: "bestofjs-cli",
-  commands,
+  commands: [staticApiDailyTask, ...commands],
 });
 
 function getCommand(task: Task) {

--- a/apps/backend/src/flags.ts
+++ b/apps/backend/src/flags.ts
@@ -3,6 +3,11 @@ export const cliFlags = {
     type: Number,
     default: 1,
   },
+  dryRun: {
+    type: Boolean,
+    description: "Dry run mode",
+    default: false,
+  },
   logLevel: {
     type: Number,
     description:

--- a/apps/backend/src/tasks/build-static-api.task.ts
+++ b/apps/backend/src/tasks/build-static-api.task.ts
@@ -6,35 +6,13 @@ import {
   getProjectURL,
 } from "@repo/db/projects";
 import { schema } from "@repo/db";
-
-type ProjectItem = {
-  name: string;
-  added_at: string;
-  description: string;
-  url?: string;
-  stars: number;
-  full_name: string;
-  owner_id: string;
-  created_at: string;
-  pushed_at: string;
-  contributor_count: number | null;
-  status: string;
-  tags: string[];
-  trends: {
-    daily?: number;
-    weekly?: number | null;
-    monthly?: number | null;
-    yearly?: number | null;
-  };
-  npm?: string;
-  downloads?: number;
-  icon?: string;
-};
+import { ProjectItem } from "./static-api-types";
 
 export const buildStaticApiTask: Task = {
   name: "build-static-api",
   description:
     "Build a static API from the database, to be used by the frontend app.",
+
   run: async ({ db, logger, processProjects, saveJSON }) => {
     const results = await processProjects(async (project) => {
       const repo = project.repo;
@@ -53,7 +31,7 @@ export const buildStaticApiTask: Task = {
       const data: ProjectItem = {
         name: project.name,
         added_at: formatDate(project.createdAt),
-        description: getProjectDescription(project),
+        description: truncate(getProjectDescription(project), 75),
         stars: repo.stars || 0,
         full_name: project.repo.full_name,
         owner_id: repo.owner_id,
@@ -161,4 +139,9 @@ const findProjectByTagId = (projects: ProjectItem[]) => (tagId: string) =>
 
 function formatDate(date: Date | null) {
   return date ? date.toISOString().slice(0, 10) : "";
+}
+
+function truncate(input: string, maxLength = 50) {
+  const isTruncated = input.length > maxLength;
+  return isTruncated ? `${input.slice(0, maxLength)}...` : input;
 }

--- a/apps/backend/src/tasks/notify-daily.task.ts
+++ b/apps/backend/src/tasks/notify-daily.task.ts
@@ -1,0 +1,230 @@
+import { Task } from "@/task-runner";
+import { ProjectItem } from "./static-api-types";
+
+import fs from "fs-extra";
+import path from "path";
+import debugPackage from "debug";
+const debug = debugPackage("notify");
+
+export const notifyDailyTask: Task = {
+  name: "notify-daily",
+  description:
+    "Send notification on Slack and Discord after static API is built",
+
+  run: async ({ dryRun, logger }) => {
+    const slackURL = process.env.SLACK_DAILY_WEBHOOK;
+    if (!slackURL) throw new Error('No "SLACK_WEBHOOK" env. variable defined');
+    const discordURL = process.env.DISCORD_DAILY_WEBHOOK;
+    if (!discordURL)
+      throw new Error('No "DISCORD_WEBHOOK" env. variable defined');
+
+    const projects = await fetchHottestProjects();
+
+    logger.debug("Send the daily notifications...");
+
+    if (await notifySlack({ projects, url: slackURL, dryRun })) {
+      logger.info("Notification sent to Slack");
+    }
+
+    if (await notifyDiscord({ projects, url: discordURL, dryRun })) {
+      logger.info("Notification sent to Discord");
+    }
+    return { data: null, meta: { sent: true } };
+  },
+};
+
+async function fetchHottestProjects() {
+  const projects = await fetchProjectsFromJSON();
+
+  const score = (project: ProjectItem) => project.trends?.daily || 0;
+
+  const topProjects = projects
+    .filter(isIncludedInHotProjects)
+    .sort((a, b) => (score(a) > score(b) ? -1 : 1))
+    .slice(0, 5);
+  return topProjects;
+}
+
+const isIncludedInHotProjects = (project: ProjectItem) => {
+  const hotProjectsExcludedTags = ["meta", "learning"];
+
+  const hasExcludedTag = hotProjectsExcludedTags.some((tag) =>
+    project.tags.includes(tag)
+  );
+  return !hasExcludedTag;
+};
+
+async function fetchProjectsFromJSON() {
+  const filePath = path.join(process.cwd(), "build", "projects.json");
+  const data = await fs.readJson(filePath);
+  return data.projects as ProjectItem[];
+}
+
+async function notifySlack({
+  projects,
+  url,
+  dryRun,
+}: {
+  projects: ProjectItem[];
+  url: string;
+  dryRun: boolean;
+}) {
+  const text = `TOP 5 Hottest Projects Today (${formatTodayDate()})`;
+
+  const attachments = projects.map((project, i) => {
+    const stars = project.trends.daily;
+    const text = `Number ${i + 1} +${stars} stars since yesterday:`;
+    return projectToSlackAttachment(project, text);
+  });
+
+  if (dryRun) {
+    console.info("[DRY RUN] No message sent to Slack", { text, attachments }); //eslint-disable-line no-console
+    return;
+  }
+
+  await sendMessageToSlack(text, { url, channel: "", attachments });
+  return true;
+}
+
+async function notifyDiscord({
+  projects,
+  url,
+  dryRun,
+}: {
+  projects: ProjectItem[];
+  url: string;
+  dryRun: boolean;
+}) {
+  const text = `TOP 5 Hottest Projects Today (${formatTodayDate()})`;
+  const colors = ["9c0042", "d63c4a", "f76d42", "ffae63", "ffe38c"]; // hex colors without the `#`
+
+  const embeds = projects.map((project, index) => {
+    const stars = project.trends.daily;
+    const text = `+${stars} stars since yesterday [number ${index + 1}]`;
+    const color = colors[index];
+    return projectToDiscordEmbed(project, text, color);
+  });
+
+  if (dryRun) {
+    console.info("[DRY RUN] No message sent to Discord", { text, embeds }); //eslint-disable-line no-console
+    return;
+  }
+
+  await sendMessageToDiscord(text, { url, embeds });
+  return true;
+}
+
+// Convert a `project` object (from bestofjs API)
+// into an "attachment" included in the Slack message
+// See: https://api.slack.com/docs/message-attachments
+function projectToSlackAttachment(project: ProjectItem, pretext: string) {
+  const url = project.url || `https://github.com/${project.full_name}`;
+  const owner = project.full_name.split("/")[0];
+  const author_name = owner;
+  // `thumb_url` does not accept .svg files so we don't use project `logo` property
+  const thumb_url = `https://avatars.githubusercontent.com/u/${project.owner_id}?v=3&s=75`;
+  const attachment = {
+    color: "#e65100",
+    pretext,
+    author_name,
+    author_link: `https://github.com/${owner}`,
+    title: project.name,
+    title_link: url,
+    text: project.description,
+    thumb_url,
+  };
+  return attachment;
+}
+
+function projectToDiscordEmbed(
+  project: ProjectItem,
+  text: string,
+  color: string
+) {
+  const url = project.url || `https://github.com/${project.full_name}`;
+  const thumbnailSize = 50;
+  return {
+    type: "article",
+    title: project.name,
+    url,
+    description: project.description,
+    thumbnail: {
+      url: `https://avatars.githubusercontent.com/u/${project.owner_id}?v=3&s=${thumbnailSize}`,
+      width: thumbnailSize,
+      height: thumbnailSize,
+    },
+    color: parseInt(color, 16), // has to be a decimal number
+    footer: { text }, // a header would be better to introduce the project
+  };
+}
+
+// Send a message to a Slack channel
+async function sendMessageToSlack(
+  text: string,
+  {
+    url,
+    channel,
+    attachments,
+  }: { url: string; channel?: string; attachments: any }
+) {
+  const body = {
+    text,
+    mrkdwn: true,
+    attachments,
+  };
+  if (channel) {
+    // TODO add correct types
+    (body as any).channel = `#${channel}`; // Override the default webhook channel, if specified (for tests)
+  }
+
+  debug("Request", body);
+  try {
+    const result = await fetch(url, {
+      method: "POST",
+      body: JSON.stringify(body),
+      headers: { "content-type": "application/json" },
+    }).then((res) => res.text());
+
+    debug("Response", result);
+    return true;
+  } catch (error) {
+    throw new Error(`Invalid response from Slack ${(error as Error).message}`);
+  }
+}
+
+async function sendMessageToDiscord(
+  text: string,
+  { url, embeds }: { url: string; embeds: any }
+) {
+  const body = {
+    content: text,
+    embeds,
+  };
+  try {
+    debug(`Sending webhook to ${url}`, body);
+    const result = fetch(url, {
+      method: "POST",
+      body: JSON.stringify(body),
+      headers: { "content-type": "application/json" },
+    }).then((res) => res.text());
+
+    debug("Response", result || "(No response)");
+    return true;
+  } catch (error) {
+    throw new Error(
+      `Invalid response from Discord ${(error as Error).message}`
+    );
+  }
+}
+
+/**
+ * @returns format a date as "Tuesday, May 14"
+ */
+function formatTodayDate() {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+  });
+  return formatter.format(new Date());
+}

--- a/apps/backend/src/tasks/static-api-types.ts
+++ b/apps/backend/src/tasks/static-api-types.ts
@@ -1,0 +1,23 @@
+export type ProjectItem = {
+  name: string;
+  added_at: string;
+  description: string;
+  url?: string;
+  stars: number;
+  full_name: string;
+  owner_id: string;
+  created_at: string;
+  pushed_at: string;
+  contributor_count: number | null;
+  status: string;
+  tags: string[];
+  trends: {
+    daily?: number;
+    weekly?: number | null;
+    monthly?: number | null;
+    yearly?: number | null;
+  };
+  npm?: string;
+  downloads?: number;
+  icon?: string;
+};

--- a/apps/backend/src/tasks/trigger-build-webapp.task.ts
+++ b/apps/backend/src/tasks/trigger-build-webapp.task.ts
@@ -1,0 +1,48 @@
+import { Task } from "@/task-runner";
+
+export const triggerBuildWebappTask: Task = {
+  name: "trigger-build-webapp",
+  description: "Trigger the build of the Next.js app",
+
+  run: async ({ logger }) => {
+    await invalidateWebAppCacheByTag("all-projects");
+    await invalidateWebAppCacheByTag("project-details");
+    await invalidateWebAppCacheByTag("package-downloads");
+    await triggerWebAppBuild();
+
+    return { data: null, meta: { sent: true } };
+
+    async function invalidateWebAppCacheByTag(tag: string) {
+      const rootURL = "https://bestofjs.org"; // TODO: use env variable?
+      const invalidateCacheURL = `${rootURL}/api/revalidate?tag=${tag}`;
+      try {
+        const result = await fetch(invalidateCacheURL).then((res) =>
+          res.json()
+        );
+        logger.debug(result);
+        logger.info(`Invalid cache request for "${tag}" tag sent!`);
+      } catch (error) {
+        throw new Error(
+          `Unable to invalid the cache for "${tag}" tag ${
+            (error as Error).message
+          }`
+        );
+      }
+    }
+
+    async function triggerWebAppBuild() {
+      const webhookURL = process.env.FRONTEND_BUILD_WEB_HOOK;
+      if (!webhookURL)
+        throw new Error(`No webhook URL specified (FRONTEND_BUILD_WEB_HOOK)`);
+      try {
+        const result = await fetch(webhookURL).then((res) => res.json());
+        logger.debug(result);
+        logger.info("Daily build webhook request sent!");
+      } catch (error) {
+        throw new Error(
+          `Unable to send daily build webhook ${(error as Error).message}`
+        );
+      }
+    }
+  },
+};

--- a/apps/backend/vercel.json
+++ b/apps/backend/vercel.json
@@ -13,5 +13,8 @@
         "value": "*"
       }
     }
-  ]
+  ],
+  "git": {
+    "deploymentEnabled": false
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,10 +82,10 @@ importers:
         version: 5.0.5
       next:
         specifier: 14.1.1-canary.2
-        version: 14.1.1-canary.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 14.1.1-canary.2(@babel/core@7.22.9)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-themes:
         specifier: ^0.2.1
-        version: 0.2.1(next@14.1.1-canary.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 0.2.1(next@14.1.1-canary.2(@babel/core@7.22.9)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       pretty-bytes:
         specifier: ^6.1.1
         version: 6.1.1
@@ -180,6 +180,9 @@ importers:
       consola:
         specifier: ^3.2.3
         version: 3.2.3
+      debug:
+        specifier: ^4.3.4
+        version: 4.3.4
       dotenv-cli:
         specifier: ^7.4.2
         version: 7.4.2
@@ -216,6 +219,10 @@ importers:
       zod:
         specifier: ^3.22.4
         version: 3.23.8
+    devDependencies:
+      '@types/debug':
+        specifier: ^4.1.12
+        version: 4.1.12
 
   apps/bestofjs-nextjs:
     dependencies:
@@ -320,10 +327,10 @@ importers:
         version: 6.4.1
       next:
         specifier: 14.2.0-canary.1
-        version: 14.2.0-canary.1(@babel/core@7.22.9)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 14.2.0-canary.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-themes:
         specifier: ^0.2.1
-        version: 0.2.1(next@14.2.0-canary.1(@babel/core@7.22.9)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 0.2.1(next@14.2.0-canary.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       nextjs-bundle-analysis:
         specifier: ^0.5.0
         version: 0.5.0
@@ -11824,8 +11831,8 @@ snapshots:
       '@typescript-eslint/parser': 6.9.1(eslint@8.46.0)(typescript@5.2.2)
       eslint: 8.46.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1)(eslint@8.46.0)
-      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.5.5)(eslint@8.46.0)
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1(eslint@8.46.0))(eslint@8.46.0)
+      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1(eslint@8.46.0))(eslint@8.46.0))(eslint@8.46.0)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.46.0)
       eslint-plugin-react: 7.33.2(eslint@8.46.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.46.0)
@@ -11847,13 +11854,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1)(eslint@8.46.0):
+  eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1(eslint@8.46.0))(eslint@8.46.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.46.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1)(eslint@8.46.0))(eslint@8.46.0)
-      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.5.5)(eslint@8.46.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1(eslint@8.46.0))(eslint@8.46.0))(eslint@8.46.0)
+      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1(eslint@8.46.0))(eslint@8.46.0))(eslint@8.46.0)
       get-tsconfig: 4.6.2
       globby: 13.2.2
       is-core-module: 2.13.0
@@ -11865,18 +11872,18 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1)(eslint@8.46.0))(eslint@8.46.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1(eslint@8.46.0))(eslint@8.46.0))(eslint@8.46.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.9.1(eslint@8.46.0)(typescript@5.2.2)
       eslint: 8.46.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1)(eslint@8.46.0)
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1(eslint@8.46.0))(eslint@8.46.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.28.1(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.5.5)(eslint@8.46.0):
+  eslint-plugin-import@2.28.1(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1(eslint@8.46.0))(eslint@8.46.0))(eslint@8.46.0):
     dependencies:
       array-includes: 3.1.6
       array.prototype.findlastindex: 1.2.2
@@ -11886,7 +11893,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.46.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1)(eslint@8.46.0))(eslint@8.46.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1(eslint@8.46.0))(eslint@8.46.0))(eslint@8.46.0)
       has: 1.0.3
       is-core-module: 2.13.0
       is-glob: 4.0.3
@@ -13637,19 +13644,19 @@ snapshots:
 
   negotiator@0.6.3: {}
 
-  next-themes@0.2.1(next@14.1.1-canary.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next-themes@0.2.1(next@14.1.1-canary.2(@babel/core@7.22.9)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      next: 14.1.1-canary.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.1.1-canary.2(@babel/core@7.22.9)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  next-themes@0.2.1(next@14.2.0-canary.1(@babel/core@7.22.9)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next-themes@0.2.1(next@14.2.0-canary.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      next: 14.2.0-canary.1(@babel/core@7.22.9)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.0-canary.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  next@14.1.1-canary.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next@14.1.1-canary.2(@babel/core@7.22.9)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@next/env': 14.1.1-canary.2
       '@swc/helpers': 0.5.2
@@ -13674,7 +13681,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@14.2.0-canary.1(@babel/core@7.22.9)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next@14.2.0-canary.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@next/env': 14.2.0-canary.1
       '@swc/helpers': 0.5.5


### PR DESCRIPTION
## Goal

Add `static-api-daily` script to be run by build process on Vercel.

Build command setup on Vercel: `pnpm -F backend static-api-daily`

This script is made of 3 tasks:

- `build-static-api` (the main one) rebuilds the JSON file with consolidated data consumed by the app
- `trigger-build-webapp` sends the webhook to revuild Next.js app
- `notify-daily` sends daily notifications on Slack and Discord

