### PR TITLE
Show `last_commit` instead of `pushed_at` in GitHub card

### DIFF
--- a/apps/admin/src/app/projects/[slug]/view-repo.tsx
+++ b/apps/admin/src/app/projects/[slug]/view-repo.tsx
@@ -75,6 +75,8 @@ function ViewRepoData({ repo }: { repo: typeof schema.repos.$inferSelect }) {
       </p>
       <p>Created</p>
       <p>{formatDateOnly(repo.created_at)}</p>
+      <p>Last commit</p>
+      <p>{repo.last_commit ? formatDateOnly(repo.last_commit) : "-"}</p>
       <p>Pushed at</p>
       <p>{formatDateOnly(repo.pushed_at)}</p>
       <p>Commit count</p>

--- a/apps/bestofjs-nextjs/src/app/projects/[slug]/project-details-github/github-card.tsx
+++ b/apps/bestofjs-nextjs/src/app/projects/[slug]/project-details-github/github-card.tsx
@@ -59,12 +59,18 @@ export const ProjectDetailsGitHubCard = ({ project }: Props) => {
 
 const GitHubData = ({ project }: { project: ProjectDetails }) => {
   const {
-    repo: { commit_count, contributor_count, created_at, full_name, pushed_at },
+    repo: {
+      commit_count,
+      contributor_count,
+      created_at,
+      full_name,
+      last_commit,
+    },
   } = project;
   const url = `https://github.com/${full_name}`;
 
   return (
-    <div className="grid grid-cols-2 gap-4">
+    <div className="grid gap-4 sm:grid-cols-2">
       <div>
         <ExternalLink url={url} className="flex items-center gap-1 font-sans">
           {full_name}
@@ -74,7 +80,8 @@ const GitHubData = ({ project }: { project: ProjectDetails }) => {
       <div>
         {created_at && (
           <>
-            Created {fromNow(created_at)}, last commit {fromNow(pushed_at)}
+            Created {fromNow(created_at)}
+            {last_commit && <>, last commit {fromNow(last_commit)}</>}
           </>
         )}
       </div>


### PR DESCRIPTION
## Goal

Improve the UI about GitHub data in project details page:

- show the `last_commit` date instead of `pushed_at` (because pushed_at is not really relevant, what we want to show is the last commit on the default branch)
- make the layout more responsive

## How to test

Visit the project details page, notice the layout swtiches between 1 column and 2 columns depending on the screen size.

## Screenshots

![image](https://github.com/user-attachments/assets/e6104830-6b1a-49de-8fa0-4ca568da14c8)

