### PR TITLE
Add database backup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules
 
 # local PostgreSQL database
 db-data
+db-backup
 
 # Output of typecheck command
 tsconfig.tsbuildinfo

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -43,6 +43,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@types/debug": "^4.1.12"
+    "@types/debug": "^4.1.12",
+    "nano-spawn": "^0.2.0"
   }
 }

--- a/apps/backend/src/backup/README.md
+++ b/apps/backend/src/backup/README.md
@@ -1,0 +1,9 @@
+# Database backup
+
+Script to be run manually to generate a backup of the Postgres database in the folder `db-backup`, at the root of the monorepo.
+
+Requirement: `pg_dump` (should come with `psql`)
+
+```sh
+NODE_ENV=production bun run ./apps/backend/src/backup/make-backup.ts
+```

--- a/apps/backend/src/backup/make-backup.ts
+++ b/apps/backend/src/backup/make-backup.ts
@@ -1,0 +1,66 @@
+import { createWriteStream, existsSync, readdirSync } from "fs";
+import path from "path";
+import consola from "consola";
+import spawn from "nano-spawn";
+import prettyMs from "pretty-ms";
+
+main();
+
+/** Backup the database in `db-backup` folder at the root of the monorepo */
+async function main() {
+  const url = process.env.POSTGRES_URL;
+  if (!url) throw new Error("Missing POSTGRES_URL environment variable");
+  const nextBackupFilename = getNextBackupFilename();
+  console.log(nextBackupFilename);
+
+  const filepath = path.join(getFolderFullPath(), nextBackupFilename);
+  await launchBackupCommand(url, filepath);
+}
+
+async function launchBackupCommand(dbURL: string, filepath: string) {
+  consola.box("Backup...", filepath);
+  try {
+    const result = await spawn("pg_dump", [dbURL], {
+      stdout: createWriteStream(filepath),
+    });
+    consola.success("Backup done", prettyMs(result.durationMs));
+  } catch (error) {
+    consola.error("Backup failed", error);
+  }
+}
+
+function getFolderFullPath() {
+  const year = new Date().getFullYear();
+  return path.join(process.cwd(), "db-backup", year.toString());
+}
+
+function getNextBackupFilename() {
+  const nextBackupNumber = getNextBackupNumber();
+  const formattedNumber = nextBackupNumber.toString().padStart(3, "0");
+  return `backup-${formattedNumber}.sql`;
+}
+
+function getNextBackupNumber() {
+  const fileNames = getPreviousBackupFilenames();
+  const lastFileName = fileNames.at(-1);
+  if (!lastFileName) return 1;
+  const lastBackupNumber = extractBackupNumber(lastFileName);
+  if (!lastBackupNumber) {
+    throw new Error("Invalid backup filename");
+  }
+  return lastBackupNumber + 1;
+}
+
+function getPreviousBackupFilenames() {
+  const filepath = getFolderFullPath();
+  if (!existsSync(filepath))
+    throw new Error(`Backup folder not found: ${filepath}`);
+  const fileNames = readdirSync(filepath);
+  fileNames.sort();
+  return fileNames;
+}
+
+function extractBackupNumber(fileName: string): number | null {
+  const match = fileName.match(/backup-(\d+)\.sql/);
+  return match ? parseInt(match[1], 10) : null;
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Best of JS monorepo",
   "scripts": {
+    "backup": "NODE_ENV=production bun run ./apps/backend/src/backup/make-backup.ts",
     "test": "pnpm -F bestofjs-nextjs test",
     "test:e2e": "pnpm -F bestofjs-nextjs test:e2e",
     "test:e2e:install": "pnpm -F bestofjs-nextjs exec playwright install"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,6 +232,9 @@ importers:
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12
+      nano-spawn:
+        specifier: ^0.2.0
+        version: 0.2.0
 
   apps/bestofjs-nextjs:
     dependencies:
@@ -6533,6 +6536,10 @@ packages:
     peerDependencies:
       react: '*'
       react-dom: '*'
+
+  nano-spawn@0.2.0:
+    resolution: {integrity: sha512-IjZBIOLxSlxu+m/kacg9JuP93oUpRemeV0mEuCy64nzBKKIL9m0aLJHtVPcVuzJDHFhElzjpwbW4a3tMzgKoZQ==}
+    engines: {node: '>=18.19'}
 
   nanoid@3.3.8:
     resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
@@ -15146,6 +15153,8 @@ snapshots:
       sourcemap-codec: 1.4.8
       stacktrace-js: 2.0.2
       stylis: 4.3.0
+
+  nano-spawn@0.2.0: {}
 
   nanoid@3.3.8: {}
 


### PR DESCRIPTION
## Goal

Script to be run manually to generate a backup file of the Postgres database in the folder `db-backup`, at the root of the monorepo.

Requirement: `pg_dump` (should come with `psql`)

Added to `package.json` for convenience:

```sh
bun run backup
```


## How to test

For production database:

```sh
NODE_ENV=production bun run ./apps/backend/src/backup/make-backup.ts
```
