### PR TITLE
Run E2E tests against localhost instead of Vercel Preview URL

### DIFF
--- a/.github/tooling/github-actions/install/action.yml
+++ b/.github/tooling/github-actions/install/action.yml
@@ -4,10 +4,12 @@ description: "Set up Node.js with PNPM"
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v4
-      with:
-        node-version: 20
     - name: Install PNPM
       uses: pnpm/action-setup@v4
       with:
         version: 9.4.0
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: pnpm

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -34,7 +34,7 @@ jobs:
       POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
     steps:
       - name: Code Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Environment
         uses: ./.github/tooling/github-actions/install
@@ -64,7 +64,7 @@ jobs:
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: report
           path: apps/bestofjs-nextjs/playwright-report/

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -30,6 +30,8 @@ jobs:
     name: E2E Tests
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    env:
+      POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
     steps:
       - name: Code Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Code Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Environment
         uses: ./.github/tooling/github-actions/install

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -28,6 +28,8 @@ jobs:
 
   automated-testing:
     name: E2E Tests
+    # only run when PR are merged into develop
+    if: github.ref == 'refs/heads/develop'
     timeout-minutes: 10
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -54,10 +54,17 @@ jobs:
       - name: Install Playwright Browsers
         run: pnpm -F bestofjs-nextjs exec playwright install chromium --with-deps
 
-      - name: Run Playwright tests
-        run: pnpm test:e2e
+      - name: Start app and run tests
         env:
           BASE_URL: http://localhost:3000
+        run: |
+          pnpm -F bestofjs-nextjs start &
+          echo "Waiting for app to be ready..."
+          while ! curl -s http://localhost:3000 > /dev/null; do
+            sleep 1
+          done
+          echo "App is ready. Running tests..."
+          pnpm  -F bestofjs-nextjs test:e2e
 
       - name: Upload report
         if: always()

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -23,9 +23,6 @@ jobs:
       - name: Code Linting
         run: pnpm -F bestofjs-nextjs lint
 
-      - name: Code Linting
-        run: pnpm -F bestofjs-nextjs lint
-
       - name: Unit tests
         run: pnpm -F bestofjs-nextjs test:ci
 
@@ -34,18 +31,6 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - name: Waiting for 200 from the Vercel Preview
-        uses: patrickedqvist/wait-for-vercel-preview@v1.2.0 # https://github.com/patrickedqvist/wait-for-vercel-preview
-        id: vercel_preview_url
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          check_interval: 5 # seconds
-          max_timeout: 6000 # seconds
-          # Environment uses a special ASCII dash example: "Preview – bestofjs"
-          # If having issues, need to confirm environment name from the github deployments API
-          # https://github.com/patrickedqvist/wait-for-vercel-preview/issues/33
-          environment: "Preview – bestofjs"
-
       - name: Code Checkout
         uses: actions/checkout@v3
 
@@ -56,13 +41,21 @@ jobs:
         shell: bash
         run: pnpm -F bestofjs-nextjs install
 
+      - name: Build
+        shell: bash
+        run: pnpm -F bestofjs-nextjs build
+
+      - name: Start the app
+        shell: bash
+        run: pnpm -F bestofjs-nextjs start
+
       - name: Install Playwright Browsers
         run: pnpm -F bestofjs-nextjs exec playwright install chromium --with-deps
 
       - name: Run Playwright tests
         run: pnpm test:e2e
         env:
-          BASE_URL: ${{ steps.vercel_preview_url.outputs.url }}
+          BASE_URL: http://localhost:3000
 
       - name: Upload report
         if: always()

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -47,10 +47,6 @@ jobs:
         shell: bash
         run: pnpm -F bestofjs-nextjs build
 
-      - name: Start the app
-        shell: bash
-        run: pnpm -F bestofjs-nextjs start
-
       - name: Install Playwright Browsers
         run: pnpm -F bestofjs-nextjs exec playwright install chromium --with-deps
 


### PR DESCRIPTION
## Goal

- Instead of waiting for the deploy on Vercel to run the E2E tests, run the test in local after building the application, to make the check faster
- Only run E2E tests when PR are merged (to be revisted when migrating to Turbo monorepo maybe)

## Possible improvement for another PR

Cache for Next.js build: https://nextjs.org/docs/pages/building-your-application/deploying/ci-build-caching#github-actions
