### PR TITLE
Connect to database using `@vercel/postgres` package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ node_modules
 
 # local PostgreSQL database
 db-data
+
+# Output of typecheck command
+tsconfig.tsbuildinfo

--- a/apps/admin/src/app/projects/[slug]/actions.ts
+++ b/apps/admin/src/app/projects/[slug]/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { unstable_noStore as noStore, revalidatePath } from "next/cache";
+import { snapshotsService } from "@/db";
 import { EditableProjectData, getDatabase } from "@repo/db";
 import { createClient } from "@repo/db/github";
 import {
@@ -69,10 +70,9 @@ export async function addSnapshotAction(
   const stars = data.stargazers_count as number;
 
   // TODO add a real UI?
-  const service = new SnapshotsService(getDatabase());
   console.log("Adding snapshot for", repoId, stars);
 
-  service.addSnapshot(repoId, stars);
+  snapshotsService.addSnapshot(repoId, stars);
 
   revalidatePath(`/projects/${projectSlug}`);
 }

--- a/apps/admin/src/app/projects/[slug]/edit/page.tsx
+++ b/apps/admin/src/app/projects/[slug]/edit/page.tsx
@@ -1,5 +1,5 @@
-import { getDatabase } from "@repo/db";
-import { ProjectService, getAllTags } from "@repo/db/projects";
+import { projectService } from "@/db";
+import { getAllTags } from "@repo/db/projects";
 
 import { ProjectLogo } from "@/components/project-logo";
 
@@ -13,8 +13,7 @@ type PageProps = {
 };
 
 export default async function EditProjectPage({ params: { slug } }: PageProps) {
-  const service = new ProjectService(getDatabase());
-  const project = await service.getProjectBySlug(slug);
+  const project = await projectService.getProjectBySlug(slug);
   const allTags = await getAllTags();
 
   if (!project) {

--- a/apps/admin/src/app/projects/[slug]/page.tsx
+++ b/apps/admin/src/app/projects/[slug]/page.tsx
@@ -1,4 +1,5 @@
-import { getAllTags, getProjectBySlug } from "@repo/db/projects";
+import { projectService } from "@/db";
+import { getAllTags } from "@repo/db/projects";
 import invariant from "tiny-invariant";
 
 import { ProjectLogo } from "@/components/project-logo";
@@ -19,7 +20,7 @@ type PageProps = {
 export const revalidate = 0;
 
 export default async function ViewProjectPage({ params: { slug } }: PageProps) {
-  const project = await getProjectBySlug(slug);
+  const project = await projectService.getProjectBySlug(slug);
   const allTags = await getAllTags();
 
   if (!project) {

--- a/apps/admin/src/app/projects/[slug]/view-repo.tsx
+++ b/apps/admin/src/app/projects/[slug]/view-repo.tsx
@@ -30,6 +30,14 @@ export function ViewRepo({ repo }: Props) {
           <p>{repo.full_name}</p>
           <p>Description</p>
           <p>{repo.description}</p>
+          <p>Homepage</p>
+          <p>
+            {repo.homepage ? (
+              <a href={repo.homepage}>{repo.homepage}</a>
+            ) : (
+              <i className="text-muted-foreground">No homepage</i>
+            )}
+          </p>
           <p>Created</p>
           <p>{formatDateOnly(repo.created_at)}</p>
           <p>Pushed at</p>

--- a/apps/admin/src/db.ts
+++ b/apps/admin/src/db.ts
@@ -1,0 +1,10 @@
+import { getDatabase } from "@repo/db";
+import { ProjectService } from "@repo/db/projects";
+import { SnapshotsService } from "@repo/db/snapshots";
+
+const db = getDatabase();
+
+/** Export singletons to avoid creating too many connections */
+export const projectService = new ProjectService(db);
+
+export const snapshotsService = new SnapshotsService(db);

--- a/apps/bestofjs-nextjs/src/app/db.ts
+++ b/apps/bestofjs-nextjs/src/app/db.ts
@@ -1,0 +1,7 @@
+import { getDatabase } from "@repo/db";
+import { ProjectService } from "@repo/db/projects";
+
+const db = getDatabase();
+
+/** Export a singleton to avoid creating too many connections */
+export const projectService = new ProjectService(db);

--- a/apps/bestofjs-nextjs/src/app/projects/[slug]/page.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react";
 import { Metadata } from "next";
-import { ProjectDetails, getProjectBySlug } from "@repo/db/projects";
+import { ProjectDetails } from "@repo/db/projects";
 
 import { ProjectDetailsGitHubCard } from "./project-details-github/github-card";
 import { ProjectHeader } from "./project-header";
@@ -11,6 +11,7 @@ import { addCacheBustingParam } from "@/helpers/url";
 import { Card, CardContent } from "@/components/ui/card";
 import { api } from "@/server/api";
 import { getHotProjectsRequest } from "@/app/backend-search-requests";
+import { projectService } from "@/app/db";
 
 import { ProjectDetailsNpmCard } from "./project-details-npm/project-details-npm";
 
@@ -24,7 +25,7 @@ export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
   const { slug } = params;
-  const project = await getProjectBySlug(slug);
+  const project = await projectService.getProjectBySlug(slug);
   if (!project) return { title: "Project not found" };
 
   const title = project.name;
@@ -47,7 +48,7 @@ export async function generateMetadata({
 
 export default async function ProjectDetailsPage({ params }: PageProps) {
   const { slug } = params;
-  const project = await getProjectBySlug(slug);
+  const project = await projectService.getProjectBySlug(slug);
   if (!project) {
     // TODO show a better page when an invalid slug is provided
     return <>Project not found!</>;

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "generate": "dotenv -e ../../.env pnpm drizzle-kit generate",
     "migrate": "dotenv -e ../../.env bun run src/migrate.ts",
-    "studio": "dotenv -e ../../.env pnpm drizzle-kit studio"
+    "studio": "dotenv -e ../../.env pnpm drizzle-kit studio",
+    "typecheck": "tsc --noEmit",
+    "typecheck:watch": "tsc --noEmit --incremental --watch"
   },
   "exports": {
     ".": "./src/index.ts",
@@ -21,6 +23,7 @@
     "@types/debug": "^4.1.12",
     "@types/lodash": "^4.14.195",
     "@types/luxon": "^3.4.2",
+    "@vercel/postgres": "^0.9.0",
     "debug": "^4.3.4",
     "dotenv-cli": "^7.4.2",
     "drizzle-kit": "^0.22.7",
@@ -36,5 +39,8 @@
     "slugify": "^1.6.6",
     "tiny-invariant": "^1.3.1",
     "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.1.6"
   }
 }

--- a/packages/db/src/database.ts
+++ b/packages/db/src/database.ts
@@ -1,0 +1,4 @@
+export interface DatabaseService<T> {
+  db: T;
+  disconnect(): void;
+}

--- a/packages/db/src/local-database.ts
+++ b/packages/db/src/local-database.ts
@@ -1,0 +1,24 @@
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+
+import { env } from "./env.mjs";
+
+import * as schema from "./schema";
+import { DatabaseService } from "./database";
+
+export type DB = ReturnType<typeof drizzle<typeof schema>>;
+
+export class LocalDatabase implements DatabaseService<DB> {
+  db: DB;
+  pg: ReturnType<typeof postgres>;
+  constructor() {
+    const dbURL = env.POSTGRES_URL;
+    this.pg = postgres(dbURL);
+    this.db = drizzle(this.pg, { schema });
+  }
+
+  async disconnect() {
+    await this.pg.end();
+    console.log("Local DB disconnected");
+  }
+}

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -3,5 +3,6 @@ import { DB, runQuery } from "./index";
 
 runQuery(async (db: DB) => {
   console.log("Migrate PG");
+  // @ts-expect-error TODO `migrate` should be provided by the database service
   await migrate(db, { migrationsFolder: "./drizzle" });
 });

--- a/packages/db/src/projects/create.ts
+++ b/packages/db/src/projects/create.ts
@@ -26,6 +26,7 @@ export async function createProject(gitHubURL: string) {
       slug: slugify(data.name),
       description: data.description,
       url: data.homepage,
+      status: "active",
     })
     .returning();
 

--- a/packages/db/src/projects/get.ts
+++ b/packages/db/src/projects/get.ts
@@ -1,16 +1,10 @@
 import { asc, eq } from "drizzle-orm";
+import { PgColumn } from "drizzle-orm/pg-core";
 import invariant from "tiny-invariant";
 import { z } from "zod";
 
-import { DB, getDatabase } from "../index";
+import { DB } from "../index";
 import * as schema from "../schema";
-import { PgColumn } from "drizzle-orm/pg-core";
-
-export async function getProjectBySlug(slug: string) {
-  const service = new ProjectService(getDatabase());
-  const project = await service.getProjectBySlug(slug);
-  return project;
-}
 
 export class ProjectService {
   db: DB;

--- a/packages/db/src/vercel-database.ts
+++ b/packages/db/src/vercel-database.ts
@@ -1,0 +1,22 @@
+import { sql } from "@vercel/postgres";
+import { drizzle } from "drizzle-orm/vercel-postgres";
+
+import * as schema from "./schema";
+import { DatabaseService } from "./database";
+
+export type DB = ReturnType<typeof drizzle<typeof schema>>;
+
+export class VercelPostgresService implements DatabaseService<DB> {
+  db: DB;
+  constructor() {
+    console.log("Vercel DB connected");
+    this.db = drizzle(sql, { schema });
+    sql.on("remove", () => {
+      console.log("Vercel DB disconnected");
+    });
+  }
+
+  disconnect() {
+    sql.end();
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,7 +188,7 @@ importers:
         version: 7.4.2
       drizzle-orm:
         specifier: ^0.31.2
-        version: 0.31.2(@types/react@18.2.18)(postgres@3.4.3)(react@18.2.0)
+        version: 0.31.2(@neondatabase/serverless@0.9.4)(@types/pg@8.11.6)(@types/react@18.2.18)(@vercel/postgres@0.9.0)(bun-types@1.1.17)(postgres@3.4.3)(react@18.2.0)
       fs-extra:
         specifier: ^11.1.1
         version: 11.1.1
@@ -234,7 +234,7 @@ importers:
         version: 3.4.8(@klass/core@3.4.8)(react@18.2.0)
       '@next/bundle-analyzer':
         specifier: ^14.0.3
-        version: 14.0.3
+        version: 14.0.3(bufferutil@4.0.8)
       '@radix-ui/react-checkbox':
         specifier: ^1.0.4
         version: 1.0.4(@types/react-dom@18.2.7)(@types/react@18.2.18)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -390,7 +390,7 @@ importers:
         version: 3.6.0(vite@3.2.10(@types/node@18.19.21)(terser@5.19.2))
       vitest:
         specifier: ^0.34.3
-        version: 0.34.3(jsdom@16.7.0)(playwright@1.39.0)(terser@5.19.2)
+        version: 0.34.3(jsdom@16.7.0(bufferutil@4.0.8))(playwright@1.39.0)(terser@5.19.2)
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -593,13 +593,13 @@ importers:
         version: 0.14.3
       jest:
         specifier: ^27.5.1
-        version: 27.5.1
+        version: 27.5.1(bufferutil@4.0.8)
       jest-preview:
         specifier: ^0.3.1
-        version: 0.3.1(postcss@8.4.31)
+        version: 0.3.1(bufferutil@4.0.8)(postcss@8.4.31)
       jest-watch-typeahead:
         specifier: ^1.1.0
-        version: 1.1.0(jest@27.5.1)
+        version: 1.1.0(jest@27.5.1(bufferutil@4.0.8))
       msw:
         specifier: ^0.41.0
         version: 0.41.1(typescript@4.9.5)
@@ -630,6 +630,9 @@ importers:
       '@types/luxon':
         specifier: ^3.4.2
         version: 3.4.2
+      '@vercel/postgres':
+        specifier: ^0.9.0
+        version: 0.9.0
       debug:
         specifier: ^4.3.4
         version: 4.3.4
@@ -641,7 +644,7 @@ importers:
         version: 0.22.7
       drizzle-orm:
         specifier: ^0.31.2
-        version: 0.31.2(@types/react@18.2.18)(postgres@3.4.3)(react@18.2.0)
+        version: 0.31.2(@neondatabase/serverless@0.9.4)(@types/pg@8.11.6)(@types/react@18.2.18)(@vercel/postgres@0.9.0)(bun-types@1.1.17)(postgres@3.4.3)(react@18.2.0)
       emoji-regex:
         specifier: ^10.3.0
         version: 10.3.0
@@ -675,6 +678,10 @@ importers:
       zod:
         specifier: ^3.22.4
         version: 3.23.8
+    devDependencies:
+      '@types/bun':
+        specifier: ^1.1.6
+        version: 1.1.6
 
 packages:
 
@@ -1980,6 +1987,9 @@ packages:
     resolution: {integrity: sha512-GJ1qzBq82EQ3bwhsvw5nScbrLzOSI5H/TyB2CGd1K7dDqX58DJDLJHexiN+S5Ucvl6/84FjRdIysz0RxE/L8MA==}
     engines: {node: '>=14'}
 
+  '@neondatabase/serverless@0.9.4':
+    resolution: {integrity: sha512-D0AXgJh6xkf+XTlsO7iwE2Q1w8981E1cLCPAALMU2YKtkF/1SF6BiAzYARZFYo175ON+b1RNIy9TdSFHm5nteg==}
+
   '@next/bundle-analyzer@14.0.3':
     resolution: {integrity: sha512-+UriXNEn2vGR2IxTiiuen45G7lXUbtMh0hgS/UH2o2E4TnScwjEEepqT76pY8fdpa5JEZ+gvBy6aSnrw4G2P2w==}
 
@@ -2949,6 +2959,9 @@ packages:
   '@types/babel__traverse@7.20.1':
     resolution: {integrity: sha512-MitHFXnhtgwsGZWtT68URpOvLN4EREih1u3QtQiN4VdAxWKRVvGCSvw/Qth0M0Qq3pJpnGOu5JaM/ydK7OGbqg==}
 
+  '@types/bun@1.1.6':
+    resolution: {integrity: sha512-uJgKjTdX0GkWEHZzQzFsJkWp5+43ZS7HC8sZPFnOwnSo1AsNl2q9o2bFeS23disNDqbggEgyFkKCHl/w8iZsMA==}
+
   '@types/chai-subset@1.3.3':
     resolution: {integrity: sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==}
 
@@ -3030,11 +3043,17 @@ packages:
   '@types/node@20.11.10':
     resolution: {integrity: sha512-rZEfe/hJSGYmdfX9tvcPMYeYPW2sNl50nsw4jZmRcaG0HIAb0WYEpsB05GOb53vjqpyE9GUhlDQ4jLSoB5q9kg==}
 
+  '@types/node@20.12.14':
+    resolution: {integrity: sha512-scnD59RpYD91xngrQQLGkE+6UrHUPzeKZWhhjBSa3HSkwjbQc38+q3RoIVEwxQGRw3M+j5hpNAM+lgV3cVormg==}
+
   '@types/numeral@2.0.2':
     resolution: {integrity: sha512-A8F30k2gYJ/6e07spSCPpkuZu79LCnkPTvqmIWQzNGcrzwFKpVOydG41lNt5wZXjSI149qjyzC2L1+F2PD/NUA==}
 
   '@types/parse-json@4.0.0':
     resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
+
+  '@types/pg@8.11.6':
+    resolution: {integrity: sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==}
 
   '@types/prettier@2.7.3':
     resolution: {integrity: sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==}
@@ -3083,6 +3102,9 @@ packages:
 
   '@types/warning@3.0.0':
     resolution: {integrity: sha512-t/Tvs5qR47OLOr+4E9ckN8AmP2Tf16gWq+/qA4iUGS/OOyHVO8wv2vjJuX8SNOUTJyWb+2t7wJm6cXILFnOROA==}
+
+  '@types/ws@8.5.12':
+    resolution: {integrity: sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==}
 
   '@types/yargs-parser@21.0.0':
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
@@ -3190,6 +3212,10 @@ packages:
 
   '@vercel/analytics@1.0.1':
     resolution: {integrity: sha512-Ux0c9qUfkcPqng3vrR0GTrlQdqNJ2JREn/2ydrVuKwM3RtMfF2mWX31Ijqo1opSjNAq6rK76PwtANw6kl6TAow==}
+
+  '@vercel/postgres@0.9.0':
+    resolution: {integrity: sha512-WiI2g3+ce2g1u1gP41MoDj2DsMuQQ+us7vHobysRixKECGaLHpfTI7DuVZmHU087ozRAGr3GocSyqmWLLo+fig==}
+    engines: {node: '>=14.6'}
 
   '@vitejs/plugin-react@2.2.0':
     resolution: {integrity: sha512-FFpefhvExd1toVRlokZgxgy2JtnBOdp4ZDsq7ldCWaqGSGn9UhWMAVm/1lxPL14JfNS5yGz+s9yFrQY6shoStA==}
@@ -3506,6 +3532,13 @@ packages:
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  bufferutil@4.0.8:
+    resolution: {integrity: sha512-4T53u4PdgsXqKaIctwF8ifXlRTTmEPJ8iEPWFdGZvcf7sbwYo6FKFEX9eNNAnzFZ7EzJAQ3CJeOtCRA4rDp7Pw==}
+    engines: {node: '>=6.14.2'}
+
+  bun-types@1.1.17:
+    resolution: {integrity: sha512-Z4+OplcSd/YZq7ZsrfD00DKJeCwuNY96a1IDJyR73+cTBaFIS7SC6LhpY/W3AMEXO9iYq5NJ58WAwnwL1p5vKg==}
 
   bundle-name@3.0.0:
     resolution: {integrity: sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==}
@@ -5905,6 +5938,10 @@ packages:
       encoding:
         optional: true
 
+  node-gyp-build@4.8.1:
+    resolution: {integrity: sha512-OSs33Z9yWr148JZcbZd5WiAXhh/n9z8TxQcdMhIOlpN9AhWpLfvVFO73+m77bBABQMaY9XSvIa+qk0jlI7Gcaw==}
+    hasBin: true
+
   node-html-parser@5.4.2:
     resolution: {integrity: sha512-RaBPP3+51hPne/OolXxcz89iYvQvKOydaqoePpOgXcrOKZhjVIzmpKZz+Hd/RBO2/zN2q6CNJhQzucVz+u3Jyw==}
 
@@ -6000,6 +6037,9 @@ packages:
   object.values@1.1.6:
     resolution: {integrity: sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==}
     engines: {node: '>= 0.4'}
+
+  obuf@1.1.2:
+    resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
 
   on-finished@2.3.0:
     resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
@@ -6186,6 +6226,21 @@ packages:
   pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-numeric@1.0.2:
+    resolution: {integrity: sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==}
+    engines: {node: '>=4'}
+
+  pg-protocol@1.6.1:
+    resolution: {integrity: sha512-jPIlvgoD63hrEuihvIg+tJhoGjUsLPn6poJY9N5CnlPd91c2T18T/9zBtLxZSb1EhYxBRoZJtzScCaWlYLtktg==}
+
+  pg-types@4.0.2:
+    resolution: {integrity: sha512-cRL3JpS3lKMGsKaWndugWQoLOCoP+Cic8oseVcbr0qhPzYD5DWXK+RZ9LY9wxRf7RQia4SCwQlXk0q6FCPrVng==}
+    engines: {node: '>=10'}
+
   picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
 
@@ -6267,6 +6322,25 @@ packages:
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@3.0.2:
+    resolution: {integrity: sha512-6faShkdFugNQCLwucjPcY5ARoW1SlbnrZjmGl0IrrqewpvxvhSLHimCVzqeuULCbG0fQv7Dtk1yDbG3xv7Veog==}
+    engines: {node: '>=12'}
+
+  postgres-bytea@3.0.0:
+    resolution: {integrity: sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==}
+    engines: {node: '>= 6'}
+
+  postgres-date@2.1.0:
+    resolution: {integrity: sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==}
+    engines: {node: '>=12'}
+
+  postgres-interval@3.0.0:
+    resolution: {integrity: sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==}
+    engines: {node: '>=12'}
+
+  postgres-range@1.1.4:
+    resolution: {integrity: sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==}
 
   postgres@3.4.3:
     resolution: {integrity: sha512-iHJn4+M9vbTdHSdDzNkC0crHq+1CUdFhx+YqCE+SqWxPjm+Zu63jq7yZborOBF64c8pc58O5uMudyL1FQcHacA==}
@@ -7392,6 +7466,10 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
 
+  utf-8-validate@6.0.4:
+    resolution: {integrity: sha512-xu9GQDeFp+eZ6LnCywXN/zBancWvOpUMzgjLPSjy4BRHSmTelvn2E0DG0o1sTiw5hkCKBHo8rwSKncfRfv2EEQ==}
+    engines: {node: '>=6.14.2'}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -7652,6 +7730,18 @@ packages:
 
   ws@8.13.0:
     resolution: {integrity: sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.18.0:
+    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -8928,7 +9018,7 @@ snapshots:
       jest-util: 28.1.3
       slash: 3.0.0
 
-  '@jest/core@27.5.1':
+  '@jest/core@27.5.1(bufferutil@4.0.8)':
     dependencies:
       '@jest/console': 27.5.1
       '@jest/reporters': 27.5.1
@@ -8942,13 +9032,13 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 27.5.1
-      jest-config: 27.5.1
+      jest-config: 27.5.1(bufferutil@4.0.8)
       jest-haste-map: 27.5.1
       jest-message-util: 27.5.1
       jest-regex-util: 27.5.1
       jest-resolve: 27.5.1
       jest-resolve-dependencies: 27.5.1
-      jest-runner: 27.5.1
+      jest-runner: 27.5.1(bufferutil@4.0.8)
       jest-runtime: 27.5.1
       jest-snapshot: 27.5.1
       jest-util: 27.5.1
@@ -9170,9 +9260,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@next/bundle-analyzer@14.0.3':
+  '@neondatabase/serverless@0.9.4':
     dependencies:
-      webpack-bundle-analyzer: 4.7.0
+      '@types/pg': 8.11.6
+
+  '@next/bundle-analyzer@14.0.3(bufferutil@4.0.8)':
+    dependencies:
+      webpack-bundle-analyzer: 4.7.0(bufferutil@4.0.8)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -10192,6 +10286,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.22.5
 
+  '@types/bun@1.1.6':
+    dependencies:
+      bun-types: 1.1.17
+
   '@types/chai-subset@1.3.3':
     dependencies:
       '@types/chai': 4.3.5
@@ -10278,9 +10376,19 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
+  '@types/node@20.12.14':
+    dependencies:
+      undici-types: 5.26.5
+
   '@types/numeral@2.0.2': {}
 
   '@types/parse-json@4.0.0': {}
+
+  '@types/pg@8.11.6':
+    dependencies:
+      '@types/node': 20.11.10
+      pg-protocol: 1.6.1
+      pg-types: 4.0.2
 
   '@types/prettier@2.7.3': {}
 
@@ -10338,6 +10446,10 @@ snapshots:
   '@types/trusted-types@2.0.3': {}
 
   '@types/warning@3.0.0': {}
+
+  '@types/ws@8.5.12':
+    dependencies:
+      '@types/node': 20.12.14
 
   '@types/yargs-parser@21.0.0': {}
 
@@ -10479,6 +10591,13 @@ snapshots:
       eslint-visitor-keys: 3.4.2
 
   '@vercel/analytics@1.0.1': {}
+
+  '@vercel/postgres@0.9.0':
+    dependencies:
+      '@neondatabase/serverless': 0.9.4
+      bufferutil: 4.0.8
+      utf-8-validate: 6.0.4
+      ws: 8.18.0(bufferutil@4.0.8)(utf-8-validate@6.0.4)
 
   '@vitejs/plugin-react@2.2.0(vite@3.2.10(@types/node@14.18.54)(terser@5.19.2))':
     dependencies:
@@ -10879,6 +10998,15 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  bufferutil@4.0.8:
+    dependencies:
+      node-gyp-build: 4.8.1
+
+  bun-types@1.1.17:
+    dependencies:
+      '@types/node': 20.12.14
+      '@types/ws': 8.5.12
 
   bundle-name@3.0.0:
     dependencies:
@@ -11489,9 +11617,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.31.2(@types/react@18.2.18)(postgres@3.4.3)(react@18.2.0):
+  drizzle-orm@0.31.2(@neondatabase/serverless@0.9.4)(@types/pg@8.11.6)(@types/react@18.2.18)(@vercel/postgres@0.9.0)(bun-types@1.1.17)(postgres@3.4.3)(react@18.2.0):
     optionalDependencies:
+      '@neondatabase/serverless': 0.9.4
+      '@types/pg': 8.11.6
       '@types/react': 18.2.18
+      '@vercel/postgres': 0.9.0
+      bun-types: 1.1.17
       postgres: 3.4.3
       react: 18.2.0
 
@@ -12896,16 +13028,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-cli@27.5.1:
+  jest-cli@27.5.1(bufferutil@4.0.8):
     dependencies:
-      '@jest/core': 27.5.1
+      '@jest/core': 27.5.1(bufferutil@4.0.8)
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
       import-local: 3.1.0
-      jest-config: 27.5.1
+      jest-config: 27.5.1(bufferutil@4.0.8)
       jest-util: 27.5.1
       jest-validate: 27.5.1
       prompts: 2.4.2
@@ -12917,7 +13049,7 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  jest-config@27.5.1:
+  jest-config@27.5.1(bufferutil@4.0.8):
     dependencies:
       '@babel/core': 7.22.9
       '@jest/test-sequencer': 27.5.1
@@ -12929,13 +13061,13 @@ snapshots:
       glob: 7.2.3
       graceful-fs: 4.2.11
       jest-circus: 27.5.1
-      jest-environment-jsdom: 27.5.1
+      jest-environment-jsdom: 27.5.1(bufferutil@4.0.8)
       jest-environment-node: 27.5.1
       jest-get-type: 27.5.1
       jest-jasmine2: 27.5.1
       jest-regex-util: 27.5.1
       jest-resolve: 27.5.1
-      jest-runner: 27.5.1
+      jest-runner: 27.5.1(bufferutil@4.0.8)
       jest-util: 27.5.1
       jest-validate: 27.5.1
       micromatch: 4.0.5
@@ -12975,7 +13107,7 @@ snapshots:
       jest-util: 27.5.1
       pretty-format: 27.5.1
 
-  jest-environment-jsdom@27.5.1:
+  jest-environment-jsdom@27.5.1(bufferutil@4.0.8):
     dependencies:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
@@ -12983,7 +13115,7 @@ snapshots:
       '@types/node': 14.18.54
       jest-mock: 27.5.1
       jest-util: 27.5.1
-      jsdom: 16.7.0
+      jsdom: 16.7.0(bufferutil@4.0.8)
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -13087,7 +13219,7 @@ snapshots:
     optionalDependencies:
       jest-resolve: 27.5.1
 
-  jest-preview@0.3.1(postcss@8.4.31):
+  jest-preview@0.3.1(bufferutil@4.0.8)(postcss@8.4.31):
     dependencies:
       '@svgr/core': 6.5.1
       camelcase: 6.3.0
@@ -13103,7 +13235,7 @@ snapshots:
       slash: 3.0.0
       string-hash: 1.1.3
       update-notifier: 5.1.0
-      ws: 8.13.0
+      ws: 8.13.0(bufferutil@4.0.8)
     transitivePeerDependencies:
       - bufferutil
       - postcss
@@ -13136,7 +13268,7 @@ snapshots:
       resolve.exports: 1.1.1
       slash: 3.0.0
 
-  jest-runner@27.5.1:
+  jest-runner@27.5.1(bufferutil@4.0.8):
     dependencies:
       '@jest/console': 27.5.1
       '@jest/environment': 27.5.1
@@ -13148,7 +13280,7 @@ snapshots:
       emittery: 0.8.1
       graceful-fs: 4.2.11
       jest-docblock: 27.5.1
-      jest-environment-jsdom: 27.5.1
+      jest-environment-jsdom: 27.5.1(bufferutil@4.0.8)
       jest-environment-node: 27.5.1
       jest-haste-map: 27.5.1
       jest-leak-detector: 27.5.1
@@ -13251,11 +13383,11 @@ snapshots:
       leven: 3.1.0
       pretty-format: 27.5.1
 
-  jest-watch-typeahead@1.1.0(jest@27.5.1):
+  jest-watch-typeahead@1.1.0(jest@27.5.1(bufferutil@4.0.8)):
     dependencies:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
-      jest: 27.5.1
+      jest: 27.5.1(bufferutil@4.0.8)
       jest-regex-util: 28.0.2
       jest-watcher: 28.1.3
       slash: 4.0.0
@@ -13289,11 +13421,11 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@27.5.1:
+  jest@27.5.1(bufferutil@4.0.8):
     dependencies:
-      '@jest/core': 27.5.1
+      '@jest/core': 27.5.1(bufferutil@4.0.8)
       import-local: 3.1.0
-      jest-cli: 27.5.1
+      jest-cli: 27.5.1(bufferutil@4.0.8)
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -13318,7 +13450,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@16.7.0:
+  jsdom@16.7.0(bufferutil@4.0.8):
     dependencies:
       abab: 2.0.6
       acorn: 8.10.0
@@ -13345,7 +13477,7 @@ snapshots:
       whatwg-encoding: 1.0.5
       whatwg-mimetype: 2.3.0
       whatwg-url: 8.7.0
-      ws: 7.5.9
+      ws: 7.5.9(bufferutil@4.0.8)
       xml-name-validator: 3.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -13729,6 +13861,8 @@ snapshots:
     dependencies:
       whatwg-url: 5.0.0
 
+  node-gyp-build@4.8.1: {}
+
   node-html-parser@5.4.2:
     dependencies:
       css-select: 4.3.0
@@ -13823,6 +13957,8 @@ snapshots:
       call-bind: 1.0.2
       define-properties: 1.2.1
       es-abstract: 1.22.1
+
+  obuf@1.1.2: {}
 
   on-finished@2.3.0:
     dependencies:
@@ -13997,6 +14133,22 @@ snapshots:
 
   pathval@1.1.1: {}
 
+  pg-int8@1.0.1: {}
+
+  pg-numeric@1.0.2: {}
+
+  pg-protocol@1.6.1: {}
+
+  pg-types@4.0.2:
+    dependencies:
+      pg-int8: 1.0.1
+      pg-numeric: 1.0.2
+      postgres-array: 3.0.2
+      postgres-bytea: 3.0.0
+      postgres-date: 2.1.0
+      postgres-interval: 3.0.0
+      postgres-range: 1.1.4
+
   picocolors@1.0.0: {}
 
   picomatch@2.3.1: {}
@@ -14073,6 +14225,18 @@ snapshots:
       nanoid: 3.3.6
       picocolors: 1.0.0
       source-map-js: 1.0.2
+
+  postgres-array@3.0.2: {}
+
+  postgres-bytea@3.0.0:
+    dependencies:
+      obuf: 1.1.2
+
+  postgres-date@2.1.0: {}
+
+  postgres-interval@3.0.0: {}
+
+  postgres-range@1.1.4: {}
 
   postgres@3.4.3: {}
 
@@ -15327,6 +15491,10 @@ snapshots:
     dependencies:
       react: 18.2.0
 
+  utf-8-validate@6.0.4:
+    dependencies:
+      node-gyp-build: 4.8.1
+
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
@@ -15448,7 +15616,7 @@ snapshots:
       fsevents: 2.3.2
       terser: 5.19.2
 
-  vitest@0.34.3(jsdom@16.7.0)(playwright@1.39.0)(terser@5.19.2):
+  vitest@0.34.3(jsdom@16.7.0(bufferutil@4.0.8))(playwright@1.39.0)(terser@5.19.2):
     dependencies:
       '@types/chai': 4.3.5
       '@types/chai-subset': 1.3.3
@@ -15475,7 +15643,7 @@ snapshots:
       vite-node: 0.34.3(@types/node@18.19.21)(terser@5.19.2)
       why-is-node-running: 2.2.2
     optionalDependencies:
-      jsdom: 16.7.0
+      jsdom: 16.7.0(bufferutil@4.0.8)
       playwright: 1.39.0
     transitivePeerDependencies:
       - less
@@ -15534,7 +15702,7 @@ snapshots:
 
   webidl-conversions@6.1.0: {}
 
-  webpack-bundle-analyzer@4.7.0:
+  webpack-bundle-analyzer@4.7.0(bufferutil@4.0.8):
     dependencies:
       acorn: 8.10.0
       acorn-walk: 8.2.0
@@ -15544,7 +15712,7 @@ snapshots:
       lodash: 4.17.21
       opener: 1.5.2
       sirv: 1.0.19
-      ws: 7.5.9
+      ws: 7.5.9(bufferutil@4.0.8)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -15648,9 +15816,18 @@ snapshots:
       signal-exit: 3.0.7
       typedarray-to-buffer: 3.1.5
 
-  ws@7.5.9: {}
+  ws@7.5.9(bufferutil@4.0.8):
+    optionalDependencies:
+      bufferutil: 4.0.8
 
-  ws@8.13.0: {}
+  ws@8.13.0(bufferutil@4.0.8):
+    optionalDependencies:
+      bufferutil: 4.0.8
+
+  ws@8.18.0(bufferutil@4.0.8)(utf-8-validate@6.0.4):
+    optionalDependencies:
+      bufferutil: 4.0.8
+      utf-8-validate: 6.0.4
 
   xdg-basedir@4.0.0: {}
 


### PR DESCRIPTION
## Goal

The Postgres database on Vercel (Fron https://neon.tech under the hood) is not the usual Postgres database: of course it's compatible with the usual drivers (`pg` package) but you have to use [@vercel/postgres package](https://www.npmjs.com/package/@vercel/postgres) to make the best of the database, this driver is powered by web-sockets, it should make requests faster.

This PR includes some refactoring to try to decrease the number of connections to the database.

Running the following request can return up to 400 rows, depending on the time of the day:

```sql
SELECT * FROM pg_stat_activity ORDER BY backend_start DESC
```

The only downside: it seems there is no solution to run easily a Vercel database locally.

So this PR introduces a "dual" set up to be able to connect to:

- either the traditional Postgres DB in local when running apps and script in local
- or the Vercel Database when running in Preview/Production mode

```ts
import { drizzle } from "drizzle-orm/postgres-js";
```

```ts
import { drizzle } from "drizzle-orm/vercel-postgres";
```

## Possible improvements

- Try to run the Vercel DB locally with this? https://gal.hagever.com/posts/running-vercel-postgres-locally
- Do we really need a local DB, now that we have faster connections to the Vercel DB?
