### PR TITLE
Add task to update package bundle size

### DIFF
--- a/.github/workflows/update-bundle-size.yml
+++ b/.github/workflows/update-bundle-size.yml
@@ -1,0 +1,44 @@
+name: Update Bundle Size
+on:
+  schedule:
+    - cron: "0 1 * * *"
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: "Log level: 3 => info, 4 => debug"
+        required: true
+        default: 3
+        type: choice
+        options:
+          - 3
+          - 4
+      limit:
+        description: "Number of projects to process (mainly for debugging, keep the default value of 0 to process everything)"
+        required: false
+        type: number
+        default: 0
+      skip:
+        description: "Number of projects to skip (when paginating)"
+        required: false
+        type: number
+        default: 0
+      concurrency:
+        description: "Number of projects to process concurrently"
+        required: false
+        type: number
+        default: 1
+env:
+  POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
+jobs:
+  update-bunedle-size:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v4
+      - name: Setup Environment
+        uses: ./.github/tooling/github-actions/install
+      - name: Install Dependencies
+        shell: bash
+        run: pnpm -F backend install
+      - name: Update Bundle Size
+        run: pnpm -F backend daily-update-bundle-size --loglevel ${{ inputs.logLevel || 3 }} --limit ${{ inputs.limit || 0 }} --skip ${{ inputs.skip || 0 }} --concurrency ${{ inputs.concurrency || 1 }}

--- a/.github/workflows/update-github-data.yml
+++ b/.github/workflows/update-github-data.yml
@@ -49,6 +49,6 @@ jobs:
         shell: bash
         run: pnpm -F backend install
       - name: Update GitHub Data and take snapshots
-        run: pnpm -F backend daily-update-github-data --loglevel ${{ inputs.logLevel || 3 }} --limit ${{ inputs.limit || 0 }} --skip ${{ inputs.skip || 0 }} --concurrency ${{ inputs.concurrency || 5 }} --throttleInterval ${{ inputs.throttleInterval || 750 }}
+        run: pnpm -F backend daily-update-github-data --loglevel ${{ inputs.logLevel || 3 }} --limit ${{ inputs.limit || 0 }} --skip ${{ inputs.skip || 0 }} --concurrency ${{ inputs.concurrency || 1 }} --throttleInterval ${{ inputs.throttleInterval || 750 }}
       - name: Send Webhook to Vercel
         run: pnpm -F backend trigger-build-static-api

--- a/apps/admin/src/app/projects/[slug]/actions.ts
+++ b/apps/admin/src/app/projects/[slug]/actions.ts
@@ -2,19 +2,23 @@
 
 import { unstable_noStore as noStore, revalidatePath } from "next/cache";
 import { snapshotsService } from "@/db";
-import { EditableProjectData, getDatabase } from "@repo/db";
 import { createClient } from "@repo/db/github";
 import {
+  ProjectData,
   addPackage,
   removePackage,
   saveTags,
   updateProjectById,
 } from "@repo/db/projects";
-import { SnapshotsService } from "@repo/db/snapshots";
 import { EditableTagData, updateTagById } from "@repo/db/tags";
 import invariant from "tiny-invariant";
 
 import { Tag } from "@/components/ui/tags/tag-input";
+
+type EditableProjectData = Omit<
+  ProjectData,
+  "repoId" | "id" | "createdAt" | "updatedAt"
+>;
 
 export async function updateProjectData(
   projectId: string,

--- a/apps/admin/src/app/projects/[slug]/edit/project-form.tsx
+++ b/apps/admin/src/app/projects/[slug]/edit/project-form.tsx
@@ -4,7 +4,7 @@ import { useRouter } from "next/navigation";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ReloadIcon } from "@radix-ui/react-icons";
 import { SelectValue } from "@radix-ui/react-select";
-import { ProjectData } from "@repo/db";
+import { ProjectData } from "@repo/db/projects";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";

