### PR TITLE
Refactor main list filter function

### DIFF
--- a/apps/backend/src/tasks/build-static-api.task.ts
+++ b/apps/backend/src/tasks/build-static-api.task.ts
@@ -13,7 +13,7 @@ import { truncate } from "@/shared/utils";
 import { createTask } from "@/task-runner";
 import { ProjectItem } from "./static-api-types";
 
-// Thresholds for filtering projects includes in the main list
+// Thresholds for filtering projects included in the main list
 const YEARLY_STARS_THRESHOLD = 50;
 const MONTHLY_DOWNLOADS_THRESHOLD = 100_000;
 


### PR DESCRIPTION
## Goal

Cleanup related to the generatation of the "static API" (JSON file consumed by the web app, used when performing search and displaying lists of projects)

## How to test

Build the static API in local:

```
bun run apps/backend/src/cli.ts build-static-api
```

Ensure projects are filtered correctly.

```
ℹ Finding ids of projects to process...                                                                                       2:39:28 PM
◐ Processing 3120 project(s)...                                                                                                2:39:28 PM
ℹ Processed 3120 project(s) in 12.2s (Avg: 4ms)                                                                               2:39:41 PM
ℹ 2493 projects to include in the main JSON file { trendingToday:                                                             2:39:41 PM
   [ 'snapDOM (+335)',
     'n8n (+297)',
     'AFFiNE (+229)',
     'react-bits (+164)',
     'Onlook (+137)' ] }
ℹ Saving projects.json { size: '1.65 MB' }
```

