### PR TITLE
Chore(db) Upgrade Drizzle Kit

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -30,7 +30,7 @@
     "@vercel/postgres": "^0.10.0",
     "debug": "^4.3.7",
     "dotenv-cli": "^7.4.2",
-    "drizzle-kit": "^0.26.2",
+    "drizzle-kit": "^0.27.1",
     "drizzle-orm": "^0.36.0",
     "es-toolkit": "1.26.1",
     "is-absolute-url": "^4.0.1",

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -53,9 +53,7 @@ export const projectsToTags = pgTable(
       .notNull()
       .references(() => tags.id, { onDelete: "cascade" }),
   },
-  (t) => ({
-    pk: primaryKey({ columns: [t.projectId, t.tagId] }),
-  })
+  (t) => [primaryKey({ columns: [t.projectId, t.tagId] })]
 );
 
 export const projectsRelations = relations(projects, ({ many, one }) => ({
@@ -108,9 +106,7 @@ export const repos = pgTable(
     // From scrapping
     contributor_count: integer("contributor_count"),
   },
-  (table) => ({
-    fullName: uniqueIndex("name_owner_index").on(table.owner, table.name),
-  })
+  (table) => [uniqueIndex("name_owner_index").on(table.owner, table.name)]
 );
 
 export const reposRelations = relations(repos, ({ many, one }) => ({
@@ -133,9 +129,7 @@ export const snapshots = pgTable(
     year: integer("year").notNull(),
     months: jsonb("months"),
   },
-  (table) => ({
-    pk: primaryKey({ columns: [table.repoId, table.year] }),
-  })
+  (table) => [primaryKey({ columns: [table.repoId, table.year] })]
 );
 
 export const snapshotsRelations = relations(snapshots, ({ one }) => ({
@@ -216,9 +210,7 @@ export const hallOfFameToProjects = pgTable(
       .notNull()
       .references(() => projects.id, { onDelete: "cascade" }),
   },
-  (t) => ({
-    pk: primaryKey({ columns: [t.username, t.projectId] }),
-  })
+  (t) => [primaryKey({ columns: [t.username, t.projectId] })]
 );
 
 export const hallOfFameRelations = relations(hallOfFame, ({ many }) => ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -668,8 +668,8 @@ importers:
         specifier: ^7.4.2
         version: 7.4.2
       drizzle-kit:
-        specifier: ^0.26.2
-        version: 0.26.2
+        specifier: ^0.27.1
+        version: 0.27.1
       drizzle-orm:
         specifier: ^0.36.0
         version: 0.36.0(@libsql/client-wasm@0.14.0)(@neondatabase/serverless@0.9.5)(@types/pg@8.11.6)(@types/react@18.2.18)(@vercel/postgres@0.10.0(utf-8-validate@6.0.4))(bun-types@1.1.32)(postgres@3.4.3)(react@18.2.0)
@@ -1393,8 +1393,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@drizzle-team/brocli@0.10.1':
-    resolution: {integrity: sha512-AHy0vjc+n/4w/8Mif+w86qpppHuF3AyXbcWW+R/W7GNA3F5/p2nuhlkCJaTXSLZheB4l1rtHzOfr9A7NwoR/Zg==}
+  '@drizzle-team/brocli@0.10.2':
+    resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
 
   '@emotion/babel-plugin@11.11.0':
     resolution: {integrity: sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==}
@@ -4508,8 +4508,8 @@ packages:
     resolution: {integrity: sha512-OYefcDgxd6jSdig/Cfkw1vdvyiOIRruCPnqGBbXpc95buDt9kvwL+Lic1OHc+SaQSsQub0BUZMd5+TNgy8Sh3A==}
     hasBin: true
 
-  drizzle-kit@0.26.2:
-    resolution: {integrity: sha512-cMq8omEKywjIy5KcqUo6LvEFxkl8/zYHsgYjFVXjmPWWtuW4blcz+YW9+oIhoaALgs2ebRjzXwsJgN9i6P49Dw==}
+  drizzle-kit@0.27.1:
+    resolution: {integrity: sha512-4BNA0T2blN+jW5wSwhtc+FIlCMuxYSMWCnYYdOBi5rttwq8aVXRUid0d0NCzcBKtZQSPZGAUxy+TXr7Q1OgEug==}
     hasBin: true
 
   drizzle-orm@0.36.0:
@@ -9072,7 +9072,7 @@ snapshots:
   '@dprint/win32-x64@0.45.1':
     optional: true
 
-  '@drizzle-team/brocli@0.10.1': {}
+  '@drizzle-team/brocli@0.10.2': {}
 
   '@emotion/babel-plugin@11.11.0':
     dependencies:
@@ -12250,9 +12250,9 @@ snapshots:
       '@dprint/linux-x64-musl': 0.45.1
       '@dprint/win32-x64': 0.45.1
 
-  drizzle-kit@0.26.2:
+  drizzle-kit@0.27.1:
     dependencies:
-      '@drizzle-team/brocli': 0.10.1
+      '@drizzle-team/brocli': 0.10.2
       '@esbuild-kit/esm-loader': 2.6.5
       esbuild: 0.19.12
       esbuild-register: 3.5.0(esbuild@0.19.12)


### PR DESCRIPTION
## Goal

- Upgrade to latest version of Drizzle Kit
- Fix deprecation warning about `pgTable`: using the array syntax instead of the object syntax for the extra argument that specifies the indexes)


## How to test

```
pnpm -F db studio
```

