### PR TITLE
Migrate build monthly rankings task

### DIFF
--- a/apps/backend/src/cli.ts
+++ b/apps/backend/src/cli.ts
@@ -36,11 +36,12 @@ const staticApiDailyTask = command(
     flags: sharedFlags,
   },
   (argv) => {
-    const runner = createTaskRunner([
+    const tasks: Task<any>[] = [
       buildStaticApiTask,
       triggerBuildWebappTask,
       notifyDailyTask,
-    ]);
+    ];
+    const runner = createTaskRunner(tasks);
     runner.run(argv.flags);
   }
 );

--- a/apps/backend/src/cli.ts
+++ b/apps/backend/src/cli.ts
@@ -1,7 +1,8 @@
 import { cli, command } from "cleye";
 
-import { cliFlags as flags } from "./flags";
-import { Task, TaskRunner } from "./task-runner";
+import { cliFlags as sharedFlags } from "./flags";
+import { createTaskRunner, Task } from "./task-runner";
+import { buildMonthlyRankingsTask } from "./tasks/build-monthly-rankings";
 import { buildStaticApiTask } from "./tasks/build-static-api.task";
 import {
   helloWorldProjectsTask,
@@ -24,6 +25,7 @@ const commands = [
   helloWorldReposTask,
   updatePackageDataTask,
   updateBundleSizeTask,
+  buildMonthlyRankingsTask,
 ].map(getCommand);
 
 const staticApiDailyTask = command(
@@ -31,14 +33,15 @@ const staticApiDailyTask = command(
     name: "static-api-daily",
     description:
       "Build command on Vercel: build static API, trigger Next.js rebuild and send notification",
-    flags,
+    flags: sharedFlags,
   },
   (argv) => {
-    const runner = new TaskRunner(argv.flags);
-    runner.addTask(buildStaticApiTask);
-    runner.addTask(triggerBuildWebappTask);
-    runner.addTask(notifyDailyTask);
-    runner.run();
+    const runner = createTaskRunner([
+      buildStaticApiTask,
+      triggerBuildWebappTask,
+      notifyDailyTask,
+    ]);
+    runner.run(argv.flags);
   }
 );
 
@@ -47,19 +50,18 @@ cli({
   commands: [staticApiDailyTask, ...commands],
 });
 
-function getCommand(task: Task) {
+function getCommand(task: Task<any>) {
   return command(
     {
       name: task.name,
-      flags,
+      flags: { ...sharedFlags, ...task.flags },
       help: {
         description: task.description,
       },
     },
     (argv) => {
-      const runner = new TaskRunner(argv.flags);
-      runner.addTask(task);
-      runner.run();
+      const runner = createTaskRunner([task]);
+      runner.run(argv.flags);
     }
   );
 }

--- a/apps/backend/src/flags.ts
+++ b/apps/backend/src/flags.ts
@@ -1,4 +1,19 @@
-export const cliFlags = {
+import { Command } from "cleye";
+import { z } from "zod";
+
+export const sharedFlagsSchema = z.object({
+  concurrency: z.number().optional().default(1),
+  dryRun: z.boolean().optional().default(false),
+  logLevel: z.number().optional().default(3),
+  limit: z.number().optional().default(0),
+  skip: z.number().optional().default(0),
+  name: z.string().optional().default(""),
+  throttleInterval: z.number().optional().default(0),
+});
+
+export type ParsedFlags = z.infer<typeof sharedFlagsSchema>;
+
+export const cliFlags: Command["options"]["flags"] = {
   concurrency: {
     type: Number,
     default: 1,
@@ -27,9 +42,11 @@ export const cliFlags = {
   name: {
     type: String,
     description: "Full name of the GitHub repo to process",
+    default: "",
   },
   throttleInterval: {
     type: Number,
     description: "Throttle interval in milliseconds",
+    default: 0,
   },
 };

--- a/apps/backend/src/task-types.ts
+++ b/apps/backend/src/task-types.ts
@@ -1,20 +1,8 @@
 import { ConsolaInstance } from "consola";
 
 import { DB } from "@repo/db";
+import { ParsedFlags } from "./flags";
 import { ProjectProcessor, RepoProcessor } from "./iteration-helpers";
-
-/** Options passed from the command line as flags */
-export type TaskRunInputParams = {
-  concurrency?: number;
-  dryRun?: boolean;
-  limit?: number;
-  skip?: number;
-  logLevel?: number;
-  name?: string;
-  throttleInterval?: number;
-};
-
-export type TaskRunParams = Required<TaskRunInputParams>;
 
 export interface TaskRunnerContext {
   logger: ConsolaInstance;
@@ -30,6 +18,6 @@ export interface TaskContext extends TaskRunnerContext {
 }
 
 export type TaskLoopOptions = Pick<
-  TaskRunParams,
+  ParsedFlags,
   "concurrency" | "limit" | "skip" | "name" | "throttleInterval"
 >;

--- a/apps/backend/src/tasks/build-monthly-rankings.ts
+++ b/apps/backend/src/tasks/build-monthly-rankings.ts
@@ -1,12 +1,19 @@
+import { orderBy, round } from "es-toolkit";
 import { z } from "zod";
 
+import {
+  flattenSnapshots,
+  getProjectDescription,
+  isProjectIncludeInRankings,
+} from "@repo/db/projects";
+import { getMonthlyDelta } from "@repo/db/snapshots";
 import { Task } from "@/task-runner";
 
 const schema = z.object({ year: z.number(), month: z.number() });
 
 export const buildMonthlyRankingsTask: Task<z.infer<typeof schema>> = {
   name: "build-monthly-rankings",
-  description: "Build monthly rankings",
+  description: "Build monthly rankings to be displayed on the frontend",
   flags: {
     year: {
       type: Number,
@@ -19,9 +26,82 @@ export const buildMonthlyRankingsTask: Task<z.infer<typeof schema>> = {
   },
   schema,
 
-  async run(_, flags) {
-    console.log("Building monthly rankings...", flags);
+  async run(context, flags) {
+    const { logger, processProjects, saveJSON } = context;
+    const { year, month } = flags;
 
-    return { data: null, meta: { success: true } };
+    const results = await processProjects(async (project) => {
+      const repo = project.repo;
+
+      if (!repo) throw new Error("No repo found");
+      if (!repo.snapshots?.length)
+        return { data: null, meta: { "no snapshots": true } };
+
+      const stars = repo.stars || 0;
+      const flattenedSnapshots = flattenSnapshots(repo.snapshots);
+      const delta = getMonthlyDelta(flattenedSnapshots, { year, month });
+
+      if (delta === undefined) {
+        return { data: null, meta: { "not enough snapshots": true } };
+      }
+      if (!isProjectIncludeInRankings(project)) {
+        return { data: null, meta: { excluded: true } };
+      }
+
+      const relativeGrowth = delta ? delta / (stars - delta) : undefined;
+
+      const data = {
+        name: project.name,
+        full_name: repo.full_name,
+        description: getProjectDescription(project),
+        stars,
+        delta,
+        relativeGrowth:
+          relativeGrowth !== undefined ? round(relativeGrowth, 4) : null,
+        tags: project.tags.map((tag) => tag.code),
+        owner_id: repo.owner_id,
+        created_at: repo.created_at,
+      };
+      return { data, meta: { success: true } };
+    });
+
+    const projects = results.data.filter((project) => project !== null);
+
+    const trending = orderBy(
+      projects.filter((project) => project !== null),
+      ["delta"],
+      ["desc"]
+    ).slice(0, 100);
+
+    const byRelativeGrowth = orderBy(
+      projects,
+      ["relativeGrowth"],
+      ["desc"]
+    ).slice(0, 100);
+
+    const output = {
+      year,
+      month,
+      isFirst: false,
+      isLatest: true,
+      trending,
+      byRelativeGrowth,
+    };
+
+    logger.info("Rankings summary", {
+      trending: trending
+        .slice(0, 5)
+        .map((project) => `${project.name} (+${project.delta})`),
+      relative: byRelativeGrowth
+        .slice(0, 5)
+        .map((project) => `${project.name} (${project.relativeGrowth})`),
+    });
+    await saveJSON(output, `monthly/${year}/${formatDate(year, month)}.json`);
+
+    return results;
   },
 };
+
+function formatDate(year: number, month: number) {
+  return `${year}-${month.toString().padStart(2, "0")}`;
+}

--- a/apps/backend/src/tasks/build-monthly-rankings.ts
+++ b/apps/backend/src/tasks/build-monthly-rankings.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+import { Task } from "@/task-runner";
+
+const schema = z.object({ year: z.number(), month: z.number() });
+
+export const buildMonthlyRankingsTask: Task<z.infer<typeof schema>> = {
+  name: "build-monthly-rankings",
+  description: "Build monthly rankings",
+  flags: {
+    year: {
+      type: Number,
+      description: "Year to build rankings for",
+    },
+    month: {
+      type: Number,
+      description: "Month to build rankings for",
+    },
+  },
+  schema,
+
+  async run(_, flags) {
+    console.log("Building monthly rankings...", flags);
+
+    return { data: null, meta: { success: true } };
+  },
+};

--- a/apps/backend/src/tasks/build-monthly-rankings.ts
+++ b/apps/backend/src/tasks/build-monthly-rankings.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import {
   flattenSnapshots,
   getProjectDescription,
-  isProjectIncludeInRankings,
+  isProjectIncludedInRankings,
 } from "@repo/db/projects";
 import { getMonthlyDelta } from "@repo/db/snapshots";
 import { Task } from "@/task-runner";
@@ -44,7 +44,7 @@ export const buildMonthlyRankingsTask: Task<z.infer<typeof schema>> = {
       if (delta === undefined) {
         return { data: null, meta: { "not enough snapshots": true } };
       }
-      if (!isProjectIncludeInRankings(project)) {
+      if (!isProjectIncludedInRankings(project)) {
         return { data: null, meta: { excluded: true } };
       }
 

--- a/apps/backend/src/tasks/notify-daily.task.ts
+++ b/apps/backend/src/tasks/notify-daily.task.ts
@@ -2,7 +2,7 @@ import path from "path";
 import debugPackage from "debug";
 import fs from "fs-extra";
 
-import { TAGS_EXCLUDED_FROM_RANKINGS } from "@repo/db/projects";
+import { TAGS_EXCLUDED_FROM_RANKINGS } from "@repo/db/constants";
 import { Task } from "@/task-runner";
 import { ProjectItem } from "./static-api-types";
 

--- a/apps/backend/src/tasks/notify-daily.task.ts
+++ b/apps/backend/src/tasks/notify-daily.task.ts
@@ -2,6 +2,7 @@ import path from "path";
 import debugPackage from "debug";
 import fs from "fs-extra";
 
+import { TAGS_EXCLUDED_FROM_RANKINGS } from "@repo/db/projects";
 import { Task } from "@/task-runner";
 import { ProjectItem } from "./static-api-types";
 
@@ -51,9 +52,7 @@ async function fetchHottestProjects() {
  * TODO: move this behavior to the `tag` record, adding an attribute `exclude_from_rankings`?
  **/
 const isIncludedInHotProjects = (project: ProjectItem) => {
-  const hotProjectsExcludedTags = ["meta", "learning", "wildcard"];
-
-  const hasExcludedTag = hotProjectsExcludedTags.some((tag) =>
+  const hasExcludedTag = TAGS_EXCLUDED_FROM_RANKINGS.some((tag) =>
     project.tags.includes(tag)
   );
   return !hasExcludedTag;

--- a/apps/bestofjs-nextjs/src/app/backend-search-requests.tsx
+++ b/apps/bestofjs-nextjs/src/app/backend-search-requests.tsx
@@ -1,4 +1,4 @@
-import { TAGS_EXCLUDED_FROM_RANKINGS } from "@repo/db/projects";
+import { TAGS_EXCLUDED_FROM_RANKINGS } from "@repo/db/constants";
 
 export function getHotProjectsRequest(count = 5) {
   return {

--- a/apps/bestofjs-nextjs/src/app/backend-search-requests.tsx
+++ b/apps/bestofjs-nextjs/src/app/backend-search-requests.tsx
@@ -1,7 +1,9 @@
+import { TAGS_EXCLUDED_FROM_RANKINGS } from "@repo/db/projects";
+
 export function getHotProjectsRequest(count = 5) {
   return {
     criteria: {
-      tags: { $nin: ["meta", "learning", "wildcard"] },
+      tags: { $nin: TAGS_EXCLUDED_FROM_RANKINGS },
     },
     sort: {
       "trends.daily": -1,

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -13,6 +13,7 @@
   },
   "exports": {
     ".": "./src/index.ts",
+    "./constants": "./src/constants.ts",
     "./projects": "./src/projects/index.ts",
     "./github": "./src/github/index.ts",
     "./snapshots": "./src/snapshots/index.ts",

--- a/packages/db/src/constants.ts
+++ b/packages/db/src/constants.ts
@@ -1,0 +1,1 @@
+export const TAGS_EXCLUDED_FROM_RANKINGS = ["meta", "learning", "wildcard"];

--- a/packages/db/src/projects/project-helpers.ts
+++ b/packages/db/src/projects/project-helpers.ts
@@ -33,7 +33,7 @@ export function getProjectMonthlyTrends(
   return getMonthlyTrends(flattenedSnapshots, date || new Date());
 }
 
-function flattenSnapshots(records: OneYearSnapshots[]) {
+export function flattenSnapshots(records: OneYearSnapshots[]) {
   // return orderBy(records, (record) => record.year, "desc") // most recent first
   return records.flatMap(({ year, months }) =>
     months.flatMap(({ month, snapshots }) =>
@@ -70,4 +70,17 @@ export function getPackageData(project: ProjectDetails) {
         downloads: firstPackage?.monthlyDownloads as number,
       }
     : null;
+}
+
+/**
+ * Exclude from the rankings projects with specific tags
+ * TODO: move this behavior to the `tag` record, adding an attribute `exclude_from_rankings`?
+ **/
+export function isProjectIncludeInRankings(project: ProjectDetails) {
+  const excludedTags = ["meta", "learning", "wildcard"];
+
+  const hasExcludedTag = excludedTags.some((tagCode) =>
+    project.tags.map((tag) => tag.code).includes(tagCode)
+  );
+  return !hasExcludedTag;
 }

--- a/packages/db/src/projects/project-helpers.ts
+++ b/packages/db/src/projects/project-helpers.ts
@@ -4,6 +4,8 @@ import invariant from "tiny-invariant";
 import { OneYearSnapshots, ProjectDetails } from ".";
 import { computeTrends, getMonthlyTrends } from "../snapshots/index";
 
+export const TAGS_EXCLUDED_FROM_RANKINGS = ["meta", "learning", "wildcard"];
+
 export function getProjectDescription(project: ProjectDetails) {
   invariant(project.repo);
   const repoDescription = project.repo.description;
@@ -76,10 +78,8 @@ export function getPackageData(project: ProjectDetails) {
  * Exclude from the rankings projects with specific tags
  * TODO: move this behavior to the `tag` record, adding an attribute `exclude_from_rankings`?
  **/
-export function isProjectIncludeInRankings(project: ProjectDetails) {
-  const excludedTags = ["meta", "learning", "wildcard"];
-
-  const hasExcludedTag = excludedTags.some((tagCode) =>
+export function isProjectIncludedInRankings(project: ProjectDetails) {
+  const hasExcludedTag = TAGS_EXCLUDED_FROM_RANKINGS.some((tagCode) =>
     project.tags.map((tag) => tag.code).includes(tagCode)
   );
   return !hasExcludedTag;

--- a/packages/db/src/projects/project-helpers.ts
+++ b/packages/db/src/projects/project-helpers.ts
@@ -2,9 +2,8 @@ import isAbsoluteURL from "is-absolute-url";
 import invariant from "tiny-invariant";
 
 import { OneYearSnapshots, ProjectDetails } from ".";
+import { TAGS_EXCLUDED_FROM_RANKINGS } from "../constants";
 import { computeTrends, getMonthlyTrends } from "../snapshots/index";
-
-export const TAGS_EXCLUDED_FROM_RANKINGS = ["meta", "learning", "wildcard"];
 
 export function getProjectDescription(project: ProjectDetails) {
   invariant(project.repo);


### PR DESCRIPTION
## Goal

- As part of the migration to the new backend powered by the Postgres database, add the task to generate the monthly rankings hosted on https://github.com/bestofjs/bestofjs-rankings
- Refactor the `TaskRunner` used to run scripts, adding CLI flags that can be used for specific tasks. For example the new tasks `build-monthly-rankings` accepts 2 specific flags: `--year` and `--month`
- Refactor (DRY) setup excluded tags from rankings in one place (handing TODO from https://github.com/bestofjs/bestofjs/pull/305)

TODO: there is redundant code to write to specify the new extra flags as we use a Zod schema to validation, in addition of adding flags definition to the CLI script (built on top of https://github.com/privatenumber/cleye)

```ts
const schema = z.object({ year: z.number(), month: z.number() });

export const buildMonthlyRankingsTask: Task<z.infer<typeof schema>> = {
  name: "build-monthly-rankings",
  description: "Build monthly rankings to be displayed on the frontend",
  flags: {
    year: {
      type: Number,
      description: "Year to build rankings for",
    },
    month: {
      type: Number,
      description: "Month to build rankings for",
    },
  },
  schema,

  async run(context, flags) {
    const { logger, processProjects, saveJSON } = context;
    const { year, month } = flags;
  }
}    
```

## How to test

Script to run locally:

```sh
bun run apps/backend/src/cli.ts build-monthly-rankings --year 2024 --month 9   
```

It will generate a file: `apps/backend/build/monthly/2024/2024-09.json` 

## Screenshots

![image](https://github.com/user-attachments/assets/a8a6b704-45d4-4132-aa5d-de41dea419ad)

