### PR TITLE
Introduce Turbo to orchestrate monorepo scripts

### DIFF
--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -9,6 +9,9 @@ jobs:
   check_before_merge:
     name: Test and lint checks
     runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - name: Code Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -20,20 +20,11 @@ jobs:
         shell: bash
         run: pnpm install
 
-      - name: Type checking / db
-        run: pnpm -F db typecheck
+      - name: Type checking with Turbo
+        run: pnpm run typecheck
 
-      - name: Type checking / api
-        run: pnpm -F db typecheck
-
-      - name: Type checking / backend
-        run: pnpm -F api typecheck
-
-      - name: Type checking / admin
-        run: pnpm -F admin typecheck
-
-      - name: Code Linting
-        run: pnpm -F web lint
+      - name: Code Linting with Turbo
+        run: pnpm run lint
 
       - name: Unit tests
         run: pnpm -F web test:ci

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ tsconfig.tsbuildinfo
 
 # node-fetch-cache requests cache
 .cache
+
+# Turbo https://turbo.build/docs/getting-started/add-to-existing-repository#edit-gitignore
+.turbo

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Best of JS monorepo",
   "scripts": {
     "backup": "NODE_ENV=production bun run ./apps/backend/src/backup/make-backup.ts",
+    "build": "turbo run build -F=!legacy",
+    "lint": "turbo run lint -F=!legacy",
+    "typecheck": "turbo run typecheck -F=!legacy",
     "test": "pnpm -F web test",
     "test:e2e": "pnpm -F web test:e2e",
     "test:e2e:install": "pnpm -F web exec playwright install"
@@ -16,6 +19,7 @@
     "dotenv-cli": "^7.4.2",
     "prettier": "^3.3.3",
     "tsx": "^4.19.2",
+    "turbo": "^2.5.0",
     "typescript": "^5.7.3"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       tsx:
         specifier: ^4.19.2
         version: 4.19.2
+      turbo:
+        specifier: ^2.5.0
+        version: 2.5.0
       typescript:
         specifier: ^5.7.3
         version: 5.7.3
@@ -236,184 +239,6 @@ importers:
         specifier: ^0.2.0
         version: 0.2.0
 
-  apps/web:
-    dependencies:
-      '@klass/core':
-        specifier: ^3.4.8
-        version: 3.4.8
-      '@klass/react':
-        specifier: ^3.4.8
-        version: 3.4.8(@klass/core@3.4.8)(react@19.0.0)
-      '@next/bundle-analyzer':
-        specifier: 15.0.3
-        version: 15.0.3(bufferutil@4.0.8)
-      '@radix-ui/react-checkbox':
-        specifier: ^1.1.1
-        version: 1.1.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@radix-ui/react-collapsible':
-        specifier: ^1.1.0
-        version: 1.1.0(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@radix-ui/react-dialog':
-        specifier: ^1.1.1
-        version: 1.1.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@radix-ui/react-dropdown-menu':
-        specifier: ^2.1.1
-        version: 2.1.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@radix-ui/react-hover-card':
-        specifier: ^1.1.1
-        version: 1.1.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@radix-ui/react-popover':
-        specifier: ^1.1.1
-        version: 1.1.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@radix-ui/react-separator':
-        specifier: ^1.1.0
-        version: 1.1.0(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@radix-ui/react-slot':
-        specifier: ^1.1.0
-        version: 1.1.0(@types/react@19.0.3)(react@19.0.0)
-      '@radix-ui/react-tooltip':
-        specifier: ^1.1.2
-        version: 1.1.2(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@repo/api':
-        specifier: workspace:*
-        version: link:../../packages/api
-      '@repo/db':
-        specifier: workspace:*
-        version: link:../../packages/db
-      '@repo/eslint-config':
-        specifier: workspace:*
-        version: link:../../packages/eslint-config
-      '@t3-oss/env-nextjs':
-        specifier: ^0.11.1
-        version: 0.11.1(typescript@5.7.3)(zod@3.23.8)
-      '@types/debug':
-        specifier: ^4.1.12
-        version: 4.1.12
-      '@types/fs-extra':
-        specifier: ^11.0.1
-        version: 11.0.1
-      '@types/node':
-        specifier: ^20
-        version: 20.12.14
-      '@types/numeral':
-        specifier: ^2.0.2
-        version: 2.0.2
-      '@types/react':
-        specifier: 19.0.3
-        version: 19.0.3
-      '@types/react-dom':
-        specifier: 19.0.3
-        version: 19.0.3(@types/react@19.0.3)
-      '@typescript-eslint/parser':
-        specifier: ^8.16.0
-        version: 8.16.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.3)
-      '@vercel/analytics':
-        specifier: ^1.0.1
-        version: 1.0.1
-      autoprefixer:
-        specifier: ^10.4.14
-        version: 10.4.14(postcss@8.4.31)
-      clsx:
-        specifier: ^2.0.0
-        version: 2.0.0
-      cmdk:
-        specifier: ^1.0.0
-        version: 1.0.0(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      cross-env:
-        specifier: ^7.0.3
-        version: 7.0.3
-      dayjs:
-        specifier: ^1.11.8
-        version: 1.11.9
-      debug:
-        specifier: ^4.3.7
-        version: 4.3.7
-      dotenv-cli:
-        specifier: ^7.4.2
-        version: 7.4.2
-      es-toolkit:
-        specifier: ^1.31.0
-        version: 1.31.0
-      eslint:
-        specifier: ^9.16.0
-        version: 9.16.0(jiti@1.21.6)
-      fs-extra:
-        specifier: ^11.2.0
-        version: 11.2.0
-      lucide-react:
-        specifier: 0.428.0
-        version: 0.428.0(react@19.0.0)
-      mingo:
-        specifier: 6.4.15
-        version: 6.4.15
-      next:
-        specifier: 15.1.5
-        version: 15.1.5(@babel/core@7.25.2)(@playwright/test@1.47.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      next-themes:
-        specifier: ^0.4.4
-        version: 0.4.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      postcss:
-        specifier: ^8.4.31
-        version: 8.4.31
-      pretty-bytes:
-        specifier: ^6.1.1
-        version: 6.1.1
-      qss:
-        specifier: ^3.0.0
-        version: 3.0.0
-      react:
-        specifier: 19.0.0
-        version: 19.0.0
-      react-dom:
-        specifier: 19.0.0
-        version: 19.0.0(react@19.0.0)
-      sharp:
-        specifier: ^0.32.6
-        version: 0.32.6
-      swr:
-        specifier: ^2.2.5
-        version: 2.2.5(react@19.0.0)
-      tailwind-merge:
-        specifier: ^1.12.0
-        version: 1.14.0
-      tailwindcss:
-        specifier: ^3.4.0
-        version: 3.4.15
-      tailwindcss-animate:
-        specifier: ^1.0.5
-        version: 1.0.6(tailwindcss@3.4.15)
-      tiny-invariant:
-        specifier: ^1.3.3
-        version: 1.3.3
-      typescript:
-        specifier: ^5.7.3
-        version: 5.7.3
-      unstated-next:
-        specifier: ^1.1.0
-        version: 1.1.0
-      use-debounce:
-        specifier: ^3.0.0
-        version: 3.4.3(react@19.0.0)
-      vague-time:
-        specifier: ^2.4.2
-        version: 2.4.2
-      vite-tsconfig-paths:
-        specifier: ^5.1.3
-        version: 5.1.3(typescript@5.7.3)(vite@5.4.14(@types/node@20.12.14)(terser@5.19.2))
-      vitest:
-        specifier: ^2.1.9
-        version: 2.1.9(@types/node@20.12.14)(jsdom@16.7.0(bufferutil@4.0.8))(terser@5.19.2)
-      zod:
-        specifier: ^3.23.8
-        version: 3.23.8
-    devDependencies:
-      '@playwright/test':
-        specifier: ^1.47.2
-        version: 1.47.2
-      nextjs-bundle-analysis:
-        specifier: ^0.5.0
-        version: 0.5.0
-
   apps/legacy:
     dependencies:
       '@chakra-ui/react':
@@ -597,6 +422,184 @@ importers:
       whatwg-fetch:
         specifier: ^3.6.2
         version: 3.6.17
+
+  apps/web:
+    dependencies:
+      '@klass/core':
+        specifier: ^3.4.8
+        version: 3.4.8
+      '@klass/react':
+        specifier: ^3.4.8
+        version: 3.4.8(@klass/core@3.4.8)(react@19.0.0)
+      '@next/bundle-analyzer':
+        specifier: 15.0.3
+        version: 15.0.3(bufferutil@4.0.8)
+      '@radix-ui/react-checkbox':
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-collapsible':
+        specifier: ^1.1.0
+        version: 1.1.0(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.1
+        version: 2.1.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-hover-card':
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-popover':
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-separator':
+        specifier: ^1.1.0
+        version: 1.1.0(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-slot':
+        specifier: ^1.1.0
+        version: 1.1.0(@types/react@19.0.3)(react@19.0.0)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@repo/api':
+        specifier: workspace:*
+        version: link:../../packages/api
+      '@repo/db':
+        specifier: workspace:*
+        version: link:../../packages/db
+      '@repo/eslint-config':
+        specifier: workspace:*
+        version: link:../../packages/eslint-config
+      '@t3-oss/env-nextjs':
+        specifier: ^0.11.1
+        version: 0.11.1(typescript@5.7.3)(zod@3.23.8)
+      '@types/debug':
+        specifier: ^4.1.12
+        version: 4.1.12
+      '@types/fs-extra':
+        specifier: ^11.0.1
+        version: 11.0.1
+      '@types/node':
+        specifier: ^20
+        version: 20.12.14
+      '@types/numeral':
+        specifier: ^2.0.2
+        version: 2.0.2
+      '@types/react':
+        specifier: 19.0.3
+        version: 19.0.3
+      '@types/react-dom':
+        specifier: 19.0.3
+        version: 19.0.3(@types/react@19.0.3)
+      '@typescript-eslint/parser':
+        specifier: ^8.16.0
+        version: 8.16.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.3)
+      '@vercel/analytics':
+        specifier: ^1.0.1
+        version: 1.0.1
+      autoprefixer:
+        specifier: ^10.4.14
+        version: 10.4.14(postcss@8.4.31)
+      clsx:
+        specifier: ^2.0.0
+        version: 2.0.0
+      cmdk:
+        specifier: ^1.0.0
+        version: 1.0.0(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      cross-env:
+        specifier: ^7.0.3
+        version: 7.0.3
+      dayjs:
+        specifier: ^1.11.8
+        version: 1.11.9
+      debug:
+        specifier: ^4.3.7
+        version: 4.3.7
+      dotenv-cli:
+        specifier: ^7.4.2
+        version: 7.4.2
+      es-toolkit:
+        specifier: ^1.31.0
+        version: 1.31.0
+      eslint:
+        specifier: ^9.16.0
+        version: 9.16.0(jiti@1.21.6)
+      fs-extra:
+        specifier: ^11.2.0
+        version: 11.2.0
+      lucide-react:
+        specifier: 0.428.0
+        version: 0.428.0(react@19.0.0)
+      mingo:
+        specifier: 6.4.15
+        version: 6.4.15
+      next:
+        specifier: 15.1.5
+        version: 15.1.5(@babel/core@7.25.2)(@playwright/test@1.47.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next-themes:
+        specifier: ^0.4.4
+        version: 0.4.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      postcss:
+        specifier: ^8.4.31
+        version: 8.4.31
+      pretty-bytes:
+        specifier: ^6.1.1
+        version: 6.1.1
+      qss:
+        specifier: ^3.0.0
+        version: 3.0.0
+      react:
+        specifier: 19.0.0
+        version: 19.0.0
+      react-dom:
+        specifier: 19.0.0
+        version: 19.0.0(react@19.0.0)
+      sharp:
+        specifier: ^0.32.6
+        version: 0.32.6
+      swr:
+        specifier: ^2.2.5
+        version: 2.2.5(react@19.0.0)
+      tailwind-merge:
+        specifier: ^1.12.0
+        version: 1.14.0
+      tailwindcss:
+        specifier: ^3.4.0
+        version: 3.4.15
+      tailwindcss-animate:
+        specifier: ^1.0.5
+        version: 1.0.6(tailwindcss@3.4.15)
+      tiny-invariant:
+        specifier: ^1.3.3
+        version: 1.3.3
+      typescript:
+        specifier: ^5.7.3
+        version: 5.7.3
+      unstated-next:
+        specifier: ^1.1.0
+        version: 1.1.0
+      use-debounce:
+        specifier: ^3.0.0
+        version: 3.4.3(react@19.0.0)
+      vague-time:
+        specifier: ^2.4.2
+        version: 2.4.2
+      vite-tsconfig-paths:
+        specifier: ^5.1.3
+        version: 5.1.3(typescript@5.7.3)(vite@5.4.14(@types/node@20.12.14)(terser@5.19.2))
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@20.12.14)(jsdom@16.7.0(bufferutil@4.0.8))(terser@5.19.2)
+      zod:
+        specifier: ^3.23.8
+        version: 3.23.8
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.47.2
+        version: 1.47.2
+      nextjs-bundle-analysis:
+        specifier: ^0.5.0
+        version: 0.5.0
 
   packages/api:
     dependencies:
@@ -8037,6 +8040,40 @@ packages:
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
+  turbo-darwin-64@2.5.0:
+    resolution: {integrity: sha512-fP1hhI9zY8hv0idym3hAaXdPi80TLovmGmgZFocVAykFtOxF+GlfIgM/l4iLAV9ObIO4SUXPVWHeBZQQ+Hpjag==}
+    cpu: [x64]
+    os: [darwin]
+
+  turbo-darwin-arm64@2.5.0:
+    resolution: {integrity: sha512-p9sYq7kXH7qeJwIQE86cOWv/xNqvow846l6c/qWc26Ib1ci5W7V0sI5thsrP3eH+VA0d+SHalTKg5SQXgNQBWA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  turbo-linux-64@2.5.0:
+    resolution: {integrity: sha512-1iEln2GWiF3iPPPS1HQJT6ZCFXynJPd89gs9SkggH2EJsj3eRUSVMmMC8y6d7bBbhBFsiGGazwFIYrI12zs6uQ==}
+    cpu: [x64]
+    os: [linux]
+
+  turbo-linux-arm64@2.5.0:
+    resolution: {integrity: sha512-bKBcbvuQHmsX116KcxHJuAcppiiBOfivOObh2O5aXNER6mce7YDDQJy00xQQNp1DhEfcSV2uOsvb3O3nN2cbcA==}
+    cpu: [arm64]
+    os: [linux]
+
+  turbo-windows-64@2.5.0:
+    resolution: {integrity: sha512-9BCo8oQ7BO7J0K913Czbc3tw8QwLqn2nTe4E47k6aVYkM12ASTScweXPTuaPFP5iYXAT6z5Dsniw704Ixa5eGg==}
+    cpu: [x64]
+    os: [win32]
+
+  turbo-windows-arm64@2.5.0:
+    resolution: {integrity: sha512-OUHCV+ueXa3UzfZ4co/ueIHgeq9B2K48pZwIxKSm5VaLVuv8M13MhM7unukW09g++dpdrrE1w4IOVgxKZ0/exg==}
+    cpu: [arm64]
+    os: [win32]
+
+  turbo@2.5.0:
+    resolution: {integrity: sha512-PvSRruOsitjy6qdqwIIyolv99+fEn57gP6gn4zhsHTEcCYgXPhv6BAxzAjleS8XKpo+Y582vTTA9nuqYDmbRuA==}
+    hasBin: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -16808,6 +16845,33 @@ snapshots:
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  turbo-darwin-64@2.5.0:
+    optional: true
+
+  turbo-darwin-arm64@2.5.0:
+    optional: true
+
+  turbo-linux-64@2.5.0:
+    optional: true
+
+  turbo-linux-arm64@2.5.0:
+    optional: true
+
+  turbo-windows-64@2.5.0:
+    optional: true
+
+  turbo-windows-arm64@2.5.0:
+    optional: true
+
+  turbo@2.5.0:
+    optionalDependencies:
+      turbo-darwin-64: 2.5.0
+      turbo-darwin-arm64: 2.5.0
+      turbo-linux-64: 2.5.0
+      turbo-linux-arm64: 2.5.0
+      turbo-windows-64: 2.5.0
+      turbo-windows-arm64: 2.5.0
 
   type-check@0.4.0:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": [".next/**", "!.next/cache/**", "public/data/**", "build/**"],
+      "env": ["POSTGRES_URL"]
+    },
+    "lint": {
+      "dependsOn": ["^lint"]
+    },
+    "typecheck": {
+      "dependsOn": ["^typecheck"]
+    },
+    "dev": {
+      "persistent": true,
+      "cache": false
+    }
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,7 @@
     "build": {
       "dependsOn": ["^build"],
       "outputs": [".next/**", "!.next/cache/**", "public/data/**", "build/**"],
-      "env": ["POSTGRES_URL"]
+      "env": ["POSTGRES_URL", "GITHUB_ACCESS_TOKEN", "STAGE"]
     },
     "lint": {
       "dependsOn": ["^lint"]


### PR DESCRIPTION
## Goal

After some exploration (https://github.com/bestofjs/bestofjs/pull/311/) it's time to take advantage of [Turbo](https://turbo.build/docs/core-concepts/remote-caching) to orchestrate 🎶  all scripts within the repo!

Benefits:

- Provide global commands to ensure the code is "clean" running type checking and linting against all workspaces
- Speed up commands in local (avoiding useless operations if nothing changed)
- Provide better control about what to trigger when anything changes (compared to what is available on GitHub Actions) and the ability to run the checks in local

## How to test

To run the type checking command against **all** workspaces within the repo:

```sh
pnpm run typecheck
```

I wanted to skip the Turbo commands against the `legacy` app that triggers hundreds of TS errors, this why I set up scripts in the root `package.json`.

```json
{
    "build": "turbo run build -F=!legacy",
    "lint": "turbo run lint -F=!legacy",
    "typecheck": "turbo run typecheck -F=!legacy",
}
```


## Screenshots

#### Command Line

Running `pnpm run typecheck`, enjoy the speed ⚡ ! (`FULL TURBO` like they say 😄 )

![image](https://github.com/user-attachments/assets/48734445-3733-4c47-8fd0-411a5f297855)


#### Build on Vercel

Note: Vercel detects the fact we use Turbo and automatically triggers the build using `turbo run build` instead of `pnpm run build`

![image](https://github.com/user-attachments/assets/bed97a41-24a2-49bb-ba69-1ac3dbd52b60)


#### On GitHub Actions:

![image](https://github.com/user-attachments/assets/444919a6-531a-45d7-abd7-086840dd074c)

