### PR TITLE
Refactor include project `slug` 

### DIFF
--- a/apps/admin/src/components/tag-picker.tsx
+++ b/apps/admin/src/components/tag-picker.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { Check, ChevronsUpDown, PlusIcon } from "lucide-react";
+import { Check, PlusIcon } from "lucide-react";
 
 import { ProjectDetails } from "@repo/db/projects";
 import { Button } from "@/components/ui/button";

--- a/apps/admin/src/components/ui/separator.tsx
+++ b/apps/admin/src/components/ui/separator.tsx
@@ -18,7 +18,7 @@ const Separator = React.forwardRef<
       decorative={decorative}
       orientation={orientation}
       className={cn(
-        "shrink-0 bg-border",
+        "bg-border shrink-0",
         orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
         className
       )}

--- a/apps/backend/src/tasks/build-static-api.task.ts
+++ b/apps/backend/src/tasks/build-static-api.task.ts
@@ -30,6 +30,7 @@ export const buildStaticApiTask: Task = {
 
       const data: ProjectItem = {
         name: project.name,
+        slug: project.slug,
         added_at: formatDate(project.createdAt),
         description: truncate(getProjectDescription(project), 75),
         stars: repo.stars || 0,

--- a/apps/backend/src/tasks/static-api-types.ts
+++ b/apps/backend/src/tasks/static-api-types.ts
@@ -1,5 +1,6 @@
 export type ProjectItem = {
   name: string;
+  slug: string;
   added_at: string;
   description: string;
   url?: string;

--- a/apps/bestofjs-nextjs/package.json
+++ b/apps/bestofjs-nextjs/package.json
@@ -67,7 +67,6 @@
     "react-dom": "^18.2.0",
     "react-icons": "^3.10.0",
     "sharp": "^0.32.6",
-    "slugify": "^1.6.6",
     "swr": "^2.2.0",
     "tailwind-merge": "^1.12.0",
     "tailwindcss": "^3.3.2",

--- a/apps/bestofjs-nextjs/src/lib/global.d.ts
+++ b/apps/bestofjs-nextjs/src/lib/global.d.ts
@@ -2,6 +2,7 @@ declare namespace BestOfJS {
   // Project raw data from the JSON API
   interface RawProject {
     name: string;
+    slug: string;
     full_name: string;
     description: string;
     tags: string[];
@@ -28,7 +29,6 @@ declare namespace BestOfJS {
 
   // Project handled in the state container
   interface StateProject extends RawProject {
-    slug: string;
     repository: string;
     packageName: string;
     addedPosition: number;

--- a/apps/bestofjs-nextjs/src/server/api-projects.tsx
+++ b/apps/bestofjs-nextjs/src/server/api-projects.tsx
@@ -5,7 +5,7 @@ import {
   filterProjectsByQuery,
   getResultRelevantTags,
 } from "@/lib/search-utils";
-import { APIContext, getProjectId } from "./api-utils";
+import { APIContext } from "./api-utils";
 
 type QueryParams = {
   criteria: RawObject & {
@@ -107,6 +107,8 @@ export function createProjectsAPI({ getData }: APIContext) {
     }: Pick<QueryParams, "skip" | "limit">) {
       const { featuredProjectIds, populate, projectsBySlug } = await getData();
       const slugs = featuredProjectIds.slice(skip, skip + limit);
+      console.log(">> slugs", slugs);
+
       const projects = slugs.map((slug) => populate(projectsBySlug[slug]));
       return { projects, total: featuredProjectIds.length };
     },
@@ -121,6 +123,7 @@ export function createProjectsAPI({ getData }: APIContext) {
       const projection = {
         full_name: 1,
         name: 1,
+        slug: 1,
         owner_id: 1,
         icon: 1,
         npm: 1,
@@ -134,10 +137,7 @@ export function createProjectsAPI({ getData }: APIContext) {
         .sort({ stars: -1 })
         .all() as BestOfJS.RawProject[];
 
-      return rawProjects.map((project) => ({
-        ...project,
-        slug: getProjectId(project),
-      })) as BestOfJS.SearchIndexProject[];
+      return rawProjects;
     },
   };
 }

--- a/apps/bestofjs-nextjs/src/server/api-utils.tsx
+++ b/apps/bestofjs-nextjs/src/server/api-utils.tsx
@@ -1,5 +1,3 @@
-import slugify from "slugify";
-
 import { shuffle } from "@/helpers/shuffle";
 
 export type RawData = {
@@ -36,8 +34,6 @@ export const populateProject =
       populated.tags = tags.map((id) => tagsByKey[id]).filter((tag) => !!tag);
     }
 
-    populated.slug = getProjectId(project);
-
     if (project.npm) {
       populated.packageName = project.npm; // TODO fix data?
     }
@@ -48,14 +44,9 @@ export const populateProject =
 export function getFeaturedRandomList(projects: BestOfJS.RawProject[]) {
   const slugs = projects
     .filter((project) => project.status === "featured")
-    .map((project) => getProjectId(project));
+    .map((project) => project.slug);
 
   return shuffle(slugs);
-}
-
-// TODO read the project's slug from the API instead of computing it here
-export function getProjectId(project: BestOfJS.RawProject) {
-  return slugify(project.name, { lower: true, remove: /[.'/]/g });
 }
 
 export function getTagsByKey(

--- a/apps/bestofjs-nextjs/src/server/create-api.tsx
+++ b/apps/bestofjs-nextjs/src/server/create-api.tsx
@@ -6,7 +6,6 @@ import {
   APIContext,
   Data,
   getFeaturedRandomList,
-  getProjectId,
   getTagsByKey,
   populateProject,
   RawData,
@@ -18,7 +17,7 @@ export function createAPI(fetchProjectData: () => Promise<RawData>) {
     const tagsByKey = getTagsByKey(rawTags, projects);
     const projectsBySlug: Data["projectsBySlug"] = {};
     projects.forEach((project) => {
-      projectsBySlug[getProjectId(project)] = project;
+      projectsBySlug[project.slug] = project;
     });
     const featuredProjectIds = getFeaturedRandomList(projects);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -361,9 +361,6 @@ importers:
       sharp:
         specifier: ^0.32.6
         version: 0.32.6
-      slugify:
-        specifier: ^1.6.6
-        version: 1.6.6
       swr:
         specifier: ^2.2.0
         version: 2.2.0(react@18.2.0)
@@ -12005,8 +12002,8 @@ snapshots:
       '@typescript-eslint/parser': 6.9.1(eslint@8.46.0)(typescript@5.5.4)
       eslint: 8.46.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1(eslint@8.46.0))(eslint@8.46.0)
-      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1(eslint@8.46.0))(eslint@8.46.0))(eslint@8.46.0)
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1)(eslint@8.46.0)
+      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.5.5)(eslint@8.46.0)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.46.0)
       eslint-plugin-react: 7.33.2(eslint@8.46.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.46.0)
@@ -12028,13 +12025,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1(eslint@8.46.0))(eslint@8.46.0):
+  eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1)(eslint@8.46.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.46.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1(eslint@8.46.0))(eslint@8.46.0))(eslint@8.46.0)
-      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1(eslint@8.46.0))(eslint@8.46.0))(eslint@8.46.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1)(eslint@8.46.0))(eslint@8.46.0)
+      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.5.5)(eslint@8.46.0)
       get-tsconfig: 4.6.2
       globby: 13.2.2
       is-core-module: 2.13.0
@@ -12046,18 +12043,18 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1(eslint@8.46.0))(eslint@8.46.0))(eslint@8.46.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1)(eslint@8.46.0))(eslint@8.46.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.9.1(eslint@8.46.0)(typescript@5.5.4)
       eslint: 8.46.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1(eslint@8.46.0))(eslint@8.46.0)
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1)(eslint@8.46.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.28.1(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1(eslint@8.46.0))(eslint@8.46.0))(eslint@8.46.0):
+  eslint-plugin-import@2.28.1(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.5.5)(eslint@8.46.0):
     dependencies:
       array-includes: 3.1.6
       array.prototype.findlastindex: 1.2.2
@@ -12067,7 +12064,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.46.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1(eslint@8.46.0))(eslint@8.46.0))(eslint@8.46.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1)(eslint@8.46.0))(eslint@8.46.0)
       has: 1.0.3
       is-core-module: 2.13.0
       is-glob: 4.0.3


### PR DESCRIPTION
## Goal

Instead of computing project's slugs (used to access project's details page `/projects/:slug` path) in the Next.js app, we should read it from the database, as we have a column `slug` in the `projects` column.

This PR adds `slug` data to the the JSON file built by `build-static-api` task.

