### PR TITLE
Improve project statuses

### DIFF
--- a/apps/admin/src/app/projects/[slug]/edit/project-form.tsx
+++ b/apps/admin/src/app/projects/[slug]/edit/project-form.tsx
@@ -98,6 +98,22 @@ export function ProjectForm({ project }: Props) {
             />
             <FormField
               control={form.control}
+              name="slug"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Slug</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Slug" {...field} />
+                  </FormControl>
+                  <FormDescription>
+                    Edit with case, the slug may be referenced a lot of places
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
               name="description"
               render={({ field }) => (
                 <FormItem>

--- a/apps/admin/src/app/projects/[slug]/edit/project-form.tsx
+++ b/apps/admin/src/app/projects/[slug]/edit/project-form.tsx
@@ -9,6 +9,7 @@ import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 
+import { PROJECT_STATUSES } from "@repo/db/constants";
 import { ProjectData } from "@repo/db/projects";
 import { Button, buttonVariants } from "@/components/ui/button";
 import {
@@ -39,8 +40,6 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { updateProjectData } from "../actions";
 
-const statuses = ["active", "featured", "promoted", "deprecated"] as const;
-
 const formSchema = z.object({
   name: z.string().min(2).max(50),
   slug: z.string(),
@@ -48,7 +47,7 @@ const formSchema = z.object({
   overrideDescription: z.coerce.boolean().nullable(),
   url: z.string().url().nullable().or(z.literal("")),
   overrideURL: z.coerce.boolean().nullable(),
-  status: z.enum(statuses).default("active").nullable(),
+  status: z.enum(PROJECT_STATUSES).default("active"),
   logo: z.string().nullable(),
   comments: z.string().nullable(),
   twitter: z.string().nullable(),
@@ -196,7 +195,7 @@ export function ProjectForm({ project }: Props) {
                         <SelectValue placeholder="Status" />
                       </SelectTrigger>
                       <SelectContent>
-                        {statuses.map((status) => (
+                        {PROJECT_STATUSES.map((status) => (
                           <SelectItem key={status} value={status}>
                             {status}
                           </SelectItem>

--- a/apps/admin/src/app/projects/[slug]/edit/project-form.tsx
+++ b/apps/admin/src/app/projects/[slug]/edit/project-form.tsx
@@ -70,7 +70,7 @@ export function ProjectForm({ project }: Props) {
     console.log(values);
     await updateProjectData(project.id, values);
     toast.success("Project updated");
-    router.push(`/projects/${project.slug}`);
+    router.push(`/projects/${values.slug}`);
   }
 
   return (

--- a/apps/admin/src/app/projects/[slug]/edit/project-form.tsx
+++ b/apps/admin/src/app/projects/[slug]/edit/project-form.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ReloadIcon } from "@radix-ui/react-icons";
 import { SelectValue } from "@radix-ui/react-select";
+import { TriangleAlert } from "lucide-react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
@@ -105,8 +106,9 @@ export function ProjectForm({ project }: Props) {
                   <FormControl>
                     <Input placeholder="Slug" {...field} />
                   </FormControl>
-                  <FormDescription>
-                    Edit with case, the slug may be referenced a lot of places
+                  <FormDescription className="flex items-center gap-2">
+                    <TriangleAlert className="h-4 w-4" />
+                    Edit with care, the slug may be referenced a lot of places
                   </FormDescription>
                   <FormMessage />
                 </FormItem>

--- a/apps/admin/src/components/project-table.tsx
+++ b/apps/admin/src/components/project-table.tsx
@@ -38,7 +38,12 @@ export function ProjectTable({ projects }: Props) {
             </TableCell>
             <TableCell>
               <div className="flex flex-col gap-4">
-                <Link href={`/projects/${project.slug}`}>{project.name}</Link>
+                <Link
+                  href={`/projects/${project.slug}`}
+                  className="hover:underline"
+                >
+                  {project.name}
+                </Link>
                 <span className="text-muted-foreground">
                   {project.description}
                 </span>

--- a/apps/backend/src/tasks/build-static-api.task.ts
+++ b/apps/backend/src/tasks/build-static-api.task.ts
@@ -6,6 +6,7 @@ import {
   getProjectDescription,
   getProjectTrends,
   getProjectURL,
+  ProjectDetails,
 } from "@repo/db/projects";
 import { Task } from "@/task-runner";
 import { ProjectItem } from "./static-api-types";
@@ -20,6 +21,8 @@ export const buildStaticApiTask: Task = {
       const repo = project.repo;
 
       if (!repo) throw new Error("No repo found");
+      if (!shouldProcessProject(project))
+        return { data: null, meta: { skipped: true } };
       if (!repo.snapshots?.length)
         return { data: null, meta: { "no snapshot": true } };
 
@@ -108,6 +111,10 @@ export const buildStaticApiTask: Task = {
     }
   },
 };
+
+function shouldProcessProject(project: ProjectDetails) {
+  return !["deprecated", "hidden"].includes(project.status);
+}
 
 function isColdProject(project: ProjectItem) {
   const delta = project.trends.yearly;

--- a/packages/db/src/constants.ts
+++ b/packages/db/src/constants.ts
@@ -1,1 +1,9 @@
+export const PROJECT_STATUSES = [
+  "active",
+  "featured",
+  "promoted",
+  "deprecated",
+  "hidden",
+] as const;
+
 export const TAGS_EXCLUDED_FROM_RANKINGS = ["meta", "learning", "wildcard"];

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -9,6 +9,8 @@ import {
   timestamp,
 } from "drizzle-orm/pg-core";
 
+import { PROJECT_STATUSES } from "./constants";
+
 export const projects = pgTable("projects", {
   id: text("id").primaryKey(),
   name: text("name").notNull().unique(),
@@ -17,9 +19,7 @@ export const projects = pgTable("projects", {
   overrideDescription: boolean("override_description"),
   url: text("url"),
   overrideURL: boolean("override_url"),
-  status: text("status", {
-    enum: ["active", "featured", "promoted", "deprecated"],
-  }),
+  status: text("status", { enum: PROJECT_STATUSES }).notNull(),
   logo: text("logo"),
   twitter: text("twitter"),
   comments: text("comments"),


### PR DESCRIPTION
## Goal

- setup the list of available project statuses in a constant to keep the code DRY
- don't process `deprecated` or `hidden` projects  when building the static API

Also included: make `slug` field editable in project form.

## How to test

From the admin panel, ensure the statuses show up properly when editing an existing project

## Screenshots

![image](https://github.com/user-attachments/assets/ac7feb78-9d76-4bc5-bed2-f0a3d7f160c2)

