### PR TITLE
Fix GitHub Actions after migration to PNPM catalog feature

### DIFF
--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Install Dependencies
         shell: bash
-        run: pnpm -F web install
+        run: pnpm -F web... install
 
       - name: Build
         shell: bash

--- a/.github/workflows/update-bundle-size.yml
+++ b/.github/workflows/update-bundle-size.yml
@@ -39,6 +39,6 @@ jobs:
         uses: ./.github/tooling/github-actions/install
       - name: Install Dependencies
         shell: bash
-        run: pnpm -F backend install
+        run: pnpm -F backend... install
       - name: Update Bundle Size
         run: pnpm -F backend daily-update-bundle-size --loglevel ${{ inputs.logLevel || 3 }} --limit ${{ inputs.limit || 0 }} --skip ${{ inputs.skip || 0 }} --concurrency ${{ inputs.concurrency || 1 }}

--- a/.github/workflows/update-github-data.yml
+++ b/.github/workflows/update-github-data.yml
@@ -47,7 +47,7 @@ jobs:
         uses: ./.github/tooling/github-actions/install
       - name: Install Dependencies
         shell: bash
-        run: pnpm -F backend install
+        run: pnpm install
       - name: Update GitHub Data and take snapshots
         run: pnpm -F backend daily-update-github-data --loglevel ${{ inputs.logLevel || 3 }} --limit ${{ inputs.limit || 0 }} --skip ${{ inputs.skip || 0 }} --concurrency ${{ inputs.concurrency || 1 }} --throttleInterval ${{ inputs.throttleInterval || 750 }}
       - name: Send Webhook to Vercel

--- a/.github/workflows/update-github-data.yml
+++ b/.github/workflows/update-github-data.yml
@@ -47,7 +47,7 @@ jobs:
         uses: ./.github/tooling/github-actions/install
       - name: Install Dependencies
         shell: bash
-        run: pnpm install
+        run: pnpm install -F backend...
       - name: Update GitHub Data and take snapshots
         run: pnpm -F backend daily-update-github-data --loglevel ${{ inputs.logLevel || 3 }} --limit ${{ inputs.limit || 0 }} --skip ${{ inputs.skip || 0 }} --concurrency ${{ inputs.concurrency || 1 }} --throttleInterval ${{ inputs.throttleInterval || 750 }}
       - name: Send Webhook to Vercel

--- a/.github/workflows/update-github-data.yml
+++ b/.github/workflows/update-github-data.yml
@@ -47,7 +47,7 @@ jobs:
         uses: ./.github/tooling/github-actions/install
       - name: Install Dependencies
         shell: bash
-        run: pnpm install -F backend...
+        run: pnpm -F backend... install
       - name: Update GitHub Data and take snapshots
         run: pnpm -F backend daily-update-github-data --loglevel ${{ inputs.logLevel || 3 }} --limit ${{ inputs.limit || 0 }} --skip ${{ inputs.skip || 0 }} --concurrency ${{ inputs.concurrency || 1 }} --throttleInterval ${{ inputs.throttleInterval || 750 }}
       - name: Send Webhook to Vercel

--- a/.github/workflows/update-package-data.yml
+++ b/.github/workflows/update-package-data.yml
@@ -44,6 +44,6 @@ jobs:
         uses: ./.github/tooling/github-actions/install
       - name: Install Dependencies
         shell: bash
-        run: pnpm -F backend install
+        run: pnpm -F backend... install
       - name: Update Packages Data
         run: pnpm -F backend daily-update-package-data --loglevel ${{ inputs.logLevel || 3 }} --limit ${{ inputs.limit || 0 }} --skip ${{ inputs.skip || 0 }} --concurrency ${{ inputs.concurrency || 5 }} --throttleInterval ${{ inputs.throttleInterval || 0 }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
 auto-install-peers=true
+shared-workspace-lockfile=true
+dedupe-peer-dependents=true


### PR DESCRIPTION
## Goal

Fix the broken scripts running on GitHub Actions after the introduction of PNPM 10 Catalog feature: #356 

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'debug' 
```

![image](https://github.com/user-attachments/assets/99e8c2b6-92b2-49dd-8228-af1e5ba23275)

It seems we need to add a suffix `...` when running `pnpm -F backend install` commands!

## How to test

Trigger actions manually from GitHub Actions tab

- Update GitHub data
- Update Package date
- Update Package Size


