### PR TITLE
Improve back tasks, introducing `createTask`

### DIFF
--- a/apps/backend/src/cli.ts
+++ b/apps/backend/src/cli.ts
@@ -1,7 +1,8 @@
 import { cli, command } from "cleye";
 
 import { cliFlags as sharedFlags } from "./flags";
-import { createTaskRunner, Task } from "./task-runner";
+import { createTaskRunner } from "./task-runner";
+import { Task } from "./task-types";
 import { buildMonthlyRankingsTask } from "./tasks/build-monthly-rankings";
 import { buildStaticApiTask } from "./tasks/build-static-api.task";
 import {

--- a/apps/backend/src/iteration-helpers/repo-processor.ts
+++ b/apps/backend/src/iteration-helpers/repo-processor.ts
@@ -1,5 +1,5 @@
 import { DB, schema } from "@repo/db";
-import { and, asc, desc, eq } from "@repo/db/drizzle";
+import { and, asc, desc, eq, SQL } from "@repo/db/drizzle";
 import { snapshotsSchema } from "@repo/db/projects";
 import { TaskLoopOptions, TaskRunnerContext } from "@/task-types";
 import { ItemProcessor } from "./abstract-item-processor";
@@ -18,7 +18,7 @@ export class RepoProcessor extends ItemProcessor<Repo> {
     return item.full_name;
   }
 
-  async getAllItemsIds() {
+  async getAllItemsIds(where?: SQL) {
     const { db, logger } = this.context;
     const { limit, skip, fullName, slug } = this.loopOptions;
     const { repos, projects } = schema;
@@ -27,21 +27,33 @@ export class RepoProcessor extends ItemProcessor<Repo> {
       .select({ id: repos.id })
       .from(repos)
       .orderBy(desc(repos.added_at))
-      .offset(skip);
+      .offset(skip)
+      .leftJoin(projects, eq(projects.repoId, repos.id));
 
     if (limit) {
       query.limit(limit);
     }
 
+    const whereClauses = [];
+
     if (fullName) {
       const [owner, name] = fullName.split("/");
-      query.where(and(eq(repos.owner, owner), eq(repos.name, name)));
+      whereClauses.push(and(eq(repos.owner, owner), eq(repos.name, name)));
     }
 
     if (slug) {
-      query.leftJoin(projects, eq(repos.id, projects.repoId));
-      query.where(eq(projects.slug, slug));
+      whereClauses.push(eq(projects.slug, slug));
     }
+
+    if (where) {
+      whereClauses.push(where);
+    }
+
+    if (whereClauses.length > 0) {
+      query.where(and(...whereClauses));
+    }
+
+    console.log(query.toSQL());
 
     const foundRepos = await query;
     if (!foundRepos.length) logger.error("No repos found");

--- a/apps/backend/src/task-runner.ts
+++ b/apps/backend/src/task-runner.ts
@@ -1,5 +1,4 @@
 import path from "path";
-import { Command } from "cleye";
 import { createConsola } from "consola";
 import fs from "fs-extra";
 import prettyBytes from "pretty-bytes";
@@ -12,22 +11,30 @@ import {
   ProjectProcessor,
   RepoProcessor,
 } from "./iteration-helpers";
-import { MetaResult } from "./iteration-helpers/utils";
-import { TaskContext } from "./task-types";
+import { Task, TaskContext } from "./task-types";
 
-export type Task<FlagsType = undefined> = {
+export function createTask<FlagsType = undefined>({
+  name,
+  description,
+  flags,
+  schema,
+  run,
+}: {
   name: string;
   description?: string;
-  flags?: Command["options"]["flags"];
   schema?: z.ZodType<FlagsType>;
-  run: (
-    ctx: TaskContext,
-    flags: FlagsType extends undefined ? undefined : FlagsType
-  ) => Promise<{
-    data: unknown;
-    meta: MetaResult;
-  }>;
-};
+  flags?: Task["flags"];
+  run: Task<FlagsType>["run"];
+}) {
+  const task: Task<FlagsType> = {
+    name,
+    description,
+    schema,
+    flags, //TODO infer flags from schema
+    run,
+  };
+  return task;
+}
 
 type RawFlags = { [key: string]: unknown };
 

--- a/apps/backend/src/task-types.ts
+++ b/apps/backend/src/task-types.ts
@@ -1,4 +1,6 @@
+import { Command } from "cleye";
 import { ConsolaInstance } from "consola";
+import { z } from "zod";
 
 import { DB } from "@repo/db";
 import { ParsedFlags } from "./flags";
@@ -7,6 +9,21 @@ import {
   ProjectProcessor,
   RepoProcessor,
 } from "./iteration-helpers";
+import { MetaResult } from "./iteration-helpers/utils";
+
+export type Task<FlagsType = undefined> = {
+  name: string;
+  description?: string;
+  flags?: Command["options"]["flags"];
+  schema?: z.ZodType<FlagsType>;
+  run: (
+    ctx: TaskContext,
+    flags: FlagsType extends undefined ? undefined : FlagsType
+  ) => Promise<{
+    data: unknown;
+    meta: MetaResult;
+  }>;
+};
 
 export interface TaskRunnerContext {
   logger: ConsolaInstance;

--- a/apps/backend/src/tasks/build-monthly-rankings.ts
+++ b/apps/backend/src/tasks/build-monthly-rankings.ts
@@ -8,11 +8,9 @@ import {
 } from "@repo/db/projects";
 import { getMonthlyDelta } from "@repo/db/snapshots";
 import { truncate } from "@/shared/utils";
-import { Task } from "@/task-runner";
+import { createTask } from "@/task-runner";
 
-const schema = z.object({ year: z.number(), month: z.number() });
-
-export const buildMonthlyRankingsTask: Task<z.infer<typeof schema>> = {
+export const buildMonthlyRankingsTask = createTask({
   name: "build-monthly-rankings",
   description: "Build monthly rankings to be displayed on the frontend",
   flags: {
@@ -25,7 +23,7 @@ export const buildMonthlyRankingsTask: Task<z.infer<typeof schema>> = {
       description: "Month to build rankings for",
     },
   },
-  schema,
+  schema: z.object({ year: z.number(), month: z.number() }),
 
   async run(context, flags) {
     const { logger, processRepos, saveJSON } = context;
@@ -108,7 +106,7 @@ export const buildMonthlyRankingsTask: Task<z.infer<typeof schema>> = {
 
     return results;
   },
-};
+});
 
 function formatDate(year: number, month: number) {
   return `${year}-${month.toString().padStart(2, "0")}`;

--- a/apps/backend/src/tasks/build-static-api.task.ts
+++ b/apps/backend/src/tasks/build-static-api.task.ts
@@ -9,10 +9,10 @@ import {
   ProjectDetails,
 } from "@repo/db/projects";
 import { truncate } from "@/shared/utils";
-import { Task } from "@/task-runner";
+import { createTask } from "@/task-runner";
 import { ProjectItem } from "./static-api-types";
 
-export const buildStaticApiTask: Task = {
+export const buildStaticApiTask = createTask({
   name: "build-static-api",
   description:
     "Build a static API from the database, to be used by the frontend app.",
@@ -112,7 +112,7 @@ export const buildStaticApiTask: Task = {
       return tags;
     }
   },
-};
+});
 
 function shouldProcessProject(project: ProjectDetails) {
   return !["deprecated", "hidden"].includes(project.status);

--- a/apps/backend/src/tasks/notify-daily.task.ts
+++ b/apps/backend/src/tasks/notify-daily.task.ts
@@ -3,12 +3,12 @@ import { orderBy } from "es-toolkit";
 import { TAGS_EXCLUDED_FROM_RANKINGS } from "@repo/db/constants";
 import { notifyDiscordProjectList } from "@/shared/discord";
 import { projectToSlackAttachment, sendMessageToSlack } from "@/shared/slack";
-import { Task } from "@/task-runner";
+import { createTask } from "@/task-runner";
 import { ProjectItem } from "./static-api-types";
 
 const NUMBER_OF_PROJECTS = 5;
 
-export const notifyDailyTask: Task = {
+export const notifyDailyTask = createTask({
   name: "notify-daily",
   description:
     "Send notification on Slack and Discord after static API is built",
@@ -54,7 +54,7 @@ export const notifyDailyTask: Task = {
       return topProjects.slice(0, NUMBER_OF_PROJECTS);
     }
   },
-};
+});
 
 /**
  * Exclude from the rankings projects with specific tags

--- a/apps/backend/src/tasks/notify-monthly.task.ts
+++ b/apps/backend/src/tasks/notify-monthly.task.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 import { notifyDiscordProjectList } from "@/shared/discord";
-import { Task } from "@/task-runner";
+import { createTask } from "@/task-runner";
 import { ProjectItem } from "./static-api-types";
 
 interface Project extends ProjectItem {
@@ -18,7 +18,7 @@ const NUMBER_OF_PROJECTS = 5;
 
 const schema = z.object({ year: z.number(), month: z.number() });
 
-export const notifyMonthlyTask: Task<z.infer<typeof schema>> = {
+export const notifyMonthlyTask = createTask({
   name: "notify-monthly",
   description:
     "Send notification on Discord after monthly rankings are published",
@@ -62,7 +62,7 @@ export const notifyMonthlyTask: Task<z.infer<typeof schema>> = {
 
     return { data: null, meta: { sent } };
   },
-};
+});
 
 async function fetchMonthlyRankings(year: number, month: number) {
   const rootURL = process.env.RANKINGS_ROOT_URL;

--- a/apps/backend/src/tasks/trigger-build-static-api.ts
+++ b/apps/backend/src/tasks/trigger-build-static-api.ts
@@ -1,6 +1,6 @@
-import { Task } from "@/task-runner";
+import { createTask } from "@/task-runner";
 
-export const triggerBuildStaticApiTask: Task = {
+export const triggerBuildStaticApiTask = createTask({
   name: "trigger-build-static-api",
   description:
     "Trigger a build for the static API, sending a webhook to Vercel",
@@ -17,4 +17,4 @@ export const triggerBuildStaticApiTask: Task = {
 
     return { data: null, meta: { sent: true } };
   },
-};
+});

--- a/apps/backend/src/tasks/trigger-build-webapp.task.ts
+++ b/apps/backend/src/tasks/trigger-build-webapp.task.ts
@@ -1,6 +1,6 @@
-import { Task } from "@/task-runner";
+import { createTask } from "@/task-runner";
 
-export const triggerBuildWebappTask: Task = {
+export const triggerBuildWebappTask = createTask({
   name: "trigger-build-webapp",
   description: "Trigger the build of the Next.js app",
 
@@ -45,4 +45,4 @@ export const triggerBuildWebappTask: Task = {
       }
     }
   },
-};
+});

--- a/apps/backend/src/tasks/update-bundle-size.task.ts
+++ b/apps/backend/src/tasks/update-bundle-size.task.ts
@@ -1,13 +1,13 @@
 import { schema } from "@repo/db";
 import { ProjectDetails } from "@repo/db/projects";
 import { createNpmClient } from "@/apis/npm-api-client";
-import { Task } from "@/task-runner";
+import { createTask } from "@/task-runner";
 
 const npmClient = createNpmClient();
 
 type Result = "updated" | "same-version" | "timeout" | "error" | "backend-only";
 
-export const updateBundleSizeTask: Task = {
+export const updateBundleSizeTask = createTask({
   name: "update-bundle-size",
   description: "Update bundle size data from bundlejs.com",
   run: async ({ db, logger, processProjects }) => {
@@ -73,7 +73,7 @@ export const updateBundleSizeTask: Task = {
       return "updated";
     }
   },
-};
+});
 
 function needsUpdate(packageData: ProjectDetails["packages"][number]) {
   const bundle = packageData.bundles;

--- a/apps/backend/src/tasks/update-github-data.task.ts
+++ b/apps/backend/src/tasks/update-github-data.task.ts
@@ -3,9 +3,9 @@ import { schema } from "@repo/db";
 import { eq } from "@repo/db/drizzle";
 import { SnapshotsService } from "@repo/db/snapshots";
 import { Repo } from "@/iteration-helpers/repo-processor";
-import { Task } from "@/task-runner";
+import { createTask } from "@/task-runner";
 
-export const updateGitHubDataTask: Task = {
+export const updateGitHubDataTask = createTask({
   name: "update-github-data",
   description:
     "Update GitHub data for all repos and take a snapshot. To be run run every day",
@@ -56,7 +56,7 @@ export const updateGitHubDataTask: Task = {
       };
     });
   },
-};
+});
 
 function shouldProcessProject(repo: Repo) {
   const isDeprecated = repo.projects.every(

--- a/apps/backend/src/tasks/update-hall-of-fame.ts
+++ b/apps/backend/src/tasks/update-hall-of-fame.ts
@@ -2,9 +2,9 @@ import { createGitHubClient } from "@repo/api/github";
 import { schema } from "@repo/db";
 import { eq } from "@repo/db/drizzle";
 import { HallOfFameMember } from "@/iteration-helpers";
-import { Task } from "@/task-runner";
+import { createTask } from "@/task-runner";
 
-export const updateHallOfFameTask: Task = {
+export const updateHallOfFameTask = createTask({
   name: "update-hall-of-fame",
   description:
     "Update Hall of Fame members follower status based on their projects and bio",
@@ -70,4 +70,4 @@ export const updateHallOfFameTask: Task = {
       };
     });
   },
-};
+});

--- a/apps/backend/src/tasks/update-package-data.task.ts
+++ b/apps/backend/src/tasks/update-package-data.task.ts
@@ -2,11 +2,11 @@ import { schema } from "@repo/db";
 import { eq } from "@repo/db/drizzle";
 import { ProjectDetails } from "@repo/db/projects";
 import { createNpmClient } from "@/apis/npm-api-client";
-import { Task } from "@/task-runner";
+import { createTask } from "@/task-runner";
 
 const npmClient = createNpmClient();
 
-export const updatePackageDataTask: Task = {
+export const updatePackageDataTask = createTask({
   name: "update-package-data",
   description: "Update package data from NPM",
   run: async ({ db, logger, processProjects }) => {
@@ -74,7 +74,7 @@ export const updatePackageDataTask: Task = {
       return updatedData;
     }
   },
-};
+});
 
 function formatDependencies(dependencies?: { [key: string]: string }) {
   return dependencies ? Object.keys(dependencies) : [];


### PR DESCRIPTION
## Goal

- Use `createTask` function to define backend tasks in `.task.ts` files instead of plain objects
- Add `where` conditions, to be defined as `SQL` objects from Drizzle to iteration processors, to be able to target subsets of records instead of everything

## How to test

Coming soon!

