### PR TITLE
Remove "drizzle-orm" package from backend app

### DIFF
--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -23,8 +23,11 @@ jobs:
       - name: Type checking / db
         run: pnpm -F db typecheck
 
+      - name: Type checking / api
+        run: pnpm -F db typecheck
+
       - name: Type checking / backend
-        run: pnpm -F backend typecheck
+        run: pnpm -F api typecheck
 
       - name: Type checking / admin
         run: pnpm -F admin typecheck

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -18,7 +18,16 @@ jobs:
 
       - name: Install Dependencies
         shell: bash
-        run: pnpm -F bestofjs-nextjs install
+        run: pnpm install
+
+      - name: Type checking / db
+        run: pnpm -F db typecheck
+
+      - name: Type checking / backend
+        run: pnpm -F backend typecheck
+
+      - name: Type checking / admin
+        run: pnpm -F admin typecheck
 
       - name: Code Linting
         run: pnpm -F bestofjs-nextjs lint

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -26,7 +26,6 @@
     "consola": "^3.2.3",
     "debug": "^4.3.7",
     "dotenv-cli": "^7.4.2",
-    "drizzle-orm": "^0.35.3",
     "es-toolkit": "1.26.1",
     "fs-extra": "^11.2.0",
     "p-map": "^7.0.2",

--- a/apps/backend/src/iteration-helpers/hall-of-fame-processor.ts
+++ b/apps/backend/src/iteration-helpers/hall-of-fame-processor.ts
@@ -1,7 +1,7 @@
-import { desc, eq } from "drizzle-orm";
 import { omit } from "es-toolkit";
 
 import { DB, schema } from "@repo/db";
+import { desc, eq } from "@repo/db/drizzle";
 import { TaskLoopOptions, TaskRunnerContext } from "@/task-types";
 import { ItemProcessor } from "./abstract-item-processor";
 

--- a/apps/backend/src/iteration-helpers/project-processor.ts
+++ b/apps/backend/src/iteration-helpers/project-processor.ts
@@ -1,6 +1,5 @@
-import { and, desc, eq } from "drizzle-orm";
-
 import { schema } from "@repo/db";
+import { and, desc, eq } from "@repo/db/drizzle";
 import { ProjectDetails, ProjectService } from "@repo/db/projects";
 import { TaskLoopOptions, TaskRunnerContext } from "@/task-types";
 import { ItemProcessor } from "./abstract-item-processor";

--- a/apps/backend/src/iteration-helpers/repo-processor.ts
+++ b/apps/backend/src/iteration-helpers/repo-processor.ts
@@ -1,6 +1,5 @@
-import { and, asc, desc, eq } from "drizzle-orm";
-
 import { DB, schema } from "@repo/db";
+import { and, asc, desc, eq } from "@repo/db/drizzle";
 import { snapshotsSchema } from "@repo/db/projects";
 import { TaskLoopOptions, TaskRunnerContext } from "@/task-types";
 import { ItemProcessor } from "./abstract-item-processor";

--- a/apps/backend/src/tasks/update-github-data.task.ts
+++ b/apps/backend/src/tasks/update-github-data.task.ts
@@ -1,7 +1,6 @@
-import { eq } from "drizzle-orm";
-
 import { createGitHubClient } from "@repo/api/github";
 import { schema } from "@repo/db";
+import { eq } from "@repo/db/drizzle";
 import { SnapshotsService } from "@repo/db/snapshots";
 import { Repo } from "@/iteration-helpers/repo-processor";
 import { Task } from "@/task-runner";

--- a/apps/backend/src/tasks/update-hall-of-fame.ts
+++ b/apps/backend/src/tasks/update-hall-of-fame.ts
@@ -1,7 +1,6 @@
-import { eq } from "drizzle-orm";
-
 import { createGitHubClient } from "@repo/api/github";
 import { schema } from "@repo/db";
+import { eq } from "@repo/db/drizzle";
 import { HallOfFameMember } from "@/iteration-helpers";
 import { Task } from "@/task-runner";
 

