### PR TITLE
Improve database `repos` schema

### DIFF
--- a/apps/admin/src/app/projects/[slug]/page.tsx
+++ b/apps/admin/src/app/projects/[slug]/page.tsx
@@ -48,7 +48,7 @@ export default async function ViewProjectPage({ params: { slug } }: PageProps) {
         <ViewSnapshots
           snapshots={repo.snapshots}
           repoId={project.repoId}
-          repoFullName={repo.full_name}
+          repoFullName={repo.owner + "/" + repo.name}
           slug={project.slug}
         />
       )}

--- a/apps/admin/src/app/projects/[slug]/view-related-projects.tsx
+++ b/apps/admin/src/app/projects/[slug]/view-related-projects.tsx
@@ -43,10 +43,10 @@ async function SameRepoOtherProjectsSection({ project }: Props) {
 }
 
 async function SameOwnerOtherProjectsSection({ project }: Props) {
-  const owner = project.repo.full_name.split("/")[0];
+  const owner = project.repo.owner;
   const projectsFromSameOwner = await findProjectsByOwner(owner);
   const otherProjects = projectsFromSameOwner.filter(
-    (foundProject) => foundProject.repo?.full_name !== project.repo.full_name
+    (foundProject) => foundProject.repo?.name !== project.repo.name
   );
   return (
     <section>

--- a/apps/admin/src/app/projects/[slug]/view-repo.tsx
+++ b/apps/admin/src/app/projects/[slug]/view-repo.tsx
@@ -55,10 +55,10 @@ function ViewRepoData({ repo }: { repo: typeof schema.repos.$inferSelect }) {
       <p>Full Name</p>
       <p>
         <a
-          href={`https://github.com/${repo.full_name}`}
+          href={`https://github.com/${repo.owner}/${repo.name}`}
           className="hover:underline"
         >
-          {repo.full_name}
+          {repo.owner}/{repo.name}
         </a>
       </p>
       <p>Description</p>

--- a/apps/admin/src/app/projects/page.tsx
+++ b/apps/admin/src/app/projects/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { z } from "zod";
 
-import { getDatabase } from "@repo/db";
+import { db } from "@repo/db";
 import {
   countProjects,
   findProjects,
@@ -25,8 +25,6 @@ type PageProps = {
 };
 
 export default async function ProjectsPage({ searchParams }: PageProps) {
-  const db = getDatabase();
-
   const searchOptions = searchSchema.parse(searchParams);
   const { limit, offset, sort, tag, text } = searchOptions;
 

--- a/apps/admin/src/components/project-logo.tsx
+++ b/apps/admin/src/components/project-logo.tsx
@@ -10,7 +10,7 @@ type Props = {
   project: {
     name: string;
     logo?: string | null;
-    repo: { owner_id: string } | null;
+    repo: { owner_id: number } | null;
   };
   size: number;
   className?: string;
@@ -80,6 +80,6 @@ function getProjectLogoURL(input: string, colorMode: string) {
   return `https://bestofjs.org/logos/${filename}`;
 }
 
-function getGitHubOwnerAvatarURL(owner_id: string, size: number) {
+function getGitHubOwnerAvatarURL(owner_id: number, size: number) {
   return `https://avatars.githubusercontent.com/u/${owner_id}?v=3&s=${size}`;
 }

--- a/apps/admin/src/db.ts
+++ b/apps/admin/src/db.ts
@@ -1,8 +1,6 @@
-import { getDatabase } from "@repo/db";
+import { db } from "@repo/db";
 import { ProjectService } from "@repo/db/projects";
 import { SnapshotsService } from "@repo/db/snapshots";
-
-const db = getDatabase();
 
 /** Export singletons to avoid creating too many connections */
 export const projectService = new ProjectService(db);

--- a/apps/backend/src/flags.ts
+++ b/apps/backend/src/flags.ts
@@ -7,7 +7,8 @@ export const sharedFlagsSchema = z.object({
   logLevel: z.number().optional().default(3),
   limit: z.number().optional().default(0),
   skip: z.number().optional().default(0),
-  name: z.string().optional().default(""),
+  fullName: z.string().optional().default(""),
+  slug: z.string().optional().default(""),
   throttleInterval: z.number().optional().default(0),
 });
 
@@ -39,7 +40,11 @@ export const cliFlags: Command["options"]["flags"] = {
     description: "Records to skip (when paginating)",
     default: 0,
   },
-  name: {
+  slug: {
+    type: String,
+    description: "Slug of the project to process",
+  },
+  fullName: {
     type: String,
     description: "Full name of the GitHub repo to process",
     default: "",

--- a/apps/backend/src/iteration-helpers/repo-processor.ts
+++ b/apps/backend/src/iteration-helpers/repo-processor.ts
@@ -34,7 +34,7 @@ export class RepoProcessor extends ItemProcessor<Repo> {
     }
 
     if (name) {
-      query.where(eq(schema.repos.full_name, name));
+      query.where(eq(schema.repos.name, name)); // TODO handle full_name instead of name
     }
 
     const repos = await query;
@@ -77,6 +77,7 @@ async function findRepoById(db: DB, id: string) {
   });
 
   const snapshots = snapshotsSchema.parse(repo.snapshots);
+  const full_name = repo.owner + "/" + repo.name;
 
-  return { ...repo, snapshots, projects };
+  return { ...repo, full_name, snapshots, projects };
 }

--- a/apps/backend/src/iteration-helpers/repo-processor.ts
+++ b/apps/backend/src/iteration-helpers/repo-processor.ts
@@ -1,4 +1,4 @@
-import { asc, desc, eq } from "drizzle-orm";
+import { and, asc, desc, eq } from "drizzle-orm";
 
 import { DB, schema } from "@repo/db";
 import { snapshotsSchema } from "@repo/db/projects";
@@ -21,26 +21,33 @@ export class RepoProcessor extends ItemProcessor<Repo> {
 
   async getAllItemsIds() {
     const { db, logger } = this.context;
-    const { limit, skip, name } = this.loopOptions;
+    const { limit, skip, fullName, slug } = this.loopOptions;
+    const { repos, projects } = schema;
 
     const query = db
-      .select({ id: schema.repos.id })
-      .from(schema.repos)
-      .orderBy(desc(schema.repos.added_at))
+      .select({ id: repos.id })
+      .from(repos)
+      .orderBy(desc(repos.added_at))
       .offset(skip);
 
     if (limit) {
       query.limit(limit);
     }
 
-    if (name) {
-      query.where(eq(schema.repos.name, name)); // TODO handle full_name instead of name
+    if (fullName) {
+      const [owner, name] = fullName.split("/");
+      query.where(and(eq(repos.owner, owner), eq(repos.name, name)));
     }
 
-    const repos = await query;
-    if (!repos.length) logger.error("No repos found");
+    if (slug) {
+      query.leftJoin(projects, eq(repos.id, projects.repoId));
+      query.where(eq(projects.slug, slug));
+    }
 
-    const ids = repos.map((repo) => repo.id);
+    const foundRepos = await query;
+    if (!foundRepos.length) logger.error("No repos found");
+
+    const ids = foundRepos.map((repo) => repo.id);
     return ids;
   }
 

--- a/apps/backend/src/task-runner.ts
+++ b/apps/backend/src/task-runner.ts
@@ -31,15 +31,8 @@ export function createTaskRunner(tasks: Task<RawFlags | undefined>[]) {
   return {
     run(rawFlags: RawFlags) {
       const flags = sharedFlagsSchema.parse(rawFlags);
-      const logger = createConsola({ level: flags.logLevel });
-      const dryRun = flags.dryRun;
-      const options = {
-        limit: flags.limit,
-        skip: flags.skip,
-        concurrency: flags.concurrency,
-        name: flags.name,
-        throttleInterval: flags.throttleInterval,
-      };
+      const { logLevel, dryRun, ...options } = flags;
+      const logger = createConsola({ level: logLevel });
 
       return new Promise((resolve) => {
         runQuery(async (db) => {

--- a/apps/backend/src/task-types.ts
+++ b/apps/backend/src/task-types.ts
@@ -19,5 +19,5 @@ export interface TaskContext extends TaskRunnerContext {
 
 export type TaskLoopOptions = Pick<
   ParsedFlags,
-  "concurrency" | "limit" | "skip" | "name" | "throttleInterval"
+  "concurrency" | "limit" | "skip" | "slug" | "fullName" | "throttleInterval"
 >;

--- a/apps/backend/src/tasks/hello-world.task.ts
+++ b/apps/backend/src/tasks/hello-world.task.ts
@@ -22,9 +22,12 @@ export const helloWorldReposTask: Task = {
 export const helloWorldProjectsTask: Task = {
   name: "hello-world-projects",
   description: "A simple `hello world` task, looping through all projects",
-  run: async ({ processProjects }) => {
+  run: async ({ processProjects, logger }) => {
     return await processProjects(async (project) => {
       const isDeprecated = project.status === "deprecated";
+
+      logger.debug(project);
+
       return {
         meta: { isDeprecated },
         data: { stars: project.name },

--- a/apps/backend/src/tasks/static-api-types.ts
+++ b/apps/backend/src/tasks/static-api-types.ts
@@ -6,7 +6,7 @@ export type ProjectItem = {
   url?: string;
   stars: number;
   full_name: string;
-  owner_id: string;
+  owner_id: number;
   created_at: string;
   pushed_at: string;
   contributor_count: number | null;

--- a/apps/bestofjs-nextjs/src/app/db.ts
+++ b/apps/bestofjs-nextjs/src/app/db.ts
@@ -1,7 +1,5 @@
-import { getDatabase } from "@repo/db";
+import { db } from "@repo/db";
 import { ProjectService } from "@repo/db/projects";
-
-const db = getDatabase();
 
 /** Export a singleton to avoid creating too many connections */
 export const projectService = new ProjectService(db);

--- a/apps/bestofjs-nextjs/src/components/core/project-utils.ts
+++ b/apps/bestofjs-nextjs/src/components/core/project-utils.ts
@@ -21,6 +21,6 @@ function getProjectLogoURL(input: string, colorMode: string) {
   return `/logos/${filename}`;
 }
 
-function getGitHubOwnerAvatarURL(owner_id: string, size: number) {
+function getGitHubOwnerAvatarURL(owner_id: number, size: number) {
   return `https://avatars.githubusercontent.com/u/${owner_id}?v=3&s=${size}`;
 }

--- a/apps/bestofjs-nextjs/src/lib/global.d.ts
+++ b/apps/bestofjs-nextjs/src/lib/global.d.ts
@@ -19,7 +19,7 @@ declare namespace BestOfJS {
     contributor_count: number;
     pushed_at: string;
     created_at: string;
-    owner_id: string;
+    owner_id: number;
     url: string;
     branch?: string;
     npm: string;

--- a/packages/api/src/github/repo-info-query.ts
+++ b/packages/api/src/github/repo-info-query.ts
@@ -102,7 +102,7 @@ const getTopic = (edge: any) => edge.node.topic.name;
 function extractOwnerIdFromAvatarURL(url: string) {
   const re = /\/u\/(.+)\?/;
   const parts = re.exec(url);
-  if (parts) return parts[1];
+  return parseInt(parts?.[1] || "0");
 }
 
 function cleanGitHubDescription(description: string) {

--- a/packages/db/drizzle/0005_silky_carlie_cooper.sql
+++ b/packages/db/drizzle/0005_silky_carlie_cooper.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "repos" RENAME COLUMN "full_name" TO "owner";--> statement-breakpoint
+ALTER TABLE "repos" DROP CONSTRAINT "repos_full_name_unique";--> statement-breakpoint
+ALTER TABLE "repos" ALTER COLUMN "owner_id" SET DATA TYPE integer USING owner_id::integer;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "name_owner_index" ON "repos" USING btree ("owner","name");
+
+UPDATE repos SET owner = split_part(owner, '/', 1);

--- a/packages/db/drizzle/meta/0005_snapshot.json
+++ b/packages/db/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,609 @@
+{
+  "id": "fd29c96e-e1f0-4403-84f9-a5f80eecac48",
+  "prevId": "3d8c06b2-6f76-4352-91d7-95398a452578",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.bundles": {
+      "name": "bundles",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gzip": {
+          "name": "gzip",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bundles_name_packages_name_fk": {
+          "name": "bundles_name_packages_name_fk",
+          "tableFrom": "bundles",
+          "tableTo": "packages",
+          "columnsFrom": [
+            "name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.packages": {
+      "name": "packages",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "downloads": {
+          "name": "downloads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependencies": {
+          "name": "dependencies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "devDependencies": {
+          "name": "devDependencies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deprecated": {
+          "name": "deprecated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "packages_project_id_projects_id_fk": {
+          "name": "packages_project_id_projects_id_fk",
+          "tableFrom": "packages",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "override_description": {
+          "name": "override_description",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_url": {
+          "name": "override_url",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitter": {
+          "name": "twitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "comments": {
+          "name": "comments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repoId": {
+          "name": "repoId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_repoId_repos_id_fk": {
+          "name": "projects_repoId_repos_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "repos",
+          "columnsFrom": [
+            "repoId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "projects_slug_unique": {
+          "name": "projects_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      }
+    },
+    "public.projects_to_tags": {
+      "name": "projects_to_tags",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_to_tags_project_id_projects_id_fk": {
+          "name": "projects_to_tags_project_id_projects_id_fk",
+          "tableFrom": "projects_to_tags",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "projects_to_tags_tag_id_tags_id_fk": {
+          "name": "projects_to_tags_tag_id_tags_id_fk",
+          "tableFrom": "projects_to_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "projects_to_tags_project_id_tag_id_pk": {
+          "name": "projects_to_tags_project_id_tag_id_pk",
+          "columns": [
+            "project_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.repos": {
+      "name": "repos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "homepage": {
+          "name": "homepage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stargazers_count": {
+          "name": "stargazers_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pushed_at": {
+          "name": "pushed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_commit": {
+          "name": "last_commit",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_count": {
+          "name": "commit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contributor_count": {
+          "name": "contributor_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "name_owner_index": {
+          "name": "name_owner_index",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.snapshots": {
+      "name": "snapshots",
+      "schema": "",
+      "columns": {
+        "repo_id": {
+          "name": "repo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "months": {
+          "name": "months",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "snapshots_repo_id_repos_id_fk": {
+          "name": "snapshots_repo_id_repos_id_fk",
+          "tableFrom": "snapshots",
+          "tableTo": "repos",
+          "columnsFrom": [
+            "repo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "snapshots_repo_id_year_pk": {
+          "name": "snapshots_repo_id_year_pk",
+          "columns": [
+            "repo_id",
+            "year"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_code_unique": {
+          "name": "tags_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1728175271062,
       "tag": "0004_overjoyed_aqueduct",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1728864550881,
+      "tag": "0005_silky_carlie_cooper",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "generate": "dotenv -e ../../.env.${STAGE:=development} pnpm drizzle-kit generate",
-    "migrate": "dotenv -e ../../.env.${STAGE:=development} tsx src/migrate.ts",
+    "migrate": "dotenv -e ../../.env.${STAGE:=development} pnpm drizzle-kit migrate",
+    "migrate1": "dotenv -e ../../.env.${STAGE:=development} tsx src/migrate.ts",
     "studio": "dotenv -e ../../.env.${STAGE:=development} pnpm drizzle-kit studio",
     "typecheck": "tsc --noEmit",
     "typecheck:watch": "tsc --noEmit --incremental --watch",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "generate": "dotenv -e ../../.env.${STAGE:=development} pnpm drizzle-kit generate",
     "migrate": "dotenv -e ../../.env.${STAGE:=development} pnpm drizzle-kit migrate",
-    "migrate1": "dotenv -e ../../.env.${STAGE:=development} tsx src/migrate.ts",
     "studio": "dotenv -e ../../.env.${STAGE:=development} pnpm drizzle-kit studio",
     "typecheck": "tsc --noEmit",
     "typecheck:watch": "tsc --noEmit --incremental --watch",

--- a/packages/db/seed/import-projects.ts
+++ b/packages/db/seed/import-projects.ts
@@ -1,14 +1,14 @@
 import { eq } from "drizzle-orm";
 import slugify from "slugify";
 
+import { DB } from "../src/index";
+import * as schema from "../src/schema";
 import {
-  MongoProject,
   fetchAllProjects,
   fetchFeaturedProjects,
   getDateFromMongoValue,
+  MongoProject,
 } from "./read-data";
-import { DB } from "../src/index";
-import * as schema from "../src/schema";
 import { runDbScript } from "./run-db-script";
 
 const debug = false;
@@ -138,9 +138,9 @@ function getRepoRecord(doc: MongoProject) {
   const record = {
     id: getId(doc),
     added_at: getDateFromMongoValue(doc.createdAt) as Date,
-    owner_id: data.owner_id,
+    owner_id: parseInt(data.owner_id, 0),
     name: data.name,
-    full_name: data.full_name,
+    owner: data.full_name.split("/")[0],
     stars: data.stargazers_count,
     description: data.description,
     homepage: data.homepage,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -7,10 +7,7 @@ export * as schema from "./schema";
 
 export type DB = ReturnType<typeof drizzle<typeof schema>>;
 
-export function getDatabase() {
-  const service = new VercelPostgresService();
-  return service.db;
-}
+export const db = drizzle(sql, { schema });
 
 export async function runQuery(callback: (db: DB) => Promise<void>) {
   const service = new VercelPostgresService();
@@ -29,7 +26,7 @@ class VercelPostgresService {
 
   constructor() {
     console.log("Vercel DB connected");
-    this.db = drizzle(sql, { schema });
+    this.db = db;
     sql.on("remove", () => {
       console.log("Vercel DB disconnected");
     });

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -1,9 +1,0 @@
-import { migrate } from "drizzle-orm/postgres-js/migrator";
-
-import { DB, runQuery } from "./index";
-
-runQuery(async (db: DB) => {
-  console.log("Migrate PG");
-  // @ts-expect-error TODO `migrate` should be provided by the database service
-  await migrate(db, { migrationsFolder: "./drizzle" });
-});

--- a/packages/db/src/projects/create.ts
+++ b/packages/db/src/projects/create.ts
@@ -4,11 +4,10 @@ import { nanoid } from "nanoid";
 import slugify from "slugify";
 import { z } from "zod";
 
-import { getDatabase } from "..";
+import { db } from "..";
 import * as schema from "../schema";
 
 export async function createProject(gitHubURL: string) {
-  const db = getDatabase();
   const fullName = gitHubURL.split("/").slice(-2).join("/");
   const repoData = await fetchGitHubRepoData(fullName);
 
@@ -64,7 +63,6 @@ export async function addProjectToRepo({
   description: string;
   repoId: string;
 }) {
-  const db = getDatabase();
   const createdProjects = await db
     .insert(schema.projects)
     .values({

--- a/packages/db/src/projects/create.ts
+++ b/packages/db/src/projects/create.ts
@@ -2,6 +2,7 @@
 
 import { nanoid } from "nanoid";
 import slugify from "slugify";
+import { z } from "zod";
 
 import { getDatabase } from "..";
 import * as schema from "../schema";
@@ -9,37 +10,41 @@ import * as schema from "../schema";
 export async function createProject(gitHubURL: string) {
   const db = getDatabase();
   const fullName = gitHubURL.split("/").slice(-2).join("/");
-  const data = await fetchGitHubRepoData(fullName);
-  const repoId = nanoid();
-  await db
-    .insert(schema.repos)
-    .values({ id: repoId, added_at: new Date(), ...data });
+  const repoData = await fetchGitHubRepoData(fullName);
 
-  const createdProjects = await db
-    .insert(schema.projects)
-    .values({
-      id: nanoid(),
-      createdAt: new Date(),
-      repoId,
-      name: data.name,
-      slug: slugify(data.name),
-      description: data.description,
-      url: data.homepage,
-      status: "active",
-    })
-    .returning();
+  const repoId = nanoid();
+
+  const createdProjects = await db.transaction(async (tx) => {
+    await tx.insert(schema.repos).values({ id: repoId, ...repoData });
+
+    return await tx
+      .insert(schema.projects)
+      .values({
+        id: nanoid(),
+        repoId,
+        name: repoData.name,
+        slug: slugify(repoData.name),
+        description: repoData.description || "(No description)",
+        url: repoData.homepage,
+        status: "active",
+      })
+      .returning();
+  });
+
+  console.log("Project created", createdProjects);
 
   return createdProjects[0];
 }
 
 async function fetchGitHubRepoData(fullName: string) {
-  const data = await fetch(`https://api.github.com/repos/${fullName}`).then(
+  const rawData = await fetch(`https://api.github.com/repos/${fullName}`).then(
     (res) => res.json()
   );
+  const data = apiResponseSchema.parse(rawData);
   return {
     owner_id: data.owner.id,
+    owner: data.owner.login,
     name: data.name,
-    full_name: data.full_name,
     description: data.description,
     default_branch: data.default_branch,
     homepage: data.homepage,
@@ -75,3 +80,18 @@ export async function addProjectToRepo({
 
   return createdProjects[0];
 }
+
+const apiResponseSchema = z.object({
+  name: z.string(),
+  owner: z.object({
+    id: z.number(),
+    login: z.string(),
+  }),
+  homepage: z.string().nullable(),
+  default_branch: z.string().nullable(),
+  description: z.string().nullable(),
+  stargazers_count: z.number(),
+  created_at: z.string(),
+  pushed_at: z.string(),
+  topics: z.array(z.string()),
+});

--- a/packages/db/src/projects/find.ts
+++ b/packages/db/src/projects/find.ts
@@ -80,6 +80,8 @@ export async function findProjects({
       projects.logo,
       projects.createdAt,
       repos.archived,
+      repos.name,
+      repos.owner,
       repos.stars,
       repos.owner_id,
       projectsToTags.projectId,

--- a/packages/db/src/projects/get.ts
+++ b/packages/db/src/projects/get.ts
@@ -52,7 +52,11 @@ export class ProjectService {
     if (!project) return null;
     invariant(project?.repo);
     const snapshots = snapshotsSchema.parse(project?.repo?.snapshots);
-    const repo = { ...project.repo, snapshots };
+    const repo = {
+      ...project.repo,
+      full_name: project.repo.owner + "/" + project.repo.name,
+      snapshots,
+    };
 
     const tags = project.projectsToTags.map((ptt) => ptt.tag);
 

--- a/packages/db/src/projects/packages.ts
+++ b/packages/db/src/projects/packages.ts
@@ -1,10 +1,9 @@
 import { and, eq } from "drizzle-orm";
 
-import { getDatabase } from "..";
+import { db } from "..";
 import * as schema from "../schema";
 
 export async function addPackage(projectId: string, packageName: string) {
-  const db = getDatabase();
   const values = {
     name: packageName,
     projectId,
@@ -13,7 +12,6 @@ export async function addPackage(projectId: string, packageName: string) {
 }
 
 export async function removePackage(projectId: string, packageName: string) {
-  const db = getDatabase();
   await db
     .delete(schema.packages)
     .where(

--- a/packages/db/src/projects/project-helpers.ts
+++ b/packages/db/src/projects/project-helpers.ts
@@ -14,7 +14,7 @@ export function getProjectDescription(project: ProjectDetails) {
 }
 
 export function getProjectRepositoryURL(project: ProjectDetails) {
-  return "https://github.com/" + project.repo.full_name;
+  return "https://github.com/" + project.repo.owner + "/" + project.repo.name;
 }
 
 export function getProjectURL(project: ProjectDetails) {

--- a/packages/db/src/projects/tags.ts
+++ b/packages/db/src/projects/tags.ts
@@ -1,10 +1,9 @@
 import { and, asc, eq, inArray } from "drizzle-orm";
 
-import { getDatabase } from "..";
+import { db } from "..";
 import * as schema from "../schema";
 
 export function getAllTags() {
-  const db = getDatabase();
   const tags = db.query.tags.findMany({
     orderBy: asc(schema.tags.name),
   });
@@ -12,7 +11,6 @@ export function getAllTags() {
 }
 
 export async function saveTags(projectId: string, tagIds: string[]) {
-  const db = getDatabase();
   const currentTagRecords = await db.query.projectsToTags.findMany({
     where: eq(schema.projectsToTags.projectId, projectId),
   });
@@ -31,7 +29,6 @@ export async function saveTags(projectId: string, tagIds: string[]) {
 }
 
 export async function addTagsToProject(projectId: string, tagIds: string[]) {
-  const db = getDatabase();
   const values = tagIds.map((tagId) => ({
     projectId,
     tagId,
@@ -44,7 +41,6 @@ export async function removeTagsFromProject(
   projectId: string,
   tagIds: string[]
 ) {
-  const db = getDatabase();
   await db
     .delete(schema.projectsToTags)
     .where(

--- a/packages/db/src/projects/update.ts
+++ b/packages/db/src/projects/update.ts
@@ -1,6 +1,6 @@
 import { eq } from "drizzle-orm";
 
-import { getDatabase } from "..";
+import { db } from "..";
 import * as schema from "../schema";
 
 type Project = typeof schema.projects.$inferInsert;
@@ -9,12 +9,10 @@ export async function updateProjectById(
   projectId: string,
   data: Partial<Project>
 ) {
-  console.log("Update", projectId, data);
-
-  const db = getDatabase();
   const result = await db
     .update(schema.projects)
     .set(data)
-    .where(eq(schema.projects.id, projectId));
-  console.log("Done", result);
+    .where(eq(schema.projects.id, projectId))
+    .returning();
+  console.log("Project updated", result);
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -8,6 +8,7 @@ import {
   smallint,
   text,
   timestamp,
+  uniqueIndex,
 } from "drizzle-orm/pg-core";
 
 import { PROJECT_STATUSES } from "./constants";
@@ -78,33 +79,39 @@ export const projectsToTagsRelations = relations(projectsToTags, ({ one }) => ({
   }),
 }));
 
-export const repos = pgTable("repos", {
-  id: text("id").primaryKey(),
-  // Date of addition to Best of JS
-  added_at: timestamp("added_at").notNull().defaultNow(),
-  // Last update (by the daily task)
-  updated_at: timestamp("updated_at"),
-  // From GitHub REST API
-  archived: boolean("archived"),
-  default_branch: text("default_branch"),
-  description: text("description"),
-  full_name: text("full_name").notNull().unique(),
-  homepage: text("homepage"),
-  name: text("name").notNull(),
-  owner_id: text("owner_id").notNull(),
-  stars: integer("stargazers_count"),
-  topics: jsonb("topics"),
+export const repos = pgTable(
+  "repos",
+  {
+    id: text("id").primaryKey(),
+    // Date of addition to Best of JS
+    added_at: timestamp("added_at").notNull().defaultNow(),
+    // Last update (by the daily task)
+    updated_at: timestamp("updated_at"),
+    // From GitHub REST API
+    archived: boolean("archived"),
+    default_branch: text("default_branch"),
+    description: text("description"),
+    homepage: text("homepage"),
+    name: text("name").notNull(),
+    owner: text("owner").notNull(),
+    owner_id: integer("owner_id").notNull(), // used in GitHub users avatar URLs
+    stars: integer("stargazers_count"),
+    topics: jsonb("topics"),
 
-  pushed_at: timestamp("pushed_at").notNull(),
-  created_at: timestamp("created_at").notNull(),
+    pushed_at: timestamp("pushed_at").notNull(),
+    created_at: timestamp("created_at").notNull(),
 
-  // From GitHub GraphQL API
-  last_commit: timestamp("last_commit"),
-  commit_count: integer("commit_count"),
+    // From GitHub GraphQL API
+    last_commit: timestamp("last_commit"),
+    commit_count: integer("commit_count"),
 
-  // From scrapping
-  contributor_count: integer("contributor_count"),
-});
+    // From scrapping
+    contributor_count: integer("contributor_count"),
+  },
+  (table) => ({
+    fullName: uniqueIndex("name_owner_index").on(table.owner, table.name),
+  })
+);
 
 export const reposRelations = relations(repos, ({ many }) => ({
   projects: many(projects),

--- a/packages/db/src/snapshots/crud.ts
+++ b/packages/db/src/snapshots/crud.ts
@@ -1,11 +1,10 @@
 import { and, eq } from "drizzle-orm";
 
-import { getDatabase } from "..";
+import { db } from "..";
 import { MonthSnapshots, OneYearSnapshots } from "../projects";
 import * as schema from "../schema";
 
 export async function getSnapshotRecord(repoId: string, year: number) {
-  const db = getDatabase();
   const snapshot = await db.query.snapshots.findFirst({
     where: and(
       eq(schema.snapshots.repoId, repoId),
@@ -20,7 +19,6 @@ export async function updateSnapshotRecord(
   year: number,
   months: MonthSnapshots[]
 ) {
-  const db = getDatabase();
   await db
     .update(schema.snapshots)
     .set({ months, updatedAt: new Date() })
@@ -34,7 +32,6 @@ export async function createSnapshotRecord(
   year: number,
   months: MonthSnapshots[]
 ) {
-  const db = getDatabase();
   const result = await db
     .insert(schema.snapshots)
     .values({ year, repoId, months })

--- a/packages/db/src/snapshots/crud.ts
+++ b/packages/db/src/snapshots/crud.ts
@@ -37,6 +37,7 @@ export async function createSnapshotRecord(
   const db = getDatabase();
   const result = await db
     .insert(schema.snapshots)
-    .values({ year, repoId, months });
-  console.log("Snapshot created", result);
+    .values({ year, repoId, months })
+    .returning();
+  console.log("Snapshot record created", result);
 }

--- a/packages/db/src/snapshots/snapshots.ts
+++ b/packages/db/src/snapshots/snapshots.ts
@@ -47,8 +47,9 @@ export class SnapshotsService {
   ) {
     const result = await this.db
       .insert(schema.snapshots)
-      .values({ year, repoId, months });
-    console.log("Snapshot created", result);
+      .values({ year, repoId, months })
+      .returning();
+    debug("Snapshot created", result);
   }
 
   async addSnapshot(

--- a/packages/db/src/tags/create.ts
+++ b/packages/db/src/tags/create.ts
@@ -1,12 +1,10 @@
 import { nanoid } from "nanoid";
 import slugify from "slugify";
 
-import { getDatabase } from "..";
+import { db } from "..";
 import * as schema from "../schema";
 
 export async function createTag(tagName: string) {
-  const db = getDatabase();
-
   const values = {
     id: nanoid(),
     name: tagName,

--- a/packages/db/src/tags/find.ts
+++ b/packages/db/src/tags/find.ts
@@ -1,10 +1,9 @@
 import { asc, count, eq } from "drizzle-orm";
 
-import { DB, getDatabase } from "../index";
+import { db } from "../index";
 import * as schema from "../schema";
 
 export async function findTags() {
-  const db: DB = getDatabase();
   const tags = await db
     .select({
       name: schema.tags.name,

--- a/packages/db/src/tags/get.ts
+++ b/packages/db/src/tags/get.ts
@@ -1,10 +1,9 @@
 import { eq } from "drizzle-orm";
 
-import { getDatabase } from "..";
+import { db } from "..";
 import * as schema from "../schema";
 
 export async function getTagBySlug(slug: string) {
-  const db = getDatabase();
   const tag = await db.query.tags.findFirst({
     where: eq(schema.tags.code, slug),
   });

--- a/packages/db/src/tags/update.ts
+++ b/packages/db/src/tags/update.ts
@@ -1,6 +1,6 @@
 import { eq } from "drizzle-orm";
 
-import { getDatabase } from "..";
+import { db } from "..";
 import * as schema from "../schema";
 
 export type EditableTagData = Omit<
@@ -12,7 +12,6 @@ export async function updateTagById(
   tagId: string,
   data: Partial<EditableTagData>
 ) {
-  const db = getDatabase();
   const result = await db
     .update(schema.tags)
     .set(data)


### PR DESCRIPTION
## Goal

In the `repos` table we store both the `full_name` of the repo and the `name`, which is redundant since the full name is made of the `owner` and the `name` and not convenient when we need to filter repos by owner.

Changes:

- add `owner` column: the migration file includes the script to initialize it (technically we rename the `full_name` column)
- remove `full_name`
- make `owner_id` a number instead of a string (since the GitHub REST API returns numbers)
- use `drizzle-kit migrate` command for migrations
- Use a transaction when creating projects from the admin app, to avoid creating a repo linked to no project if the project creation fails
- Add `fullName` and `slug` parameters to CLI tasks, to be able to target either one project by `slug` or one repo by `fullName`
- Avoid creating too many connections to the database and simplify connections by using the exported `db` object

## How to test

Ensure all apps run as expected, especially projects pages showing list of projects

Check the CLI tasks with `fullName` and `slug` parameters

```sh
bun run apps/backend/src/cli.ts hello-world-repos --slug best-of-js --logLevel 4

bun run apps/backend/src/cli.ts hello-world-repos --fullName bestofjs/bestofjs --logLevel 4 
```