--- a/apps/admin/src/app/projects/[slug]/view-project.tsx
+++ b/apps/admin/src/app/projects/[slug]/view-project.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ProjectData } from "@repo/db";
+import { ProjectData } from "@repo/db/projects";
 
 import { buttonVariants } from "@/components/ui/button";
 import {

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -26,6 +26,7 @@
     "fs-extra": "^11.1.1",
     "p-map": "^7.0.2",
     "p-throttle": "^6.1.0",
+    "p-timeout": "^6.1.2",
     "package-json": "^6.4.0",
     "pretty-bytes": "^6.1.1",
     "tasuku": "^2.0.1",

--- a/apps/backend/src/cli.ts
+++ b/apps/backend/src/cli.ts
@@ -13,6 +13,7 @@ import { updatePackageDataTask } from "./tasks/update-package-data.task";
 import { cliFlags as flags } from "./flags";
 import { notifyDailyTask } from "./tasks/notify-daily.task";
 import { triggerBuildWebappTask } from "./tasks/trigger-build-webapp.task";
+import { updateBundleSizeTask } from "./tasks/update-bundle-size.task";
 
 const commands = [
   notifyDailyTask,
@@ -23,6 +24,7 @@ const commands = [
   helloWorldProjectsTask,
   helloWorldReposTask,
   updatePackageDataTask,
+  updateBundleSizeTask,
 ].map(getCommand);
 
 const staticApiDailyTask = command(

--- a/apps/backend/src/tasks/update-bundle-size.task.ts
+++ b/apps/backend/src/tasks/update-bundle-size.task.ts
@@ -1,0 +1,147 @@
+import { eq } from "drizzle-orm";
+
+import { createNpmClient } from "@/apis/npm-api-client";
+import { Task } from "@/task-runner";
+import { schema } from "@repo/db";
+import { ProjectDetails } from "@repo/db/projects";
+
+const npmClient = createNpmClient();
+
+type Result = "updated" | "same-version" | "timeout" | "error" | "backend-only";
+
+export const updateBundleSizeTask: Task = {
+  name: "update-bundle-size",
+  description: "Update bundle size data from bundlejs.com",
+  run: async ({ db, logger, processProjects }) => {
+    const results = await processProjects(async (project) => {
+      if (!shouldProcessProject(project)) {
+        logger.debug(`Skipping deprecated project ${project.repo.full_name}`);
+        return { meta: { skipped: true }, data: null };
+      }
+
+      const resultCounts: Record<Result, number> = {
+        "backend-only": 0,
+        "same-version": 0,
+        updated: 0,
+        error: 0,
+        timeout: 0,
+      };
+
+      for (const packageData of project.packages) {
+        const result = await processPackage(project, packageData);
+        resultCounts[result]++;
+      }
+
+      return {
+        data: null,
+        meta: resultCounts,
+      };
+    });
+
+    return results;
+
+    async function processPackage(
+      project: ProjectDetails,
+      packageData: ProjectDetails["packages"][number]
+    ): Promise<Result> {
+      const packageName = packageData.name;
+
+      if (!canRunInBrowser(project)) {
+        return "backend-only";
+      }
+
+      if (!needsUpdate(packageData)) {
+        return "same-version";
+      }
+
+      const bundleData = await npmClient.fetchBundleData(packageName);
+      const recordData = { ...bundleData, name: packageName };
+
+      // update or create the record  if it does not exist
+      // https://orm.drizzle.team/learn/guides/upsert
+      const result = await db
+        .insert(schema.bundles)
+        .values(recordData)
+        .onConflictDoUpdate({
+          target: schema.bundles.name,
+          set: { ...recordData, updatedAt: new Date() },
+        })
+        .returning();
+
+      logger.debug("Bundle record updated", result[0]);
+      if (bundleData.error) {
+        return bundleData.error === "timeout" ? "timeout" : "error";
+      }
+      return "updated";
+    }
+  },
+};
+
+function needsUpdate(packageData: ProjectDetails["packages"][number]) {
+  const bundle = packageData.bundles;
+  if (!bundle) return true;
+  const { errorMessage, version } = bundle;
+  if (errorMessage) return true;
+  const packageCurrentVersion = packageData.version;
+  if (packageCurrentVersion === version) return false;
+  return true;
+}
+
+function canRunInBrowser(project: ProjectDetails) {
+  if (isBackendProject(project)) return false;
+  return true;
+}
+
+function shouldProcessProject(project: ProjectDetails) {
+  const isDeprecated = project.status === "deprecated";
+  return !isDeprecated;
+}
+
+function isBackendProject(project: ProjectDetails) {
+  const projectTags = project.tags.map((tag) => tag.code);
+  return projectTags.some((tagName) => backendTags.includes(tagName));
+}
+
+const backendTags = [
+  "archive",
+  "astro",
+  "auto",
+  "boilerplate",
+  "build",
+  "bun",
+  "cli",
+  "cron",
+  "css-tool",
+  "deno",
+  "dependency",
+  "desktop",
+  "ecommerce",
+  "express",
+  "fullstack",
+  "iot",
+  "lint",
+  "meteor",
+  "microservice",
+  "middleware",
+  "module",
+  "mongodb",
+  "monorepo",
+  "nextjs",
+  "nodejs-framework",
+  "npm-scripts",
+  "nvm",
+  "orm",
+  "package",
+  "process",
+  "queue",
+  "runtime",
+  "rust",
+  "scaffolding",
+  "scraping",
+  "screenshot",
+  "security",
+  "serverless",
+  "ssg",
+  "test",
+  "websocket",
+];

--- a/packages/db/drizzle/0001_light_cerise.sql
+++ b/packages/db/drizzle/0001_light_cerise.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "bundles" ADD COLUMN "updated_at" timestamp;

--- a/packages/db/drizzle/meta/0001_snapshot.json
+++ b/packages/db/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,587 @@
+{
+  "id": "5c73e7d8-ca3a-4196-b610-319cab6582f4",
+  "prevId": "6ce389a6-6c59-41d5-b270-086d19a1e470",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.bundles": {
+      "name": "bundles",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gzip": {
+          "name": "gzip",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bundles_name_packages_name_fk": {
+          "name": "bundles_name_packages_name_fk",
+          "tableFrom": "bundles",
+          "tableTo": "packages",
+          "columnsFrom": [
+            "name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.packages": {
+      "name": "packages",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "downloads": {
+          "name": "downloads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependencies": {
+          "name": "dependencies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "devDependencies": {
+          "name": "devDependencies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deprecated": {
+          "name": "deprecated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "packages_project_id_projects_id_fk": {
+          "name": "packages_project_id_projects_id_fk",
+          "tableFrom": "packages",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "override_description": {
+          "name": "override_description",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_url": {
+          "name": "override_url",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitter": {
+          "name": "twitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comments": {
+          "name": "comments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repoId": {
+          "name": "repoId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_repoId_repos_id_fk": {
+          "name": "projects_repoId_repos_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "repos",
+          "columnsFrom": [
+            "repoId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "projects_slug_unique": {
+          "name": "projects_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      }
+    },
+    "public.projects_to_tags": {
+      "name": "projects_to_tags",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_to_tags_project_id_projects_id_fk": {
+          "name": "projects_to_tags_project_id_projects_id_fk",
+          "tableFrom": "projects_to_tags",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "projects_to_tags_tag_id_tags_id_fk": {
+          "name": "projects_to_tags_tag_id_tags_id_fk",
+          "tableFrom": "projects_to_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "projects_to_tags_project_id_tag_id_pk": {
+          "name": "projects_to_tags_project_id_tag_id_pk",
+          "columns": [
+            "project_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.repos": {
+      "name": "repos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "homepage": {
+          "name": "homepage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stargazers_count": {
+          "name": "stargazers_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pushed_at": {
+          "name": "pushed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_commit": {
+          "name": "last_commit",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_count": {
+          "name": "commit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contributor_count": {
+          "name": "contributor_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "repos_full_name_unique": {
+          "name": "repos_full_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "full_name"
+          ]
+        }
+      }
+    },
+    "public.snapshots": {
+      "name": "snapshots",
+      "schema": "",
+      "columns": {
+        "repo_id": {
+          "name": "repo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "months": {
+          "name": "months",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "snapshots_repo_id_repos_id_fk": {
+          "name": "snapshots_repo_id_repos_id_fk",
+          "tableFrom": "snapshots",
+          "tableTo": "repos",
+          "columnsFrom": [
+            "repo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "snapshots_repo_id_year_pk": {
+          "name": "snapshots_repo_id_year_pk",
+          "columns": [
+            "repo_id",
+            "year"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_code_unique": {
+          "name": "tags_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1723349560439,
       "tag": "0000_exotic_ultimo",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1723967504988,
+      "tag": "0001_light_cerise",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -5,13 +5,6 @@ export * as schema from "./schema";
 
 export type DB = ReturnType<typeof getDatabase>;
 
-type ProjectData = typeof schema.projects.$inferSelect;
-
-export type EditableProjectData = Omit<
-  ProjectData,
-  "repoId" | "id" | "createdAt" | "updatedAt"
->;
-
 export function getDatabase() {
   const service = getService();
   return service.db;

--- a/packages/db/src/projects/get.ts
+++ b/packages/db/src/projects/get.ts
@@ -6,6 +6,8 @@ import { z } from "zod";
 import { DB } from "../index";
 import * as schema from "../schema";
 
+export type ProjectData = typeof schema.projects.$inferSelect;
+
 export class ProjectService {
   db: DB;
   constructor(db: DB) {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -164,6 +164,7 @@ export const bundles = pgTable("bundles", {
   gzip: integer("gzip"),
   errorMessage: text("error_message"),
   createdAt: timestamp("created_at").notNull().defaultNow(),
+  updatedAt: timestamp("updated_at"),
 });
 
 export const bundlesRelations = relations(bundles, ({ one }) => ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,9 @@ importers:
       p-throttle:
         specifier: ^6.1.0
         version: 6.1.0
+      p-timeout:
+        specifier: ^6.1.2
+        version: 6.1.2
       package-json:
         specifier: ^6.4.0
         version: 6.5.0
@@ -6098,6 +6101,10 @@ packages:
   p-throttle@6.1.0:
     resolution: {integrity: sha512-eQMdGTxk2+047La67wefUtt0tEHh7D+C8Jl7QXoFCuIiNYeQ9zWs2AZiJdIAs72rSXZ06t11me2bgalRNdy3SQ==}
     engines: {node: '>=18'}
+
+  p-timeout@6.1.2:
+    resolution: {integrity: sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ==}
+    engines: {node: '>=14.16'}
 
   p-try@1.0.0:
     resolution: {integrity: sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==}
@@ -13956,6 +13963,8 @@ snapshots:
   p-map@7.0.2: {}
 
   p-throttle@6.1.0: {}
+
+  p-timeout@6.1.2: {}
 
   p-try@1.0.0: {}
 


### PR DESCRIPTION
## Goal

Following the migration to the new backend and Posgres database, this PR adds the missing task to update bundle size data stored in the `bundles` table.

Data comes from https://bundlejs.com/

Example of end-point: https://deno.bundlejs.com/?q=redux

```json
{
  "query": "?q=redux",
  "rawQuery": "%3Fq%3Dredux",
  "version": "redux@5.0.1",
  "modules": [
    [
      "redux@5.0.1",
      "export"
    ]
  ],
  "config": {
    "entryPoints": [
      "/index.ts"
    ],
    "cdn": "https://unpkg.com",
    "polyfill": false,
    "esbuild": {
      "color": true,
      "globalName": "BundledCode",
      "logLevel": "info",
      "sourcemap": false,
      "target": [
        "esnext"
      ],
      "format": "esm",
      "bundle": true,
      "minify": true,
      "treeShaking": true,
      "platform": "browser",
      "jsx": "transform"
    },
    "ansi": "ansi",
    "compression": {
      "type": "gzip",
      "quality": 9
    }
  },
  "input": "// Click Build for the Bundled, Minified & Compressed package size\nexport * from 'redux';\nexport { default } from 'redux';",
  "size": {
    "type": "gzip",
    "rawUncompressedSize": 3320,
    "uncompressedSize": "3.32 kB",
    "rawCompressedSize": 1423,
    "compressedSize": "1.42 kB",
    "size": "1.42 kB (gzip)"
  },
  "time": "in 0.97s",
  "rawTime": 970
}
```

## How to test

To run the task locally

```sh
bun run apps/backend/src/cli.ts update-bundle-size --logLevel 4 --limit 1 
```

