### PR TITLE
Feat(admin) Allow multiple projects linked to a single repository

### DIFF
--- a/apps/admin/src/app/projects/[slug]/edit/add-package-button.tsx
+++ b/apps/admin/src/app/projects/[slug]/edit/add-package-button.tsx
@@ -67,7 +67,7 @@ export function AddPackageButton({ project }: Props) {
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogTrigger asChild>
           <Button variant="default">
-            <PlusIcon />
+            <PlusIcon className="h-4 w-4" />
             Add Package
           </Button>
         </DialogTrigger>

--- a/apps/admin/src/app/projects/[slug]/page.tsx
+++ b/apps/admin/src/app/projects/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { ProjectLogo } from "@/components/project-logo";
 import { projectService } from "@/db";
 import { ViewProjectPackages } from "./view-packages";
 import { ViewProject } from "./view-project";
+import { ViewRelatedProjects } from "./view-related-projects";
 import { ViewRepo } from "./view-repo";
 import { ViewSnapshots } from "./view-snapshots";
 import { ViewTags } from "./view-tags";
@@ -43,7 +44,14 @@ export default async function ViewProjectPage({ params: { slug } }: PageProps) {
       </div>
       <ViewProject project={project} />
       <ViewTags project={project} allTags={allTags} />
-      {project.repo ? <ViewRepo repo={project.repo} /> : <>No repository!</>}
+      {project.repo ? (
+        <>
+          <ViewRepo repo={project.repo} />
+          <ViewRelatedProjects project={project} />
+        </>
+      ) : (
+        <>No repository!</>
+      )}
       <ViewTrends snapshots={repo.snapshots} />
       <ViewProjectPackages project={project} />
       {project.repo && (

--- a/apps/admin/src/app/projects/[slug]/page.tsx
+++ b/apps/admin/src/app/projects/[slug]/page.tsx
@@ -5,11 +5,9 @@ import { ProjectLogo } from "@/components/project-logo";
 import { projectService } from "@/db";
 import { ViewProjectPackages } from "./view-packages";
 import { ViewProject } from "./view-project";
-import { ViewRelatedProjects } from "./view-related-projects";
 import { ViewRepo } from "./view-repo";
 import { ViewSnapshots } from "./view-snapshots";
 import { ViewTags } from "./view-tags";
-import { ViewTrends } from "./view-trends";
 
 type PageProps = {
   params: {
@@ -44,15 +42,7 @@ export default async function ViewProjectPage({ params: { slug } }: PageProps) {
       </div>
       <ViewProject project={project} />
       <ViewTags project={project} allTags={allTags} />
-      {project.repo ? (
-        <>
-          <ViewRepo repo={project.repo} />
-          <ViewRelatedProjects project={project} />
-        </>
-      ) : (
-        <>No repository!</>
-      )}
-      <ViewTrends snapshots={repo.snapshots} />
+      {project.repo ? <ViewRepo project={project} /> : <>No repository!</>}
       <ViewProjectPackages project={project} />
       {project.repo && (
         <ViewSnapshots

--- a/apps/admin/src/app/projects/[slug]/view-related-projects.tsx
+++ b/apps/admin/src/app/projects/[slug]/view-related-projects.tsx
@@ -31,7 +31,7 @@ async function MonorepoProjectsCard({ project }: Props) {
     <Card>
       <CardHeader>
         <div className="flex justify-between">
-          <CardTitle>Other projects from the repo</CardTitle>
+          <CardTitle>Other projects linked to the repo</CardTitle>
           <div>
             <AddProjectToRepoButton repoId={project.repoId} />
           </div>
@@ -86,7 +86,7 @@ async function findProjectsByOwner(owner: string) {
 
 type RelatedProject = Pick<
   typeof schema.projects.$inferSelect,
-  "slug" | "name" | "description"
+  "slug" | "name" | "description" | "createdAt"
 > & { tags: string[] };
 
 /** A variation of the `ProjectTable` component, specific to the context of a given repo */
@@ -96,12 +96,10 @@ function CompactProjectList({ projects }: { projects: RelatedProject[] }) {
       <TableBody>
         {projects.map((project) => (
           <TableRow key={project.slug}>
-            <TableCell>
+            <TableCell className="flex flex-col gap-4">
               <a href={`/projects/${project.slug}`} className="hover:underline">
                 {project.name}
               </a>
-            </TableCell>
-            <TableCell className="flex flex-col gap-4">
               <div>{project.description}</div>
               <div className="flex flex-wrap gap-2">
                 {project.tags.map((tag) => (
@@ -115,7 +113,9 @@ function CompactProjectList({ projects }: { projects: RelatedProject[] }) {
                 ))}
               </div>
             </TableCell>
-            <TableCell></TableCell>
+            <TableCell className="w-48">
+              Added: {project.createdAt.toISOString().slice(0, 10)}
+            </TableCell>
           </TableRow>
         ))}
       </TableBody>

--- a/apps/admin/src/app/projects/[slug]/view-related-projects.tsx
+++ b/apps/admin/src/app/projects/[slug]/view-related-projects.tsx
@@ -1,0 +1,124 @@
+import { schema } from "@repo/db";
+import { findProjects, ProjectDetails } from "@repo/db/projects";
+import { AddProjectToRepoButton } from "@/components/add-project-to-repo-button";
+import { ProjectTable } from "@/components/project-table";
+import { badgeVariants } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
+import { projectService } from "@/db";
+
+type Props = {
+  project: ProjectDetails;
+};
+
+export async function ViewRelatedProjects({ project }: Props) {
+  return (
+    <>
+      <MonorepoProjectsCard project={project} />
+      <SameOwnerProjectsCard project={project} />
+    </>
+  );
+}
+
+async function MonorepoProjectsCard({ project }: Props) {
+  const projectsInSameRepo = await projectService.findProjectsByRepoId(
+    project.repoId
+  );
+  const relatedProjects = projectsInSameRepo.filter(
+    (foundProject) => foundProject.id !== project.id
+  );
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex justify-between">
+          <CardTitle>Other projects from the repo</CardTitle>
+          <div>
+            <AddProjectToRepoButton repoId={project.repoId} />
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <div>
+          {relatedProjects.length === 0 ? (
+            <i>No related projects</i>
+          ) : (
+            <CompactProjectList projects={relatedProjects} />
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+async function SameOwnerProjectsCard({ project }: Props) {
+  const owner = project.repo.full_name.split("/")[0];
+  const projectsFromSameOwner = await findProjectsByOwner(owner);
+  const otherProjects = projectsFromSameOwner.filter(
+    (foundProject) => foundProject.slug !== project.slug
+  );
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          Other projects from <i>{owner}</i>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {otherProjects.length === 0 ? (
+          <i>No other projects from {owner}</i>
+        ) : (
+          <ProjectTable projects={otherProjects} />
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+async function findProjectsByOwner(owner: string) {
+  return await findProjects({
+    db: projectService.db,
+    owner,
+    sort: "-stars",
+    limit: 0,
+    offset: 0,
+  });
+}
+
+type RelatedProject = Pick<
+  typeof schema.projects.$inferSelect,
+  "slug" | "name" | "description"
+> & { tags: string[] };
+
+/** A variation of the `ProjectTable` component, specific to the context of a given repo */
+function CompactProjectList({ projects }: { projects: RelatedProject[] }) {
+  return (
+    <Table>
+      <TableBody>
+        {projects.map((project) => (
+          <TableRow key={project.slug}>
+            <TableCell>
+              <a href={`/projects/${project.slug}`} className="hover:underline">
+                {project.name}
+              </a>
+            </TableCell>
+            <TableCell className="flex flex-col gap-4">
+              <div>{project.description}</div>
+              <div className="flex flex-wrap gap-2">
+                {project.tags.map((tag) => (
+                  <a
+                    href={`/projects/?tag=${tag}`}
+                    className={badgeVariants({ variant: "secondary" })}
+                    key={tag}
+                  >
+                    {tag}
+                  </a>
+                ))}
+              </div>
+            </TableCell>
+            <TableCell></TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/apps/admin/src/app/projects/[slug]/view-related-projects.tsx
+++ b/apps/admin/src/app/projects/[slug]/view-related-projects.tsx
@@ -1,7 +1,6 @@
 import { findProjects, ProjectDetails } from "@repo/db/projects";
 import { AddProjectToRepoButton } from "@/components/add-project-to-repo-button";
 import { ProjectTable } from "@/components/project-table";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { projectService } from "@/db";
 
 type Props = {
@@ -25,25 +24,21 @@ async function MonorepoProjectsCard({ project }: Props) {
     (foundProject) => foundProject.slug !== project.slug
   );
   return (
-    <Card>
-      <CardHeader>
-        <div className="flex justify-between">
-          <CardTitle>Other projects linked to the repo</CardTitle>
-          <div>
-            <AddProjectToRepoButton repoId={project.repoId} />
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent className="flex flex-col gap-4">
+    <div>
+      <div className="flex justify-between">
+        <h3 className="text-lg font-bold">Other projects linked to the repo</h3>
         <div>
-          {relatedProjects.length === 0 ? (
-            <i>No related projects</i>
-          ) : (
-            <ProjectTable projects={relatedProjects} />
-          )}
+          <AddProjectToRepoButton repoId={project.repoId} />
         </div>
-      </CardContent>
-    </Card>
+      </div>
+      <div className="flex flex-col gap-4">
+        {relatedProjects.length === 0 ? (
+          <i>No related projects</i>
+        ) : (
+          <ProjectTable projects={relatedProjects} />
+        )}
+      </div>
+    </div>
   );
 }
 
@@ -54,20 +49,18 @@ async function SameOwnerProjectsCard({ project }: Props) {
     (foundProject) => foundProject.repo?.full_name !== project.repo.full_name
   );
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>
-          Other projects from <i>{owner}</i>
-        </CardTitle>
-      </CardHeader>
-      <CardContent>
+    <div>
+      <h3 className="text-lg font-bold">
+        Other projects from <i>{owner}</i>
+      </h3>
+      <div>
         {otherProjects.length === 0 ? (
           <i>No other projects from {owner}</i>
         ) : (
           <ProjectTable projects={otherProjects} />
         )}
-      </CardContent>
-    </Card>
+      </div>
+    </div>
   );
 }
 

--- a/apps/admin/src/app/projects/[slug]/view-related-projects.tsx
+++ b/apps/admin/src/app/projects/[slug]/view-related-projects.tsx
@@ -10,13 +10,13 @@ type Props = {
 export async function ViewRelatedProjects({ project }: Props) {
   return (
     <>
-      <MonorepoProjectsCard project={project} />
-      <SameOwnerProjectsCard project={project} />
+      <SameRepoOtherProjectsSection project={project} />
+      <SameOwnerOtherProjectsSection project={project} />
     </>
   );
 }
 
-async function MonorepoProjectsCard({ project }: Props) {
+async function SameRepoOtherProjectsSection({ project }: Props) {
   const projectsInSameRepo = await findProjectsByFullName(
     project.repo.full_name
   );
@@ -24,7 +24,7 @@ async function MonorepoProjectsCard({ project }: Props) {
     (foundProject) => foundProject.slug !== project.slug
   );
   return (
-    <div>
+    <section>
       <div className="flex justify-between">
         <h3 className="text-lg font-bold">Other projects linked to the repo</h3>
         <div>
@@ -38,18 +38,18 @@ async function MonorepoProjectsCard({ project }: Props) {
           <ProjectTable projects={relatedProjects} />
         )}
       </div>
-    </div>
+    </section>
   );
 }
 
-async function SameOwnerProjectsCard({ project }: Props) {
+async function SameOwnerOtherProjectsSection({ project }: Props) {
   const owner = project.repo.full_name.split("/")[0];
   const projectsFromSameOwner = await findProjectsByOwner(owner);
   const otherProjects = projectsFromSameOwner.filter(
     (foundProject) => foundProject.repo?.full_name !== project.repo.full_name
   );
   return (
-    <div>
+    <section>
       <h3 className="text-lg font-bold">
         Other projects from <i>{owner}</i>
       </h3>
@@ -60,7 +60,7 @@ async function SameOwnerProjectsCard({ project }: Props) {
           <ProjectTable projects={otherProjects} />
         )}
       </div>
-    </div>
+    </section>
   );
 }
 

--- a/apps/admin/src/app/projects/[slug]/view-repo.tsx
+++ b/apps/admin/src/app/projects/[slug]/view-repo.tsx
@@ -1,4 +1,5 @@
 import { schema } from "@repo/db";
+import { ProjectDetails } from "@repo/db/projects";
 import { Badge } from "@/components/ui/badge";
 import {
   Card,
@@ -7,12 +8,16 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
 import { formatDateOnly, formatStars } from "@/lib/format-helpers";
+import { ViewRelatedProjects } from "./view-related-projects";
+import { ViewTrends } from "./view-trends";
 
 type Props = {
-  repo: typeof schema.repos.$inferSelect;
+  project: ProjectDetails;
 };
-export function ViewRepo({ repo }: Props) {
+export function ViewRepo({ project }: Props) {
+  const repo = project.repo;
   return (
     <Card>
       <CardHeader>
@@ -32,38 +37,50 @@ export function ViewRepo({ repo }: Props) {
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <div className="grid grid-cols-[200px_1fr] gap-4">
-          <p>Full Name</p>
-          <p>
-            <a
-              href={`https://github.com/${repo.full_name}`}
-              className="hover:underline"
-            >
-              {repo.full_name}
-            </a>
-          </p>
-          <p>Description</p>
-          <p>{repo.description}</p>
-          <p>Homepage</p>
-          <p>
-            {repo.homepage ? (
-              <a href={repo.homepage} className="hover:underline">
-                {repo.homepage}
-              </a>
-            ) : (
-              <i className="text-muted-foreground">No homepage</i>
-            )}
-          </p>
-          <p>Created</p>
-          <p>{formatDateOnly(repo.created_at)}</p>
-          <p>Pushed at</p>
-          <p>{formatDateOnly(repo.pushed_at)}</p>
-          <p>Commit count</p>
-          <p>{repo.commit_count}</p>
-          <p>Contributors</p>
-          <p>{repo.contributor_count}</p>
+        <div className="flex flex-col gap-6">
+          <ViewRepoData repo={repo} />
+          <Separator />
+          <ViewTrends snapshots={repo.snapshots} />
+          <Separator />
+          <ViewRelatedProjects project={project} />
         </div>
       </CardContent>
     </Card>
+  );
+}
+
+function ViewRepoData({ repo }: { repo: typeof schema.repos.$inferSelect }) {
+  return (
+    <div className="grid grid-cols-[200px_1fr] gap-4">
+      <p>Full Name</p>
+      <p>
+        <a
+          href={`https://github.com/${repo.full_name}`}
+          className="hover:underline"
+        >
+          {repo.full_name}
+        </a>
+      </p>
+      <p>Description</p>
+      <p>{repo.description}</p>
+      <p>Homepage</p>
+      <p>
+        {repo.homepage ? (
+          <a href={repo.homepage} className="hover:underline">
+            {repo.homepage}
+          </a>
+        ) : (
+          <i className="text-muted-foreground">No homepage</i>
+        )}
+      </p>
+      <p>Created</p>
+      <p>{formatDateOnly(repo.created_at)}</p>
+      <p>Pushed at</p>
+      <p>{formatDateOnly(repo.pushed_at)}</p>
+      <p>Commit count</p>
+      <p>{repo.commit_count}</p>
+      <p>Contributors</p>
+      <p>{repo.contributor_count}</p>
+    </div>
   );
 }

--- a/apps/admin/src/app/projects/[slug]/view-repo.tsx
+++ b/apps/admin/src/app/projects/[slug]/view-repo.tsx
@@ -1,4 +1,5 @@
 import { schema } from "@repo/db";
+import { Badge } from "@/components/ui/badge";
 import {
   Card,
   CardContent,
@@ -16,7 +17,14 @@ export function ViewRepo({ repo }: Props) {
     <Card>
       <CardHeader>
         <CardTitle className="flex justify-between">
-          <div>GitHub Repository</div>
+          <div>
+            GitHub Repository
+            {repo.archived && (
+              <Badge variant="destructive" className="ml-2 text-lg">
+                Archived
+              </Badge>
+            )}
+          </div>
           <div>{formatStars(repo.stars)}</div>
         </CardTitle>
         <CardDescription>
@@ -39,7 +47,9 @@ export function ViewRepo({ repo }: Props) {
           <p>Homepage</p>
           <p>
             {repo.homepage ? (
-              <a href={repo.homepage}>{repo.homepage}</a>
+              <a href={repo.homepage} className="hover:underline">
+                {repo.homepage}
+              </a>
             ) : (
               <i className="text-muted-foreground">No homepage</i>
             )}

--- a/apps/admin/src/app/projects/[slug]/view-trends.tsx
+++ b/apps/admin/src/app/projects/[slug]/view-trends.tsx
@@ -1,5 +1,4 @@
 import { getProjectTrends, OneYearSnapshots } from "@repo/db/projects";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { formatStars } from "@/lib/format-helpers";
 
 type Props = {
@@ -9,22 +8,18 @@ export function ViewTrends({ snapshots }: Props) {
   const trends = getProjectTrends(snapshots);
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Trends</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="grid grid-cols-2 gap-4">
-          <label>Today</label>
-          <div>{trends.daily ? formatStars(trends.daily) : "-"}</div>
-          <label>This week</label>
-          <div>{trends.weekly ? formatStars(trends.weekly) : "-"}</div>
-          <label>This month</label>
-          <div>{trends.monthly ? formatStars(trends.monthly) : "-"}</div>
-          <label>This year</label>
-          <div>{trends.yearly ? formatStars(trends.yearly) : "-"}</div>
-        </div>
-      </CardContent>
-    </Card>
+    <div>
+      <div className="mb-4 text-lg font-bold">Trends</div>
+      <div className="grid grid-cols-4 gap-2">
+        <label>Today</label>
+        <label>This week</label>
+        <label>This month</label>
+        <label>This year</label>
+        <div>{trends.daily ? formatStars(trends.daily) : "-"}</div>
+        <div>{trends.weekly ? formatStars(trends.weekly) : "-"}</div>
+        <div>{trends.monthly ? formatStars(trends.monthly) : "-"}</div>
+        <div>{trends.yearly ? formatStars(trends.yearly) : "-"}</div>
+      </div>
+    </div>
   );
 }

--- a/apps/admin/src/app/projects/actions.tsx
+++ b/apps/admin/src/app/projects/actions.tsx
@@ -1,5 +1,8 @@
 "use server";
 
+// The only purpose of this file is to export server actions we can include from client components to avoid the error:
+// > It is not allowed to define inline "use server" annotated Server Actions in Client Components.
+// > To use Server Actions in a Client Component, you can either export them from a separate file with "use server" at the top, or pass them down through props from a Server Component."
 import { addProjectToRepo, createProject } from "@repo/db/projects";
 
 export async function createProjectAction(gitHubURL: string) {

--- a/apps/admin/src/app/projects/actions.tsx
+++ b/apps/admin/src/app/projects/actions.tsx
@@ -1,8 +1,21 @@
 "use server";
 
-import { createProject } from "@repo/db/projects";
+import { addProjectToRepo, createProject } from "@repo/db/projects";
 
 export async function createProjectAction(gitHubURL: string) {
   const project = await createProject(gitHubURL);
+  return project;
+}
+
+export async function addProjectToRepoAction({
+  name,
+  description,
+  repoId,
+}: {
+  name: string;
+  description: string;
+  repoId: string;
+}) {
+  const project = await addProjectToRepo({ name, description, repoId });
   return project;
 }

--- a/apps/admin/src/app/projects/page.tsx
+++ b/apps/admin/src/app/projects/page.tsx
@@ -8,18 +8,9 @@ import {
   ProjectListOrderByKey,
 } from "@repo/db/projects";
 import { AddProjectButton } from "@/components/add-project-button";
-import { ProjectLogo } from "@/components/project-logo";
-import { Badge, badgeVariants } from "@/components/ui/badge";
+import { ProjectTable } from "@/components/project-table";
+import { Badge } from "@/components/ui/badge";
 import { buttonVariants } from "@/components/ui/button";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import { formatStars } from "@/lib/format-helpers";
 import { ProjectTablePagination } from "./project-table-pagination";
 import { SearchBox } from "./search-box";
 import { searchSchema } from "./search-schema";
@@ -105,67 +96,7 @@ function PaginatedProjectTable({
         />
       </div>
 
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead className="w-[100px]">Logo</TableHead>
-            <TableHead>Name</TableHead>
-            <TableHead>Added at</TableHead>
-            <TableHead>GitHub</TableHead>
-            <TableHead>Packages</TableHead>
-            <TableHead className="text-right">Stars</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {projects.map((project) => (
-            <TableRow key={project.slug}>
-              <TableCell>
-                <ProjectLogo project={project} size={50} />
-              </TableCell>
-              <TableCell>
-                <div className="flex flex-col gap-4">
-                  <Link href={`/projects/${project.slug}`}>{project.name}</Link>
-                  <span className="text-muted-foreground">
-                    {project.description}
-                  </span>
-                  {project.comments && <div>{project.comments}</div>}
-                  <div className="flex flex-wrap gap-2">
-                    {project.tags.map((tag) => (
-                      <a
-                        href={`/projects/?tag=${tag}`}
-                        className={badgeVariants({ variant: "secondary" })}
-                        key={tag}
-                      >
-                        {tag}
-                      </a>
-                    ))}
-                  </div>
-                </div>
-              </TableCell>
-              <TableCell>
-                {project.createdAt.toISOString().slice(0, 10)}
-              </TableCell>
-              <TableCell>{project.repo?.full_name || "No repo"}</TableCell>
-              <TableCell>
-                {project.packages ? (
-                  <div className="flex flex-col gap-4">
-                    {project.packages.map((pkg) => (
-                      <div key={pkg}>{pkg}</div>
-                    ))}
-                  </div>
-                ) : (
-                  <span className="text-muted-foreground italic">
-                    No package
-                  </span>
-                )}
-              </TableCell>
-              <TableCell className="text-right">
-                {formatStars(project.stars)}
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+      <ProjectTable projects={projects} />
 
       <ProjectTablePagination
         offset={offset}

--- a/apps/admin/src/components/add-project-to-repo-button.tsx
+++ b/apps/admin/src/components/add-project-to-repo-button.tsx
@@ -10,10 +10,7 @@ import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 
-import {
-  addProjectToRepoAction,
-  createProjectAction,
-} from "@/app/projects/actions";
+import { addProjectToRepoAction } from "@/app/projects/actions";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,

--- a/apps/admin/src/components/add-project-to-repo-button.tsx
+++ b/apps/admin/src/components/add-project-to-repo-button.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { DialogDescription } from "@radix-ui/react-dialog";
+import { ReloadIcon } from "@radix-ui/react-icons";
+import { Plus } from "lucide-react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+
+import {
+  addProjectToRepoAction,
+  createProjectAction,
+} from "@/app/projects/actions";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Form, FormControl, FormField, FormItem, FormMessage } from "./ui/form";
+
+const formSchema = z.object({
+  name: z.string().min(2),
+  description: z.string().min(10),
+});
+
+export function AddProjectToRepoButton({ repoId }: { repoId: string }) {
+  const [open, setOpen] = useState(false);
+  const router = useRouter();
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { name: "", description: "" },
+  });
+
+  const isPending = form.formState.isSubmitting;
+
+  async function onSubmit(values: z.infer<typeof formSchema>) {
+    try {
+      const project = await addProjectToRepoAction({ ...values, repoId });
+      toast.success(`Project added: ${project.name}`);
+      setOpen(false);
+      router.push(`/projects/${project.slug}`);
+    } catch (error) {
+      toast.error(`Unable to create the project ${(error as Error).message}`);
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogTrigger asChild>
+          <Button variant="default">
+            <Plus className="h-4 w-4" />
+            Add Project
+          </Button>
+        </DialogTrigger>
+        <DialogContent className="sm:max-w-[600px]">
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+            <DialogHeader>
+              <DialogTitle>Add Project</DialogTitle>
+              <DialogDescription>
+                Specify the name of the project to add to this repository
+              </DialogDescription>
+            </DialogHeader>
+            <div className="grid grid-cols-[100px_1fr] items-center gap-4">
+              <Label htmlFor="name" className="text-right">
+                Project name
+              </Label>
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormControl>
+                      <Input placeholder="" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <Label htmlFor="name" className="text-right">
+                Description
+              </Label>
+              <FormField
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormControl>
+                      <Input placeholder="" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <DialogFooter>
+              <Button type="submit" disabled={isPending}>
+                {isPending && (
+                  <ReloadIcon className="mr-2 h-4 w-4 animate-spin" />
+                )}
+                Add
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </Form>
+  );
+}

--- a/apps/admin/src/components/project-table.tsx
+++ b/apps/admin/src/components/project-table.tsx
@@ -62,11 +62,11 @@ export function ProjectTable({ projects }: Props) {
             <TableCell>
               <div className="flex flex-col gap-4">
                 {project.repo?.full_name || "No repo"}
-                <div>
-                  {project.repo?.archived && (
+                {project.repo?.archived && (
+                  <div>
                     <Badge variant="destructive">Archived</Badge>
-                  )}
-                </div>
+                  </div>
+                )}
               </div>
             </TableCell>
             <TableCell>

--- a/apps/admin/src/components/project-table.tsx
+++ b/apps/admin/src/components/project-table.tsx
@@ -1,0 +1,91 @@
+import Link from "next/link";
+
+import { findProjects } from "@repo/db/projects";
+import { ProjectLogo } from "@/components/project-logo";
+import { Badge, badgeVariants } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { formatStars } from "@/lib/format-helpers";
+
+type Props = {
+  projects: Awaited<ReturnType<typeof findProjects>>;
+};
+
+export function ProjectTable({ projects }: Props) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="w-[100px]">Logo</TableHead>
+          <TableHead>Name</TableHead>
+          <TableHead>Added at</TableHead>
+          <TableHead>GitHub</TableHead>
+          <TableHead>Packages</TableHead>
+          <TableHead className="text-right">Stars</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {projects.map((project) => (
+          <TableRow key={project.slug}>
+            <TableCell>
+              <ProjectLogo project={project} size={50} />
+            </TableCell>
+            <TableCell>
+              <div className="flex flex-col gap-4">
+                <Link href={`/projects/${project.slug}`}>{project.name}</Link>
+                <span className="text-muted-foreground">
+                  {project.description}
+                </span>
+                {project.comments && <div>{project.comments}</div>}
+                <div className="flex flex-wrap gap-2">
+                  {project.tags.map((tag) => (
+                    <a
+                      href={`/projects/?tag=${tag}`}
+                      className={badgeVariants({ variant: "secondary" })}
+                      key={tag}
+                    >
+                      {tag}
+                    </a>
+                  ))}
+                </div>
+              </div>
+            </TableCell>
+            <TableCell>
+              {project.createdAt.toISOString().slice(0, 10)}
+            </TableCell>
+            <TableCell>
+              <div className="flex flex-col gap-4">
+                {project.repo?.full_name || "No repo"}
+                <div>
+                  {project.repo?.archived && (
+                    <Badge variant="destructive">Archived</Badge>
+                  )}
+                </div>
+              </div>
+            </TableCell>
+            <TableCell>
+              {project.packages.filter(Boolean).length > 0 ? (
+                <div className="flex flex-col gap-4">
+                  {project.packages.map((pkg) => (
+                    <div key={pkg}>{pkg}</div>
+                  ))}
+                </div>
+              ) : (
+                <span className="text-muted-foreground italic">No package</span>
+              )}
+            </TableCell>
+            <TableCell className="text-right">
+              {formatStars(project.stars)}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/packages/db/drizzle/0002_minor_sentry.sql
+++ b/packages/db/drizzle/0002_minor_sentry.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "projects" ALTER COLUMN "repoId" SET NOT NULL;

--- a/packages/db/drizzle/meta/0002_snapshot.json
+++ b/packages/db/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,587 @@
+{
+  "id": "5c462d1f-1648-400a-be19-0f8bbbe3b03e",
+  "prevId": "5c73e7d8-ca3a-4196-b610-319cab6582f4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.bundles": {
+      "name": "bundles",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gzip": {
+          "name": "gzip",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bundles_name_packages_name_fk": {
+          "name": "bundles_name_packages_name_fk",
+          "tableFrom": "bundles",
+          "tableTo": "packages",
+          "columnsFrom": [
+            "name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.packages": {
+      "name": "packages",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "downloads": {
+          "name": "downloads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependencies": {
+          "name": "dependencies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "devDependencies": {
+          "name": "devDependencies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deprecated": {
+          "name": "deprecated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "packages_project_id_projects_id_fk": {
+          "name": "packages_project_id_projects_id_fk",
+          "tableFrom": "packages",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "override_description": {
+          "name": "override_description",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_url": {
+          "name": "override_url",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitter": {
+          "name": "twitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comments": {
+          "name": "comments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repoId": {
+          "name": "repoId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_repoId_repos_id_fk": {
+          "name": "projects_repoId_repos_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "repos",
+          "columnsFrom": [
+            "repoId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "projects_slug_unique": {
+          "name": "projects_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      }
+    },
+    "public.projects_to_tags": {
+      "name": "projects_to_tags",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_to_tags_project_id_projects_id_fk": {
+          "name": "projects_to_tags_project_id_projects_id_fk",
+          "tableFrom": "projects_to_tags",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "projects_to_tags_tag_id_tags_id_fk": {
+          "name": "projects_to_tags_tag_id_tags_id_fk",
+          "tableFrom": "projects_to_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "projects_to_tags_project_id_tag_id_pk": {
+          "name": "projects_to_tags_project_id_tag_id_pk",
+          "columns": [
+            "project_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.repos": {
+      "name": "repos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "homepage": {
+          "name": "homepage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stargazers_count": {
+          "name": "stargazers_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pushed_at": {
+          "name": "pushed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_commit": {
+          "name": "last_commit",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_count": {
+          "name": "commit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contributor_count": {
+          "name": "contributor_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "repos_full_name_unique": {
+          "name": "repos_full_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "full_name"
+          ]
+        }
+      }
+    },
+    "public.snapshots": {
+      "name": "snapshots",
+      "schema": "",
+      "columns": {
+        "repo_id": {
+          "name": "repo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "months": {
+          "name": "months",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "snapshots_repo_id_repos_id_fk": {
+          "name": "snapshots_repo_id_repos_id_fk",
+          "tableFrom": "snapshots",
+          "tableTo": "repos",
+          "columnsFrom": [
+            "repo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "snapshots_repo_id_year_pk": {
+          "name": "snapshots_repo_id_year_pk",
+          "columns": [
+            "repo_id",
+            "year"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_code_unique": {
+          "name": "tags_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1723967504988,
       "tag": "0001_light_cerise",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1725801788752,
+      "tag": "0002_minor_sentry",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/projects/create.ts
+++ b/packages/db/src/projects/create.ts
@@ -49,3 +49,29 @@ async function fetchGitHubRepoData(fullName: string) {
     topics: data.topics,
   };
 }
+
+export async function addProjectToRepo({
+  name,
+  description,
+  repoId,
+}: {
+  name: string;
+  description: string;
+  repoId: string;
+}) {
+  const db = getDatabase();
+  const createdProjects = await db
+    .insert(schema.projects)
+    .values({
+      id: nanoid(),
+      createdAt: new Date(),
+      repoId,
+      name,
+      description,
+      slug: slugify(name).toLowerCase(),
+      status: "active",
+    })
+    .returning();
+
+  return createdProjects[0];
+}

--- a/packages/db/src/projects/find.ts
+++ b/packages/db/src/projects/find.ts
@@ -1,4 +1,14 @@
-import { asc, count, desc, eq, ilike, inArray, or, sql } from "drizzle-orm";
+import {
+  asc,
+  count,
+  desc,
+  eq,
+  ilike,
+  inArray,
+  like,
+  or,
+  sql,
+} from "drizzle-orm";
 
 import { DB } from "../index";
 import * as schema from "../schema";
@@ -17,6 +27,7 @@ type Props = {
   db: DB;
   limit: number;
   offset: number;
+  owner?: string;
   sort: ProjectListOrderByKey;
   tag?: string;
   text?: string;
@@ -26,6 +37,7 @@ export async function findProjects({
   db,
   limit,
   offset,
+  owner,
   sort,
   tag,
   text,
@@ -40,6 +52,7 @@ export async function findProjects({
       repo: {
         full_name: repos.full_name,
         owner_id: repos.owner_id,
+        archived: repos.archived,
       },
       logo: projects.logo,
       tags: sql<
@@ -64,6 +77,7 @@ export async function findProjects({
       projects.description,
       projects.logo,
       projects.createdAt,
+      repos.archived,
       repos.stars,
       repos.full_name,
       repos.owner_id,
@@ -76,6 +90,9 @@ export async function findProjects({
   }
   if (tag) {
     query.where(getWhereClauseSearchByTag(db, tag));
+  }
+  if (owner) {
+    query.where(like(repos.full_name, `${owner}/%`));
   }
 
   // console.log(query.toSQL());

--- a/packages/db/src/projects/find.ts
+++ b/packages/db/src/projects/find.ts
@@ -28,6 +28,7 @@ type Props = {
   limit: number;
   offset: number;
   owner?: string;
+  full_name?: string;
   sort: ProjectListOrderByKey;
   tag?: string;
   text?: string;
@@ -37,6 +38,7 @@ export async function findProjects({
   db,
   limit,
   offset,
+  full_name,
   owner,
   sort,
   tag,
@@ -93,6 +95,9 @@ export async function findProjects({
   }
   if (owner) {
     query.where(like(repos.full_name, `${owner}/%`));
+  }
+  if (full_name) {
+    query.where(like(repos.full_name, full_name));
   }
 
   // console.log(query.toSQL());

--- a/packages/db/src/projects/get.ts
+++ b/packages/db/src/projects/get.ts
@@ -58,35 +58,6 @@ export class ProjectService {
 
     return { ...project, repo, tags };
   }
-
-  /** Usually a repo is associated with a single project but some monorepos are linked to several projects */
-  async findProjectsByRepoId(repoId: string) {
-    const found = await this.db.query.projects.findMany({
-      where: eq(schema.projects.repoId, repoId),
-      with: {
-        repo: {
-          columns: {
-            full_name: true,
-            stars: true,
-          },
-        },
-        projectsToTags: {
-          with: {
-            tag: {
-              columns: {
-                code: true,
-                name: true,
-              },
-            },
-          },
-        },
-      },
-    });
-    return found.map((project) => ({
-      ...project,
-      tags: project.projectsToTags.map((ptt) => ptt.tag.code),
-    }));
-  }
 }
 
 export type ProjectDetails = NonNullable<

--- a/packages/db/src/projects/get.ts
+++ b/packages/db/src/projects/get.ts
@@ -58,6 +58,35 @@ export class ProjectService {
 
     return { ...project, repo, tags };
   }
+
+  /** Usually a repo is associated with a single project but some monorepos are linked to several projects */
+  async findProjectsByRepoId(repoId: string) {
+    const found = await this.db.query.projects.findMany({
+      where: eq(schema.projects.repoId, repoId),
+      with: {
+        repo: {
+          columns: {
+            full_name: true,
+            stars: true,
+          },
+        },
+        projectsToTags: {
+          with: {
+            tag: {
+              columns: {
+                code: true,
+                name: true,
+              },
+            },
+          },
+        },
+      },
+    });
+    return found.map((project) => ({
+      ...project,
+      tags: project.projectsToTags.map((ptt) => ptt.tag.code),
+    }));
+  }
 }
 
 export type ProjectDetails = NonNullable<

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -25,7 +25,9 @@ export const projects = pgTable("projects", {
   comments: text("comments"),
   createdAt: timestamp("created_at").notNull().defaultNow(),
   updatedAt: timestamp("updated_at"),
-  repoId: text("repoId").references(() => repos.id, { onDelete: "cascade" }),
+  repoId: text("repoId")
+    .references(() => repos.id, { onDelete: "cascade" })
+    .notNull(),
 });
 
 export const tags = pgTable("tags", {


### PR DESCRIPTION
## Goal

One of the goals of the migration to Postgres was to allow multiple projects to be linked to the same repository, which is a common pattern with the raise of monorepos.

This is why the database design includes 2 separate tables:

- `repos`: only includes the data from GitHub about a given repository
- `projects`: connected to repos via the `repoId`, have their own name, description, URL, tags
 
From the schema.ts file:

```ts
export const projects = pgTable("projects", {
  id: text("id").primaryKey(),
  name: text("name").notNull().unique(),
  slug: text("slug").notNull().unique(),
  description: text("description").notNull(),
  repoId: text("repoId")
    .references(() => repos.id, { onDelete: "cascade" })
    .notNull(),
});


export const repos = pgTable("repos", {
  id: text("id").primaryKey(),
  archived: boolean("archived"),
  default_branch: text("default_branch"),
  description: text("description"),
  full_name: text("full_name").notNull().unique(),
  homepage: text("homepage"),
  name: text("name").notNull(),
  owner_id: text("owner_id").notNull(),
  stars: integer("stargazers_count"),
  topics: jsonb("topics"),
});
```

Other changes includes:

- Show a section with the projects from the same owner
- Extract `ProjectTable` used in search results page component to share it
- make `repoId` column required in `projects` schema

## Why we need this feature

#### Example 1: React Spectrum

We need this feature to register a project like [React Aria](https://react-spectrum.adobe.com/react-aria/index.html) that is related to the same repo as [React Spectrum](https://react-spectrum.adobe.com/), React Spectrum being a set of libraries.

![image](https://github.com/user-attachments/assets/ca70561b-4316-4a20-9368-4b9112d4a2a1)


Currently _Best of JS_ only includes the React Spectrum library: https://bestofjs.org/projects/react-spectrum

#### Example 2: xyflow

Another example: the project [xyflow](https://www.xyflow.com/) includes different packages: one for React, one for Svelte.

![image](https://github.com/user-attachments/assets/778b48cd-3255-4c71-804e-43e79d1dc267)


Currently we display "React Flow / Svelte Flow" in Best of JS, which is not great: https://bestofjs.org/projects/react-flow-svelte-flow

So this PR introduces a new button "Add project to repository" in the Project details page.

## How to test

- In the admin app, visit the "project details" page. E.g. `/projects/react-spectrum`
- A new section "Projects related to the same repo" shows the list of projects linked to the same repo
- A button lets admin users add another project to the repo

![image](https://github.com/user-attachments/assets/f2e3f146-bcac-4549-bbf3-699ece48f310)



