### PR TITLE
Rename `icon` => `logo` in static JSON API

### DIFF
--- a/apps/backend/src/tasks/build-static-api.task.ts
+++ b/apps/backend/src/tasks/build-static-api.task.ts
@@ -29,8 +29,9 @@ export const buildStaticApiTask: Task = {
       const trends = getProjectTrends(repo.snapshots);
       const tags = project.projectsToTags.map((ptt) => ptt.tag.code);
 
+      // optional data
       const url = getProjectURL(project);
-      const icon = project.logo || undefined;
+      const logo = project.logo || undefined;
       const packageData = getPackageData(project);
 
       const data: ProjectItem = {
@@ -49,7 +50,7 @@ export const buildStaticApiTask: Task = {
         created_at: formatDate(repo.created_at),
         ...(packageData && { ...packageData }),
         ...(url && { url }),
-        ...(icon && { icon }),
+        ...(logo && { logo }),
       };
 
       return {

--- a/apps/bestofjs-nextjs/package.json
+++ b/apps/bestofjs-nextjs/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "analyze": "cross-env ANALYZE=true next build",
-    "build-project-data": "node ./scripts/build-project-data.mjs",
+    "build-project-data": "dotenv -e ../../.env.${STAGE:=development} node ./scripts/build-project-data.mjs",
     "dev": "dotenv -e ../../.env.${STAGE:=development} next dev",
     "build": "pnpm build-project-data && dotenv -e ../../.env.${STAGE:=development} next build",
     "start": "dotenv -e ../../.env.${STAGE:=development} next start",

--- a/apps/bestofjs-nextjs/src/app/hall-of-fame/hall-of-member-list.tsx
+++ b/apps/bestofjs-nextjs/src/app/hall-of-fame/hall-of-member-list.tsx
@@ -60,7 +60,7 @@ function HallOfFameMember({ member }: { member: BestOfJS.HallOfFameMember }) {
                   "font-normal"
                 )}
               >
-                {project.icon && (
+                {project.logo && (
                   <ProjectLogo project={project} size={20} className="mr-2" />
                 )}
                 {project.name}

--- a/apps/bestofjs-nextjs/src/app/projects/[slug]/project-details-npm/dependencies-section.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/[slug]/project-details-npm/dependencies-section.tsx
@@ -25,8 +25,7 @@ export async function DependenciesSection({
     criteria: { npm: { $in: dependencies } },
   });
   const dependenciesNotOnBestOfJS = dependencies.filter(
-    (dependency) =>
-      !projects.find((project) => project.packageName === dependency)
+    (dependency) => !projects.find((project) => project.npm === dependency)
   );
 
   return (

--- a/apps/bestofjs-nextjs/src/app/projects/[slug]/project-header.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/[slug]/project-header.tsx
@@ -22,7 +22,7 @@ export function ProjectHeader({ project }: Props) {
         <div className="pr-4">
           <ProjectLogo
             project={{
-              icon: project.logo || "",
+              logo: project.logo || "",
               name: project.name,
               owner_id: project.repo.owner_id,
             }}

--- a/apps/bestofjs-nextjs/src/components/core/project-logo.tsx
+++ b/apps/bestofjs-nextjs/src/components/core/project-logo.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/lib/utils";
 import { getProjectLogoUrl } from "./project-utils";
 
 type Props = {
-  project: Pick<BestOfJS.Project, "name" | "owner_id" | "icon">;
+  project: Pick<BestOfJS.Project, "name" | "owner_id" | "logo">;
   size: number;
   className?: string;
 };
@@ -36,12 +36,12 @@ function getProjectImageProps({
   size,
   colorMode,
 }: {
-  project: Pick<BestOfJS.Project, "name" | "owner_id" | "icon">;
+  project: Pick<BestOfJS.Project, "name" | "owner_id" | "logo">;
   size: number;
   colorMode: "dark" | "light";
 }) {
   const retinaURL =
-    !project.icon && getProjectLogoUrl(project, size * 2, colorMode);
+    !project.logo && getProjectLogoUrl(project, size * 2, colorMode);
 
   return {
     src: getProjectLogoUrl(project, size, colorMode),

--- a/apps/bestofjs-nextjs/src/components/core/project-utils.ts
+++ b/apps/bestofjs-nextjs/src/components/core/project-utils.ts
@@ -5,12 +5,12 @@
  * - A custom SVG file if project's `icon`property is specified.
  */
 export function getProjectLogoUrl(
-  project: Pick<BestOfJS.Project, "name" | "owner_id" | "icon">,
+  project: Pick<BestOfJS.Project, "name" | "owner_id" | "logo">,
   size: number,
   colorMode: "dark" | "light"
 ) {
-  const url = project.icon
-    ? getProjectLogoURL(project.icon, colorMode)
+  const url = project.logo
+    ? getProjectLogoURL(project.logo, colorMode)
     : getGitHubOwnerAvatarURL(project.owner_id, size);
   return url;
 }

--- a/apps/bestofjs-nextjs/src/components/project-list/project-table.tsx
+++ b/apps/bestofjs-nextjs/src/components/project-list/project-table.tsx
@@ -82,7 +82,7 @@ const ProjectTableRow = ({
           </NextLink>
           <div className="hidden w-full space-x-1 md:flex">
             <a
-              href={project.repository}
+              href={"https://github.com/" + project.full_name}
               aria-label="GitHub repository"
               rel="noopener noreferrer"
               target="_blank"

--- a/apps/bestofjs-nextjs/src/lib/global.d.ts
+++ b/apps/bestofjs-nextjs/src/lib/global.d.ts
@@ -28,15 +28,8 @@ declare namespace BestOfJS {
     status: string;
   }
 
-  // Project handled in the state container
-  interface StateProject extends RawProject {
-    repository: string;
-    packageName: string;
-    isBookmark?: boolean;
-  }
-
   // Project with the `tags` property populated "react" => {id: "react". name: "React"... }
-  interface Project extends Omit<StateProject, "tags"> {
+  interface Project extends Omit<RawProject, "tags"> {
     tags: Tag[];
   }
 

--- a/apps/bestofjs-nextjs/src/lib/global.d.ts
+++ b/apps/bestofjs-nextjs/src/lib/global.d.ts
@@ -24,7 +24,7 @@ declare namespace BestOfJS {
     branch?: string;
     npm: string;
     downloads: number;
-    icon: string;
+    logo: string;
     status: string;
   }
 
@@ -47,7 +47,7 @@ declare namespace BestOfJS {
     RawProject,
     | "description"
     | "full_name"
-    | "icon"
+    | "logo"
     | "name"
     | "npm"
     | "owner_id"

--- a/apps/bestofjs-nextjs/src/server/api-utils.tsx
+++ b/apps/bestofjs-nextjs/src/server/api-utils.tsx
@@ -24,18 +24,10 @@ export const populateProject =
   (tagsByKey: { [key: string]: BestOfJS.Tag }) =>
   (project: BestOfJS.RawProject) => {
     const populated = { ...project } as unknown as BestOfJS.Project;
-    const { full_name, tags } = project;
-
-    if (full_name) {
-      populated.repository = "https://github.com/" + full_name;
-    }
+    const { tags } = project;
 
     if (tags) {
       populated.tags = tags.map((id) => tagsByKey[id]).filter((tag) => !!tag);
-    }
-
-    if (project.npm) {
-      populated.packageName = project.npm; // TODO fix data?
     }
 
     return populated;

--- a/apps/bestofjs-webui/package.json
+++ b/apps/bestofjs-webui/package.json
@@ -17,7 +17,9 @@
     "precommit": "pretty-quick --staged",
     "lint": "eslint src",
     "lint:fix": "npm run lint -- --fix",
-    "sort": "npx sort-package-json"
+    "sort": "npx sort-package-json",
+    "typecheck": "tsc --noEmit",
+    "typecheck:watch": "tsc --noEmit --watch"
   },
   "repository": {
     "type": "git",

--- a/apps/bestofjs-webui/src/components/core/project-avatar.tsx
+++ b/apps/bestofjs-webui/src/components/core/project-avatar.tsx
@@ -1,7 +1,6 @@
-import React, { useState, useEffect } from "react";
+import React, { useEffect, useState } from "react";
+import { Box, chakra, useColorMode } from "components/core";
 import ContentLoader from "react-content-loader";
-
-import { Box, useColorMode, chakra } from "components/core";
 
 type Props = {
   project: BestOfJS.Project;
@@ -44,7 +43,7 @@ export const ProjectAvatar = ({ project, size = 100 }: Props) => {
 
 function getProjectImageProps({ project, size, colorMode }) {
   const retinaURL =
-    !project.icon && getProjectAvatarUrl(project, size * 2, colorMode);
+    !project.logo && getProjectAvatarUrl(project, size * 2, colorMode);
 
   return {
     src: getProjectAvatarUrl(project, size, colorMode),
@@ -85,7 +84,7 @@ function getGitHubOwnerAvatarURL(owner_id, size) {
 }
 
 export function getProjectAvatarUrl(project, size, colorMode) {
-  return project.icon
-    ? getProjectLogoURL(project.icon, colorMode)
+  return project.logo
+    ? getProjectLogoURL(project.logo, colorMode)
     : getGitHubOwnerAvatarURL(project.owner_id, size);
 }

--- a/apps/bestofjs-webui/src/components/home/home.tsx
+++ b/apps/bestofjs-webui/src/components/home/home.tsx
@@ -1,33 +1,35 @@
 import styled from "@emotion/styled";
-import numeral from "numeral";
-import { Link as RouterLink } from "react-router-dom";
-import { GoTag, GoHeart, GoPlus } from "react-icons/go";
-
 import {
+  Box,
   Button,
   ButtonProps,
-  Box,
+  Center,
+  ExternalLink,
   Flex,
   Link,
   LinkProps,
-  Center,
+  MainContent,
   PageHeader,
+  Section,
   SectionHeading,
 } from "components/core";
-import { APP_REPO_URL, APP_DISPLAY_NAME, SPONSOR_URL } from "config";
-import { useSelector } from "containers/project-data-container";
-import { getTotalNumberOfStars } from "selectors";
-import log from "helpers/log";
-import { addProjectURL } from "components/user-requests/add-project/create-issue-link";
-import { ProjectTagGroup } from "components/tags/project-tag";
 import { StarIcon } from "components/core/icons";
-import { ExternalLink, MainContent, Section } from "components/core";
+import { SortOptionKey } from "components/search/sort-order-options";
+import { ProjectTagGroup } from "components/tags/project-tag";
 import { CompactTagList } from "components/tags/tag-list";
-import { HotProjects, NewestProjects } from "./home-projects";
+import { addProjectURL } from "components/user-requests/add-project/create-issue-link";
+import { APP_DISPLAY_NAME, APP_REPO_URL, SPONSOR_URL } from "config";
+import { useSelector } from "containers/project-data-container";
+import log from "helpers/log";
+import numeral from "numeral";
+import { GoHeart, GoPlus, GoTag } from "react-icons/go";
+import { Link as RouterLink } from "react-router-dom";
+import { getTotalNumberOfStars } from "selectors";
+
 import { BetaVersionNews } from "./beta-version-news";
 import { RandomFeaturedProject } from "./featured-projects";
 import { HomeMonthlyRankings } from "./home-monthly-rankings";
-import { SortOptionKey } from "components/search/sort-order-options";
+import { HotProjects, NewestProjects } from "./home-projects";
 
 type Props = {
   pending: boolean;

--- a/apps/bestofjs-webui/src/components/project-list/project-table.tsx
+++ b/apps/bestofjs-webui/src/components/project-list/project-table.tsx
@@ -1,19 +1,18 @@
 import styled from "@emotion/styled";
-import { Link as RouterLink } from "react-router-dom";
-import numeral from "numeral";
-import { GoMarkGithub, GoBookmark, GoHome } from "react-icons/go";
-
 import {
   Box,
+  getDeltaByDay,
   IconButton,
   Link,
   ProjectAvatar,
-  getDeltaByDay,
 } from "components/core";
-import { AuthContainer } from "containers/auth-container";
 import { DownloadCount, StarDelta, StarTotal } from "components/core/project";
 import { ProjectTagGroup } from "components/tags/project-tag";
+import { AuthContainer } from "containers/auth-container";
 import { fromNow } from "helpers/from-now";
+import numeral from "numeral";
+import { GoBookmark, GoHome, GoMarkGithub } from "react-icons/go";
+import { Link as RouterLink } from "react-router-dom";
 
 type Props = {
   projects: BestOfJS.Project[];
@@ -31,7 +30,7 @@ export const ProjectTable = ({ projects, footer, ...otherProps }: Props) => {
             if (!project) return null;
             return (
               <ProjectTableRow
-                key={project.full_name}
+                key={project.slug}
                 project={project}
                 {...otherProps}
               />

--- a/apps/bestofjs-webui/src/containers/project-data-container.ts
+++ b/apps/bestofjs-webui/src/containers/project-data-container.ts
@@ -1,9 +1,9 @@
-import { createContainer } from "unstated-next";
-import useSWR from "swr";
-
+import { getProjectId } from "components/core/project";
 import { FETCH_ALL_PROJECTS_URL } from "config";
 import { fetchJSON } from "helpers/fetch";
-import { getProjectId } from "components/core/project";
+import useSWR from "swr";
+import { createContainer } from "unstated-next";
+
 import { AuthContainer } from "./auth-container";
 
 export type State = {
@@ -73,9 +73,7 @@ function getProjectsBySlug(projects) {
   const total = projects.length;
 
   projects.forEach((project, index) => {
-    const slug = getProjectId(project);
-    projectsBySlug[slug] = {
-      slug,
+    projectsBySlug[project.slug] = {
       addedPosition: total - index,
       ...project,
       packageName: project.npm,

--- a/apps/bestofjs-webui/src/global.d.ts
+++ b/apps/bestofjs-webui/src/global.d.ts
@@ -2,6 +2,7 @@ declare namespace BestOfJS {
   // Project raw data from the JSON API
   interface RawProject {
     name: string;
+    slug: string;
     full_name: string;
     description: string;
     tags: string[];
@@ -21,7 +22,7 @@ declare namespace BestOfJS {
     branch: string;
     npm: string;
     downloads: number;
-    icon: string;
+    logo: string;
     status: "active" | "promoted" | "deprecated" | "featured";
   }
 

--- a/packages/db/src/projects/project-helpers.ts
+++ b/packages/db/src/projects/project-helpers.ts
@@ -13,6 +13,10 @@ export function getProjectDescription(project: ProjectDetails) {
     : repoDescription || project.description;
 }
 
+export function getProjectRepositoryURL(project: ProjectDetails) {
+  return "https://github.com/" + project.repo.full_name;
+}
+
 export function getProjectURL(project: ProjectDetails) {
   invariant(project.repo);
   if (project.overrideURL) return project.url;


### PR DESCRIPTION
## Goal

A small change about the JSON file used as the "static" API to make it closer to the underlying data, as a preparations step to eventually remove the static API and query the DB directly.

- `icon` => `logo`

I noticed the mismatch when working on migration of Hall of Fame data.

