### PR TITLE
Try Turborepo

### DIFF
--- a/.github/tooling/github-actions/install/action.yml
+++ b/.github/tooling/github-actions/install/action.yml
@@ -4,14 +4,6 @@ description: Set up Node.js with PNPM"
 runs:
   using: composite
   steps:
-    - name: Cache turbo build setup
-      uses: actions/cache@v4
-      with:
-        path: apps/bestofjs-nextjs/.turbo
-        key: ${{ runner.os }}-turbo-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-turbo-
-
     - name: Install PNPM
       uses: pnpm/action-setup@v4
       with:

--- a/.github/tooling/github-actions/install/action.yml
+++ b/.github/tooling/github-actions/install/action.yml
@@ -12,11 +12,12 @@ runs:
         restore-keys: |
           ${{ runner.os }}-turbo-
 
-    - uses: actions/setup-node@v4
-      with:
-        node-version: 20
-
     - name: Install PNPM
       uses: pnpm/action-setup@v4
       with:
         version: 9.4.0
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: pnpm

--- a/.github/tooling/github-actions/install/action.yml
+++ b/.github/tooling/github-actions/install/action.yml
@@ -4,9 +4,18 @@ description: "Set up Node.js with PNPM"
 runs:
   using: composite
   steps:
+    - name: Cache turbo build setup
+      uses: actions/cache@v4
+      with:
+        path: apps/bestofjs-nextjs/.turbo
+        key: ${{ runner.os }}-turbo-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-turbo-
+
     - uses: actions/setup-node@v4
       with:
         node-version: 20
+
     - name: Install PNPM
       uses: pnpm/action-setup@v4
       with:

--- a/.github/tooling/github-actions/install/action.yml
+++ b/.github/tooling/github-actions/install/action.yml
@@ -1,5 +1,5 @@
-name: "Shared setup"
-description: "Set up Node.js with PNPM"
+name: Shared setup
+description: Set up Node.js with PNPM"
 
 runs:
   using: composite

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -11,7 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Code Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Cache turbo build setup
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
 
       - name: Setup Environment
         uses: ./.github/tooling/github-actions/install
@@ -21,7 +29,7 @@ jobs:
         run: pnpm -F bestofjs-nextjs install
 
       - name: Code Linting
-        run: pnpm -F bestofjs-nextjs lint
+        run: pnpm -F bestofjs-nextjs typecheck
 
       - name: Code Linting
         run: pnpm -F bestofjs-nextjs lint

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -13,14 +13,6 @@ jobs:
       - name: Code Checkout
         uses: actions/checkout@v4
 
-      - name: Cache turbo build setup
-        uses: actions/cache@v4
-        with:
-          path: apps/bestofjs-nextjs/.turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
-
       - name: Setup Environment
         uses: ./.github/tooling/github-actions/install
 

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Cache turbo build setup
         uses: actions/cache@v4
         with:
-          path: apps/*/.turbo
+          path: apps/bestofjs-nextjs/.turbo
           key: ${{ runner.os }}-turbo-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-turbo-

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Code Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Environment
+      - name: Setup Node.js and PNPM
         uses: ./.github/tooling/github-actions/install
 
       - name: Install Dependencies
@@ -49,7 +49,7 @@ jobs:
       - name: Code Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Environment
+      - name: Setup Node.js and PNPM
         uses: ./.github/tooling/github-actions/install
 
       - name: Install Dependencies

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Cache turbo build setup
         uses: actions/cache@v4
         with:
-          path: .turbo
+          path: apps/*/.turbo
           key: ${{ runner.os }}-turbo-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-turbo-
@@ -28,7 +28,7 @@ jobs:
         shell: bash
         run: pnpm -F bestofjs-nextjs install
 
-      - name: Code Linting
+      - name: Type checking
         run: pnpm -F bestofjs-nextjs typecheck
 
       - name: Code Linting
@@ -55,7 +55,7 @@ jobs:
           environment: "Preview – bestofjs"
 
       - name: Code Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Environment
         uses: ./.github/tooling/github-actions/install

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ node_modules
 .env.development
 .env.production
 
+.turbo
+
 # local PostgreSQL database
 db-data
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@ianvs/prettier-plugin-sort-imports": "^4.3.1",
     "dotenv-cli": "^7.4.2",
     "prettier": "^3.3.3",
-    "tsx": "^4.16.2"
+    "tsx": "^4.16.2",
+    "turbo": "^2.1.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       tsx:
         specifier: ^4.16.2
         version: 4.16.2
+      turbo:
+        specifier: ^2.1.2
+        version: 2.1.2
 
   apps/admin:
     dependencies:
