### PR TITLE
Fix db queries limit parameter, don't pass `0`

### DIFF
--- a/apps/backend/src/iteration-helpers/project-processor.ts
+++ b/apps/backend/src/iteration-helpers/project-processor.ts
@@ -26,8 +26,11 @@ export class ProjectProcessor extends ItemProcessor<ProjectDetails> {
       .select({ id: schema.projects.id })
       .from(schema.projects)
       .orderBy(desc(schema.projects.createdAt))
-      .limit(limit)
       .offset(skip);
+
+    if (limit) {
+      query.limit(limit);
+    }
 
     if (name) {
       query.where(eq(schema.projects.slug, name));

--- a/apps/backend/src/iteration-helpers/repo-processor.ts
+++ b/apps/backend/src/iteration-helpers/repo-processor.ts
@@ -26,8 +26,11 @@ export class RepoProcessor extends ItemProcessor<Repo> {
       .select({ id: schema.repos.id })
       .from(schema.repos)
       .orderBy(desc(schema.repos.added_at))
-      .limit(limit)
       .offset(skip);
+
+    if (limit) {
+      query.limit(limit);
+    }
 
     if (name) {
       query.where(eq(schema.repos.full_name, name));


### PR DESCRIPTION
## Goal

SQL queries made with `limit 0` return no rows but we used to use `0` as the default value because Drizzle was ignoring `limit` if it was zero... until the following issue was handled:

https://github.com/drizzle-team/drizzle-orm/issues/2011

Yesterday the upgrade to the latest version of Drizzle (#310 ) broke the build process of the app.