--- a/apps/backend/src/tasks/update-package-data.task.ts
+++ b/apps/backend/src/tasks/update-package-data.task.ts
@@ -1,6 +1,5 @@
-import { eq } from "drizzle-orm";
-
 import { schema } from "@repo/db";
+import { eq } from "@repo/db/drizzle";
 import { ProjectDetails } from "@repo/db/projects";
 import { createNpmClient } from "@/apis/npm-api-client";
 import { Task } from "@/task-runner";

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -13,6 +13,8 @@
   },
   "exports": {
     ".": "./src/index.ts",
+    "./drizzle": "./src/drizzle.ts",
+    "./schema": "./src/schema.ts",
     "./constants": "./src/constants.ts",
     "./projects": "./src/projects/index.ts",
     "./snapshots": "./src/snapshots/index.ts",
@@ -29,7 +31,7 @@
     "debug": "^4.3.7",
     "dotenv-cli": "^7.4.2",
     "drizzle-kit": "^0.26.2",
-    "drizzle-orm": "^0.35.3",
+    "drizzle-orm": "^0.36.0",
     "es-toolkit": "1.26.1",
     "is-absolute-url": "^4.0.1",
     "luxon": "^3.5.0",

--- a/packages/db/src/drizzle.ts
+++ b/packages/db/src/drizzle.ts
@@ -1,0 +1,2 @@
+// Re-export everything from drizzle-orm to avoid having to install it in the apps
+export * from "drizzle-orm";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,9 +195,6 @@ importers:
       dotenv-cli:
         specifier: ^7.4.2
         version: 7.4.2
-      drizzle-orm:
-        specifier: ^0.35.3
-        version: 0.35.3(@libsql/client-wasm@0.14.0)(@neondatabase/serverless@0.10.1)(@types/pg@8.11.6)(@types/react@18.2.18)(@vercel/postgres@0.10.0)(bun-types@1.1.32)(postgres@3.4.3)(react@18.2.0)
       es-toolkit:
         specifier: 1.26.1
         version: 1.26.1
@@ -674,8 +671,8 @@ importers:
         specifier: ^0.26.2
         version: 0.26.2
       drizzle-orm:
-        specifier: ^0.35.3
-        version: 0.35.3(@libsql/client-wasm@0.14.0)(@neondatabase/serverless@0.9.5)(@types/pg@8.11.6)(@types/react@18.2.18)(@vercel/postgres@0.10.0(utf-8-validate@6.0.4))(bun-types@1.1.32)(postgres@3.4.3)(react@18.2.0)
+        specifier: ^0.36.0
+        version: 0.36.0(@libsql/client-wasm@0.14.0)(@neondatabase/serverless@0.9.5)(@types/pg@8.11.6)(@types/react@18.2.18)(@vercel/postgres@0.10.0(utf-8-validate@6.0.4))(bun-types@1.1.32)(postgres@3.4.3)(react@18.2.0)
       es-toolkit:
         specifier: 1.26.1
         version: 1.26.1
@@ -2270,9 +2267,6 @@ packages:
   '@mswjs/interceptors@0.29.1':
     resolution: {integrity: sha512-3rDakgJZ77+RiQUuSK69t1F0m8BQKA8Vh5DCS5V0DWvNY67zob2JhhQrhCO0AKLGINTRSFd1tBaHcJTkhefoSw==}
     engines: {node: '>=18'}
-
-  '@neondatabase/serverless@0.10.1':
-    resolution: {integrity: sha512-Upn555uEYL/q8aqMdPSviggNWeeZLCl5FhCIs7A4hmshfoOAAfML+Sqbcxr+Re2WZN5+hpyM9JClImXnBuhuXw==}
 
   '@neondatabase/serverless@0.9.5':
     resolution: {integrity: sha512-siFas6gItqv6wD/pZnvdu34wEqgG3nSE6zWZdq5j2DEsa+VvX8i/5HXJOo06qrw5axPXn+lGCxeR+NLaSPIXug==}
@@ -4518,12 +4512,12 @@ packages:
     resolution: {integrity: sha512-cMq8omEKywjIy5KcqUo6LvEFxkl8/zYHsgYjFVXjmPWWtuW4blcz+YW9+oIhoaALgs2ebRjzXwsJgN9i6P49Dw==}
     hasBin: true
 
-  drizzle-orm@0.35.3:
-    resolution: {integrity: sha512-Uv6N+b36x4BaZlxc96e+ag7RnMapBLGhc4SSi2F7RDwqYJipWjaU/P68RUp1FbW9r+mxoDp8nMz2Eece8PJxfA==}
+  drizzle-orm@0.36.0:
+    resolution: {integrity: sha512-6BETYPdKSR7cDHC0ZfqZk2VrKJ8n/Rfd3ajFPsAbc69gi87nwZ6oBA2wUGMELHA0tQE4kUKN0Ds00LUZQ6Z69A==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=3'
-      '@electric-sql/pglite': '>=0.1.1'
+      '@electric-sql/pglite': '>=0.2.0'
       '@libsql/client': '>=0.10.0'
       '@libsql/client-wasm': '>=0.10.0'
       '@neondatabase/serverless': '>=0.1'
@@ -4558,6 +4552,8 @@ packages:
       '@electric-sql/pglite':
         optional: true
       '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
         optional: true
       '@neondatabase/serverless':
         optional: true
@@ -9813,10 +9809,12 @@ snapshots:
     dependencies:
       '@libsql/core': 0.14.0
       js-base64: 3.7.7
+    optional: true
 
   '@libsql/core@0.14.0':
     dependencies:
       js-base64: 3.7.7
+    optional: true
 
   '@molt/command@0.9.0':
     dependencies:
@@ -9844,11 +9842,6 @@ snapshots:
       is-node-process: 1.2.0
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
-
-  '@neondatabase/serverless@0.10.1':
-    dependencies:
-      '@types/pg': 8.11.6
-    optional: true
 
   '@neondatabase/serverless@0.9.5':
     dependencies:
@@ -12266,22 +12259,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.35.3(@libsql/client-wasm@0.14.0)(@neondatabase/serverless@0.10.1)(@types/pg@8.11.6)(@types/react@18.2.18)(@vercel/postgres@0.10.0)(bun-types@1.1.32)(postgres@3.4.3)(react@18.2.0):
-    dependencies:
-      '@libsql/client-wasm': 0.14.0
+  drizzle-orm@0.36.0(@libsql/client-wasm@0.14.0)(@neondatabase/serverless@0.9.5)(@types/pg@8.11.6)(@types/react@18.2.18)(@vercel/postgres@0.10.0(utf-8-validate@6.0.4))(bun-types@1.1.32)(postgres@3.4.3)(react@18.2.0):
     optionalDependencies:
-      '@neondatabase/serverless': 0.10.1
-      '@types/pg': 8.11.6
-      '@types/react': 18.2.18
-      '@vercel/postgres': 0.10.0(utf-8-validate@6.0.4)
-      bun-types: 1.1.32
-      postgres: 3.4.3
-      react: 18.2.0
-
-  drizzle-orm@0.35.3(@libsql/client-wasm@0.14.0)(@neondatabase/serverless@0.9.5)(@types/pg@8.11.6)(@types/react@18.2.18)(@vercel/postgres@0.10.0(utf-8-validate@6.0.4))(bun-types@1.1.32)(postgres@3.4.3)(react@18.2.0):
-    dependencies:
       '@libsql/client-wasm': 0.14.0
-    optionalDependencies:
       '@neondatabase/serverless': 0.9.5
       '@types/pg': 8.11.6
       '@types/react': 18.2.18
@@ -14107,7 +14087,8 @@ snapshots:
 
   jiti@1.19.1: {}
 
-  js-base64@3.7.7: {}
+  js-base64@3.7.7:
+    optional: true
 
   js-cookie@2.2.1: {}
 


### PR DESCRIPTION
## Goal

After the migration to Drizzle 0.35 #326, I noticed lots of TS errors (73 errors!) in the `backend` app.

I'm not sure about the exact cause, but it seems that removing `drizzle-orm` from `backend` app and re-exporting drizzle-orm from the `db` package fixes the issue.

## How to test

```sh
pnpm -F backend typecheck
```

## TODO

The type checking task should run in all packages on GitHub actions, after every push to ensure we don't miss these errors.