@@ -7471,6 +7474,40 @@ packages:
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
+  turbo-darwin-64@2.1.2:
+    resolution: {integrity: sha512-3TEBxHWh99h2yIzkuIigMEOXt/ItYQp0aPiJjPd1xN4oDcsKK5AxiFKPH9pdtfIBzYsY59kQhZiFj0ELnSP7Bw==}
+    cpu: [x64]
+    os: [darwin]
+
+  turbo-darwin-arm64@2.1.2:
+    resolution: {integrity: sha512-he0miWNq2WxJzsH82jS2Z4MXpnkzn9SH8a79iPXiJkq25QREImucscM4RPasXm8wARp91pyysJMq6aasD45CeA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  turbo-linux-64@2.1.2:
+    resolution: {integrity: sha512-fKUBcc0rK8Vdqv5a/E3CSpMBLG1bzwv+Q0Q83F8fG2ZfNCNKGbcEYABdonNZkkx141Rj03cZQFCgxu3MVEGU+A==}
+    cpu: [x64]
+    os: [linux]
+
+  turbo-linux-arm64@2.1.2:
+    resolution: {integrity: sha512-sV8Bpmm0WiuxgbhxymcC7wSsuxfBBieI98GegSwbr/bs1ANAgzCg93urIrdKdQ3/b31zZxQwcaP4FBF1wx1Qdg==}
+    cpu: [arm64]
+    os: [linux]
+
+  turbo-windows-64@2.1.2:
+    resolution: {integrity: sha512-wcmIJZI9ORT9ykHGliFE6kWRQrlH930QGSjSgWC8uFChFFuOyUlvC7ttcxuSvU9VqC7NF4C+GVAcFJQ8lTjN7g==}
+    cpu: [x64]
+    os: [win32]
+
+  turbo-windows-arm64@2.1.2:
+    resolution: {integrity: sha512-zdnXjrhk7YO6CP+Q5wPueEvOCLH4lDa6C4rrwiakcWcPgcQGbVozJlo4uaQ6awo8HLWQEvOwu84RkWTdLAc/Hw==}
+    cpu: [arm64]
+    os: [win32]
+
+  turbo@2.1.2:
+    resolution: {integrity: sha512-Jb0rbU4iHEVQ18An/YfakdIv9rKnd3zUfSE117EngrfWXFHo3RndVH96US3GsT8VHpwTncPePDBT2t06PaFLrw==}
+    hasBin: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -15650,6 +15687,33 @@ snapshots:
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  turbo-darwin-64@2.1.2:
+    optional: true
+
+  turbo-darwin-arm64@2.1.2:
+    optional: true
+
+  turbo-linux-64@2.1.2:
+    optional: true
+
+  turbo-linux-arm64@2.1.2:
+    optional: true
+
+  turbo-windows-64@2.1.2:
+    optional: true
+
+  turbo-windows-arm64@2.1.2:
+    optional: true
+
+  turbo@2.1.2:
+    optionalDependencies:
+      turbo-darwin-64: 2.1.2
+      turbo-darwin-arm64: 2.1.2
+      turbo-linux-64: 2.1.2
+      turbo-linux-arm64: 2.1.2
+      turbo-windows-64: 2.1.2
+      turbo-windows-arm64: 2.1.2
 
   type-check@0.4.0:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": [".next/**", "!.next/cache/**"]
+    },
+    "lint": {
+      "dependsOn": ["^lint"]
+    },
+    "typecheck": {
+      "dependsOn": ["^typecheck"]
+    },
+    "dev": {
+      "persistent": true,
+      "cache": false
+    }
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,8 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": [".next/**", "!.next/cache/**"]
+      "outputs": [".next/**", "!.next/cache/**"],
+      "env": ["POSTGRES_URL"]
     },
     "lint": {
       "dependsOn": ["^lint"]

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": [".next/**", "!.next/cache/**", "build/**"],
+      "outputs": [".next/**", "!.next/cache/**", "public/data/**", "build/**"],
       "env": ["POSTGRES_URL"]
     },
     "lint": {

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": [".next/**", "!.next/cache/**"],
+      "outputs": [".next/**", "!.next/cache/**", "build/**"],
       "env": ["POSTGRES_URL"]
     },
     "lint": {


### PR DESCRIPTION
## Goal

Add [Turborepo](https://turbo.build/repo/docs/) to orchestrate and speed up tasks within the monorepo and avoid meaningless build processes started whenever a commit is pushed.

I tried to follow the setup described here GitHub Actions: https://turbo.build/repo/docs/guides/ci-vendors/github-actions that includes this step:

```yml
- name: Cache turbo build setup
  uses: actions/cache@v4
  with:
    path: apps/bestofjs-nextjs/.turbo
    key: ${{ runner.os }}-turbo-${{ github.sha }}
    restore-keys: |
      ${{ runner.os }}-turbo-
```


But something does not work as expected on GitHub actions as I noticed this warning in the post Node.js setup job:

```
##[debug]Search path '/home/runner/work/bestofjs/bestofjs/apps/bestofjs-nextjs/.turbo'
##[debug]Cache Paths:
##[debug][]
Warning: Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

It seems the default caching mechanism provided by PNPM works, as I can see the cache being hit (360 M)

![image](https://github.com/user-attachments/assets/c79458d9-6222-47a9-90a8-f083cd55cdeb)




