### PR TITLE
Various fixes about monthly rankings generation

### DIFF
--- a/apps/backend/src/tasks/build-static-api.task.ts
+++ b/apps/backend/src/tasks/build-static-api.task.ts
@@ -9,6 +9,7 @@ import {
   ProjectDetails,
 } from "@repo/db/projects";
 import { Task } from "@/task-runner";
+import { truncate } from "@/utils";
 import { ProjectItem } from "./static-api-types";
 
 export const buildStaticApiTask: Task = {
@@ -161,9 +162,4 @@ function getDailyHotProjects(projects: ProjectItem[]) {
 
 function formatDate(date: Date | null) {
   return date ? date.toISOString().slice(0, 10) : "";
-}
-
-function truncate(input: string, maxLength = 50) {
-  const isTruncated = input.length > maxLength;
-  return isTruncated ? `${input.slice(0, maxLength)}...` : input;
 }

--- a/apps/backend/src/tasks/hello-world.task.ts
+++ b/apps/backend/src/tasks/hello-world.task.ts
@@ -3,11 +3,14 @@ import { Task } from "@/task-runner";
 export const helloWorldReposTask: Task = {
   name: "hello-world-repos",
   description: "A simple `hello world` task to, looping through all repos",
-  run: async ({ processRepos }) => {
+  run: async ({ processRepos, logger }) => {
     return await processRepos(async (repo) => {
       const isDeprecated = repo.projects.every(
         (project) => project.status === "deprecated"
       );
+
+      logger.debug(repo);
+
       return {
         meta: { isDeprecated },
         data: { stars: repo.stars },

--- a/apps/backend/src/utils.ts
+++ b/apps/backend/src/utils.ts
@@ -1,0 +1,4 @@
+export function truncate(input: string, maxLength = 50) {
+  const isTruncated = input.length > maxLength;
+  return isTruncated ? `${input.slice(0, maxLength)}...` : input;
+}

--- a/apps/bestofjs-nextjs/src/server/api-rankings.ts
+++ b/apps/bestofjs-nextjs/src/server/api-rankings.ts
@@ -47,7 +47,8 @@ export function createRankingsAPI(
 
       const sortedProjects = projects
         .map(({ full_name, delta }) => {
-          const project = foundProjects.find(
+          // we use `findLast` to lookup data because the oldest projects have a higher priority. TODO don't lookup by full_name, use a unique key
+          const project = foundProjects.findLast(
             (project) => project.full_name === full_name
           );
           if (!project) {

--- a/packages/db/drizzle/0004_overjoyed_aqueduct.sql
+++ b/packages/db/drizzle/0004_overjoyed_aqueduct.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "projects" ADD COLUMN "priority" smallint DEFAULT 0 NOT NULL;

--- a/packages/db/drizzle/meta/0004_snapshot.json
+++ b/packages/db/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,595 @@
+{
+  "id": "3d8c06b2-6f76-4352-91d7-95398a452578",
+  "prevId": "d0db254b-73a3-44c8-8882-18e84bf63a86",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.bundles": {
+      "name": "bundles",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gzip": {
+          "name": "gzip",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bundles_name_packages_name_fk": {
+          "name": "bundles_name_packages_name_fk",
+          "tableFrom": "bundles",
+          "tableTo": "packages",
+          "columnsFrom": [
+            "name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.packages": {
+      "name": "packages",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "downloads": {
+          "name": "downloads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependencies": {
+          "name": "dependencies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "devDependencies": {
+          "name": "devDependencies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deprecated": {
+          "name": "deprecated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "packages_project_id_projects_id_fk": {
+          "name": "packages_project_id_projects_id_fk",
+          "tableFrom": "packages",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "override_description": {
+          "name": "override_description",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_url": {
+          "name": "override_url",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitter": {
+          "name": "twitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "comments": {
+          "name": "comments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repoId": {
+          "name": "repoId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_repoId_repos_id_fk": {
+          "name": "projects_repoId_repos_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "repos",
+          "columnsFrom": [
+            "repoId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "projects_slug_unique": {
+          "name": "projects_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      }
+    },
+    "public.projects_to_tags": {
+      "name": "projects_to_tags",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_to_tags_project_id_projects_id_fk": {
+          "name": "projects_to_tags_project_id_projects_id_fk",
+          "tableFrom": "projects_to_tags",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "projects_to_tags_tag_id_tags_id_fk": {
+          "name": "projects_to_tags_tag_id_tags_id_fk",
+          "tableFrom": "projects_to_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "projects_to_tags_project_id_tag_id_pk": {
+          "name": "projects_to_tags_project_id_tag_id_pk",
+          "columns": [
+            "project_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.repos": {
+      "name": "repos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "homepage": {
+          "name": "homepage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stargazers_count": {
+          "name": "stargazers_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pushed_at": {
+          "name": "pushed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_commit": {
+          "name": "last_commit",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_count": {
+          "name": "commit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contributor_count": {
+          "name": "contributor_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "repos_full_name_unique": {
+          "name": "repos_full_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "full_name"
+          ]
+        }
+      }
+    },
+    "public.snapshots": {
+      "name": "snapshots",
+      "schema": "",
+      "columns": {
+        "repo_id": {
+          "name": "repo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "months": {
+          "name": "months",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "snapshots_repo_id_repos_id_fk": {
+          "name": "snapshots_repo_id_repos_id_fk",
+          "tableFrom": "snapshots",
+          "tableTo": "repos",
+          "columnsFrom": [
+            "repo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "snapshots_repo_id_year_pk": {
+          "name": "snapshots_repo_id_year_pk",
+          "columns": [
+            "repo_id",
+            "year"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_code_unique": {
+          "name": "tags_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1726269359368,
       "tag": "0003_deep_the_enforcers",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1728175271062,
+      "tag": "0004_overjoyed_aqueduct",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "generate": "dotenv -e ../../.env.${STAGE:=development} pnpm drizzle-kit generate",
-    "migrate": "bun run src/migrate.ts",
+    "migrate": "dotenv -e ../../.env.${STAGE:=development} tsx src/migrate.ts",
     "studio": "dotenv -e ../../.env.${STAGE:=development} pnpm drizzle-kit studio",
     "typecheck": "tsc --noEmit",
     "typecheck:watch": "tsc --noEmit --incremental --watch",

--- a/packages/db/src/projects/project-helpers.ts
+++ b/packages/db/src/projects/project-helpers.ts
@@ -81,7 +81,9 @@ export function getPackageData(project: ProjectDetails) {
  * Exclude from the rankings projects with specific tags
  * TODO: move this behavior to the `tag` record, adding an attribute `exclude_from_rankings`?
  **/
-export function isProjectIncludedInRankings(project: ProjectDetails) {
+export function isProjectIncludedInRankings(
+  project: Pick<ProjectDetails, "tags">
+) {
   const hasExcludedTag = TAGS_EXCLUDED_FROM_RANKINGS.some((tagCode) =>
     project.tags.map((tag) => tag.code).includes(tagCode)
   );

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -5,6 +5,7 @@ import {
   jsonb,
   pgTable,
   primaryKey,
+  smallint,
   text,
   timestamp,
 } from "drizzle-orm/pg-core";
@@ -22,6 +23,7 @@ export const projects = pgTable("projects", {
   status: text("status", { enum: PROJECT_STATUSES }).notNull(),
   logo: text("logo"),
   twitter: text("twitter"),
+  priority: smallint("priority").notNull().default(0),
   comments: text("comments"),
   createdAt: timestamp("created_at").notNull().defaultNow(),
   updatedAt: timestamp("updated_at"),

--- a/packages/db/src/snapshots/monthly-trends.ts
+++ b/packages/db/src/snapshots/monthly-trends.ts
@@ -5,7 +5,7 @@ export function getMonthlyTrends(snapshots: Snapshot[], date: Date) {
   const trends = months
     .map((month) => ({
       ...month,
-      delta: getMonthlyDelta(snapshots, month),
+      delta: getMonthlyDelta(snapshots, month).delta,
     }))
     .filter((month) => month.delta !== undefined);
   return trends as (SnapshotMonth & { delta: number })[];
@@ -20,18 +20,19 @@ export function getLastSnapshotOfTheMonth(
   );
 }
 
-export function getMonthlyDelta(
-  snapshots: Snapshot[],
-  date: SnapshotMonth
-): number | undefined {
+export function getMonthlyDelta(snapshots: Snapshot[], date: SnapshotMonth) {
   const firstSnapshot = getFirstSnapshotOfTheMonth(snapshots, date);
 
   const lastSnapshot = getFirstSnapshotOfTheMonth(
     snapshots,
     getNextMonth(date)
   );
-  if (!lastSnapshot || !firstSnapshot) return undefined;
-  return lastSnapshot.stars - firstSnapshot.stars;
+  const delta =
+    !lastSnapshot || !firstSnapshot
+      ? undefined
+      : lastSnapshot.stars - firstSnapshot.stars;
+  const stars = lastSnapshot?.stars || undefined;
+  return { delta, stars };
 }
 
 export function getFirstSnapshotOfTheMonth(


### PR DESCRIPTION
## Goal

- Remove duplicate projects in the Monthly Rankings JSON file generated every month. Because of #308 several projects from the same repo can show up, E.g. `Svelte Flow` and `React Flow`. It should fix the error about duplicate keys when displaying the list.
- Truncate description in the JSON file (the description is not used anyway)
- In generated data, handle number of stars at the end of the month instead of at the time the script is launched: to be able to re-run the script for a given month without triggering changes about `stars`
- introduce a `priority` field in the project schema to be able to set priorities for projects belonging to the same repo

## How to test

To generate the rankings from September

```sh
bun run apps/backend/src/cli.ts build-monthly-rankings --year 2024 --month 9
```

The files are copied to https://github.com/bestofjs/bestofjs-rankings and served by Vercel.

## Notes

The whole implementation of the "Monthly Rankings" feature should be rebuilt to take into account the new backend.
Instead of generating the current JSON files every month, a more structured approach would be better for data consistency.

The current JSON files are almost useless as the UI only handles the project `full_name` and the number of stars added during the month.
