### PR TITLE
Exclude specific projects from rankings

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -26,6 +26,7 @@
     "debug": "^4.3.4",
     "dotenv-cli": "^7.4.2",
     "drizzle-orm": "^0.31.2",
+    "es-toolkit": "1.16.0-dev.477",
     "fs-extra": "^11.1.1",
     "p-map": "^7.0.2",
     "p-throttle": "^6.1.0",

--- a/apps/backend/src/tasks/build-static-api.task.ts
+++ b/apps/backend/src/tasks/build-static-api.task.ts
@@ -1,3 +1,5 @@
+import { orderBy } from "es-toolkit";
+
 import { schema } from "@repo/db";
 import {
   getPackageData,
@@ -72,7 +74,8 @@ export const buildStaticApiTask: Task = {
       // .map(compactProjectData); // we don't need the `version` in `projects.json`
 
       logger.info(
-        `${projects.length} projects to include in the main JSON file`
+        `${projects.length} projects to include in the main JSON file`,
+        { trendingToday: getDailyHotProjects(projects) }
       );
       const date = new Date();
 
@@ -137,6 +140,16 @@ function getYearsSinceLastCommit(project: ProjectItem) {
 
 const findProjectByTagId = (projects: ProjectItem[]) => (tagId: string) =>
   projects.find(({ tags }) => tags.includes(tagId));
+
+function getDailyHotProjects(projects: ProjectItem[]) {
+  return orderBy<ProjectItem>(
+    projects,
+    [(project) => project.trends.daily],
+    ["desc"]
+  )
+    .slice(0, 5)
+    .map((project) => `${project.name} (+${project.trends.daily})`);
+}
 
 function formatDate(date: Date | null) {
   return date ? date.toISOString().slice(0, 10) : "";

--- a/apps/backend/src/tasks/notify-daily.task.ts
+++ b/apps/backend/src/tasks/notify-daily.task.ts
@@ -46,8 +46,12 @@ async function fetchHottestProjects() {
   return topProjects;
 }
 
+/**
+ * Exclude from the rankings projects with specific tags
+ * TODO: move this behavior to the `tag` record, adding an attribute `exclude_from_rankings`?
+ **/
 const isIncludedInHotProjects = (project: ProjectItem) => {
-  const hotProjectsExcludedTags = ["meta", "learning"];
+  const hotProjectsExcludedTags = ["meta", "learning", "wildcard"];
 
   const hasExcludedTag = hotProjectsExcludedTags.some((tag) =>
     project.tags.includes(tag)

--- a/apps/bestofjs-nextjs/src/app/backend-search-requests.tsx
+++ b/apps/bestofjs-nextjs/src/app/backend-search-requests.tsx
@@ -1,7 +1,7 @@
 export function getHotProjectsRequest(count = 5) {
   return {
     criteria: {
-      tags: { $nin: ["meta", "learning"] },
+      tags: { $nin: ["meta", "learning", "wildcard"] },
     },
     sort: {
       "trends.daily": -1,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,9 @@ importers:
       drizzle-orm:
         specifier: ^0.31.2
         version: 0.31.2(@neondatabase/serverless@0.9.4)(@types/pg@8.11.6)(@types/react@18.2.18)(@vercel/postgres@0.9.0)(bun-types@1.1.17)(postgres@3.4.3)(react@18.2.0)
+      es-toolkit:
+        specifier: 1.16.0-dev.477
+        version: 1.16.0-dev.477
       fs-extra:
         specifier: ^11.1.1
         version: 11.1.1
@@ -4345,6 +4348,9 @@ packages:
   es-to-primitive@1.2.1:
     resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.16.0-dev.477:
+    resolution: {integrity: sha512-nH1boc3ktszKnneIecVOn1cHn9PoAstYAtb7V/7Njpv/xJrYjLBf+jWWHIsQkncFmIEi0ZKCSdylG2xE8vE1qw==}
 
   esbuild-android-64@0.15.18:
     resolution: {integrity: sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==}
@@ -11804,6 +11810,8 @@ snapshots:
       is-date-object: 1.0.5
       is-symbol: 1.0.4
 
+  es-toolkit@1.16.0-dev.477: {}
+
   esbuild-android-64@0.15.18:
     optional: true
 
@@ -12002,8 +12010,8 @@ snapshots:
       '@typescript-eslint/parser': 6.9.1(eslint@8.46.0)(typescript@5.5.4)
       eslint: 8.46.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1)(eslint@8.46.0)
-      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.5.5)(eslint@8.46.0)
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1(eslint@8.46.0))(eslint@8.46.0)
+      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1(eslint@8.46.0))(eslint@8.46.0))(eslint@8.46.0)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.46.0)
       eslint-plugin-react: 7.33.2(eslint@8.46.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.46.0)
@@ -12025,13 +12033,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1)(eslint@8.46.0):
+  eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1(eslint@8.46.0))(eslint@8.46.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.46.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1)(eslint@8.46.0))(eslint@8.46.0)
-      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.5.5)(eslint@8.46.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1(eslint@8.46.0))(eslint@8.46.0))(eslint@8.46.0)
+      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1(eslint@8.46.0))(eslint@8.46.0))(eslint@8.46.0)
       get-tsconfig: 4.6.2
       globby: 13.2.2
       is-core-module: 2.13.0
@@ -12043,18 +12051,18 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1)(eslint@8.46.0))(eslint@8.46.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1(eslint@8.46.0))(eslint@8.46.0))(eslint@8.46.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.9.1(eslint@8.46.0)(typescript@5.5.4)
       eslint: 8.46.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1)(eslint@8.46.0)
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1(eslint@8.46.0))(eslint@8.46.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.28.1(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.5.5)(eslint@8.46.0):
+  eslint-plugin-import@2.28.1(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1(eslint@8.46.0))(eslint@8.46.0))(eslint@8.46.0):
     dependencies:
       array-includes: 3.1.6
       array.prototype.findlastindex: 1.2.2
@@ -12064,7 +12072,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.46.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1)(eslint@8.46.0))(eslint@8.46.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@6.9.1(eslint@8.46.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.28.1(eslint@8.46.0))(eslint@8.46.0))(eslint@8.46.0)
       has: 1.0.3
       is-core-module: 2.13.0
       is-glob: 4.0.3


### PR DESCRIPTION
## Goal

Following discussions we had with @BBlackwo we'd like to promote some projects that don't match the usual criteria and we have created a new tag called "Editor's pick" whose defintion could be:

> Projects that don't match the usual criteria about being either written in a language that compile to JavaScript or a build tool that emits JavaScript, picked by Best of JS authors.

The discussion started with the request to add the 2 following projects:

- Coolify: https://github.com/michaelrambeau/bestofjs/issues/964
- Immich: https://github.com/michaelrambeau/bestofjs/issues/980

However we don't want these projects to show up in the home page "Today's hot projects" because they tend to be the hottest projects every day.

So we want to exclude them from the rankings (daily, monthly, and yearly in the _Rising Stars_), the same way we don't include the learning resources in the rankings.

## Screenshots

![image](https://github.com/user-attachments/assets/a6124966-08a3-4beb-bd05-82a402605b0b)

The tag's description, showing up when "hovering" the tag:

![image](https://github.com/user-attachments/assets/509b1f58-18bc-4966-9007-a4277e28271a)





