### PR TITLE
Fix OG images removing the `<title>` attribute from SVG files

### DIFF
--- a/apps/web/src/app/api/og/og-image-layout.tsx
+++ b/apps/web/src/app/api/og/og-image-layout.tsx
@@ -1,3 +1,4 @@
+/** biome-ignore-all lint/a11y/noSvgWithoutTitle: titles are rendered! */
 type Props = {
   children: React.ReactNode;
 };
@@ -44,7 +45,6 @@ function AppLogo() {
       }}
     >
       <svg xmlns="http://www.w3.org/2000/svg" width="200" viewBox="0 0 700 200">
-        <title>Best of JS</title>
         <g transform="translate(-40 -30)">
           <path
             fill="currentColor"

--- a/apps/web/src/app/api/og/og-utils.tsx
+++ b/apps/web/src/app/api/og/og-utils.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable @next/next/no-img-element */
+/** biome-ignore-all lint/a11y/noSvgWithoutTitle: titles are rendered! */
 
 import type React from "react";
 import { ImageResponse } from "next/og";
@@ -68,7 +69,6 @@ export function StarIcon() {
       width="1em"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title>Star</title>
       <path d="M22 9.24l-7.19-.62L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21 12 17.27 18.18 21l-1.63-7.03L22 9.24zM12 15.4l-3.76 2.27 1-4.28-3.32-2.88 4.38-.38L12 6.1l1.71 4.04 4.38.38-3.32 2.88 1 4.28L12 15.4z"></path>
     </svg>
   );
@@ -84,7 +84,6 @@ export function TagIcon({ size = "1.5em" }) {
       height={size}
       width={size}
     >
-      <title>Tag</title>
       <path
         fillRule="evenodd"
         d="M7.73 1.73C7.26 1.26 6.62 1 5.96 1H3.5C2.13 1 1 2.13 1 3.5v2.47c0 .66.27 1.3.73 1.77l6.06 6.06c.39.39 1.02.39 1.41 0l4.59-4.59a.996.996 0 0 0 0-1.41L7.73 1.73zM2.38 7.09c-.31-.3-.47-.7-.47-1.13V3.5c0-.88.72-1.59 1.59-1.59h2.47c.42 0 .83.16 1.13.47l6.14 6.13-4.73 4.73-6.13-6.15zM3.01 3h2v2H3V3h.01z"


### PR DESCRIPTION
## Goal

Fix #366 I should have not added `<title>` attributes to SVG files used to generate dynamic OG images, to satisfy one of the linting rules provided by Biome (we migrated 3 weeks ago: #364 )

## How to test

Visit `/api/og` and ensure the OG image is rendered correctly

## Screenshots

<img width="1200" height="630" alt="image" src="https://github.com/user-attachments/assets/495fa91b-6888-4dbb-a3a7-e1668a9a0875" />

