### PR TITLE
Try to fix caching issue with JSON data

### DIFF
--- a/apps/web/scripts/build-project-data.mjs
+++ b/apps/web/scripts/build-project-data.mjs
@@ -19,7 +19,9 @@ main();
 async function buildJsonFile(filename) {
   const url = env.STATIC_API_ROOT_URL_V2 + `/` + filename;
   console.log(`Fetching data from ${url}`);
-  const data = await fetch(url).then((res) => res.json());
+  const data = await fetch(url, { cache: "no-store" }).then((res) =>
+    res.json()
+  );
   console.log("Fetched data", data.date);
   const filepath = path.join(process.cwd(), "public", "data", filename);
   console.log("Copy", filepath);


### PR DESCRIPTION
## Goal

After the latest changes, it seems there is a caching issue when calling the pre-build script that fetches data from the JSON file deployed by `bestofjs-static-api-v2` on Vercel.

From the log on Vercel, for `bestofjs` project:

```
web:build: === Build JSON files for the backend... ===
web:build: Fetching data from https://bestofjs-static-api-v2.vercel.app/projects.json
web:build: Fetched data 2025-04-19T22:15:05.275Z
web:build: Copy /vercel/path0/apps/web/public/data/projects.json
web:build: === Prebuild process OK! ===
```

It should fetch data for `2025-04-20T21:54:52.876Z` instead (the date inside the latest JSON file generated this morning)

## How to test

Tricky to test as we need to merge and wait 24 hours and check the build logs!

