### PR TITLE
Improve link UX, show a spinner while navigation is pending

### DIFF
--- a/apps/web/src/app/projects/page.tsx
+++ b/apps/web/src/app/projects/page.tsx
@@ -13,6 +13,10 @@ import {
   toTrendsProject,
 } from "@/app/projects/project-adapter";
 import { PlusIcon, TagIcon, XMarkIcon } from "@/components/core";
+import {
+  LinkPendingIcon,
+  LinkPendingOverlay,
+} from "@/components/core/link-pending";
 import { PageHeading } from "@/components/core/typography";
 import { TrendsProjectPaginatedList } from "@/components/project-list/trends-project-paginated-list";
 import { TrendsProjectScopePicker } from "@/components/project-list/trends-scope-picker";
@@ -308,10 +312,19 @@ function RelevantTags({
           <NextLink
             key={tag.code}
             href={url}
-            className={buttonVariants({ variant: "outline", size: "sm" })}
+            className={cn(
+              buttonVariants({ variant: "outline", size: "sm" }),
+              "relative px-2.5",
+            )}
           >
             {tag.name}
-            {showIcon && <PlusIcon className="size-5" />}
+            {showIcon ? (
+              <LinkPendingIcon>
+                <PlusIcon className="size-5" />
+              </LinkPendingIcon>
+            ) : (
+              <LinkPendingOverlay />
+            )}
           </NextLink>
         );
       })}
@@ -343,7 +356,9 @@ function CurrentTags({
             className={cn(badgeVariants({ variant: "default" }), "text-md")}
           >
             {tag.name}
-            <XMarkIcon className="size-5" />
+            <LinkPendingIcon>
+              <XMarkIcon className="size-5" />
+            </LinkPendingIcon>
           </NextLink>
         );
       })}
@@ -357,7 +372,9 @@ function CurrentTags({
           className={cn(badgeVariants({ variant: "default" }), "text-md")}
         >
           "{textQuery}"
-          <XMarkIcon className="size-5" />
+          <LinkPendingIcon>
+            <XMarkIcon className="size-5" />
+          </LinkPendingIcon>
         </NextLink>
       )}
     </div>

--- a/apps/web/src/components/core/link-pending.tsx
+++ b/apps/web/src/components/core/link-pending.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import type React from "react";
+import { useLinkStatus } from "next/link";
+
+import { Spinner } from "@/components/ui/spinner";
+import { cn } from "@/lib/utils";
+
+/**
+ * Swaps a link's trailing icon for a spinner while its navigation is pending.
+ *
+ * Filter links point at the route segment already on screen
+ * (`/projects?tags=a` → `?tags=b`), so React keeps the mounted list visible
+ * through the transition and nothing else acknowledges the click.
+ *
+ * Must render inside a `<Link>`: `useLinkStatus()` reads that link's context
+ * and returns `{ pending: false }` anywhere else.
+ */
+export function LinkPendingIcon({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  const { pending } = useLinkStatus();
+
+  return (
+    <span
+      className={cn(
+        "relative inline-flex size-5 items-center justify-center",
+        className,
+      )}
+    >
+      <span
+        className={cn(
+          "inline-flex transition-opacity",
+          pending ? "opacity-0" : "opacity-100",
+        )}
+      >
+        {children}
+      </span>
+      <Spinner
+        aria-hidden={!pending}
+        className={cn(
+          "absolute size-4 transition-opacity",
+          // The delay applies to the fade in only, so a navigation that
+          // resolves in under 150ms never flashes a spinner.
+          pending ? "opacity-100 delay-150" : "opacity-0",
+        )}
+      />
+    </span>
+  );
+}
+
+/**
+ * Same feedback for links with no icon to swap: a spinner fades in over the
+ * link's own content, so the chip never changes size.
+ *
+ * The parent `<Link>` needs `relative`, and `bg-inherit` keeps the overlay on
+ * the chip's current background, hover included.
+ */
+export function LinkPendingOverlay() {
+  const { pending } = useLinkStatus();
+
+  return (
+    <span
+      aria-hidden={!pending}
+      className={cn(
+        "pointer-events-none absolute inset-0 flex items-center justify-center rounded-[inherit] bg-inherit transition-opacity",
+        pending ? "opacity-100 delay-150" : "opacity-0",
+      )}
+    >
+      <Spinner className="size-3.5" />
+    </span>
+  );
+}

--- a/apps/web/src/components/core/link-pending.tsx
+++ b/apps/web/src/components/core/link-pending.tsx
@@ -33,6 +33,7 @@ export function LinkPendingIcon({
       )}
     >
       <span
+        aria-hidden={pending}
         className={cn(
           "inline-flex transition-opacity",
           pending ? "opacity-0" : "opacity-100",

--- a/apps/web/src/components/core/pagination/pagination-controls.tsx
+++ b/apps/web/src/components/core/pagination/pagination-controls.tsx
@@ -2,6 +2,7 @@ import type React from "react";
 import NextLink from "next/link";
 
 import { ChevronLeftIcon, ChevronRightIcon } from "@/components/core/icons";
+import { LinkPendingIcon } from "@/components/core/link-pending";
 import { buttonVariants } from "@/components/ui/button";
 import { formatNumber } from "@/helpers/numbers";
 import type {
@@ -58,12 +59,16 @@ export function BottomPaginationControls<T extends PaginationProps>(
   return (
     <div className="flex gap-2">
       <PaginationButton href={previousPageURL} isDisabled={!hasPreviousPage}>
-        <ChevronLeftIcon className="size-4" />
+        <LinkPendingIcon className="size-4">
+          <ChevronLeftIcon className="size-4" />
+        </LinkPendingIcon>
         Prev
       </PaginationButton>
       <PaginationButton href={nextPageURL} isDisabled={!hasNextPage}>
         Next
-        <ChevronRightIcon className="size-4" />
+        <LinkPendingIcon className="size-4">
+          <ChevronRightIcon className="size-4" />
+        </LinkPendingIcon>
       </PaginationButton>
     </div>
   );

--- a/apps/web/src/components/tags/project-tag-group.tsx
+++ b/apps/web/src/components/tags/project-tag-group.tsx
@@ -29,7 +29,15 @@ export function ProjectTagGroup<T extends TagFilterState = TagFilterState>({
           : `/projects?tags=${tag.code}`;
         return (
           <div key={tag.code} className="m-1">
-            <ProjectTag tag={tag} url={url} />
+            <ProjectTag
+              tag={tag}
+              url={url}
+              // A `buildPageURL` means the caller is a listing page, so the link
+              // only changes its search params: the list stays mounted and no
+              // loading shell appears. Without it the chip leads to /projects
+              // from somewhere else, and that route's skeleton covers the wait.
+              showPendingIndicator={Boolean(buildPageURL)}
+            />
           </div>
         );
       })}

--- a/apps/web/src/components/tags/project-tag.tsx
+++ b/apps/web/src/components/tags/project-tag.tsx
@@ -2,6 +2,7 @@
 
 import NextLink from "next/link";
 
+import { LinkPendingOverlay } from "@/components/core/link-pending";
 import { badgeVariants } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
@@ -11,10 +12,17 @@ export function ProjectTag({
   tag,
   url,
   className,
+  showPendingIndicator,
 }: {
   tag: BestOfJS.RawTag;
   url: string;
   className?: string;
+  /**
+   * Only for chips whose link keeps the visitor on the listing page they are
+   * already on. Those navigations re-use the mounted list instead of mounting
+   * the route's loading shell, so without this nothing acknowledges the click.
+   */
+  showPendingIndicator?: boolean;
 }) {
   return (
     <ProjectTagHoverCard tag={tag}>
@@ -22,11 +30,12 @@ export function ProjectTag({
         href={url}
         className={cn(
           badgeVariants({ variant: "outline" }),
-          "rounded-sm bg-card px-3 py-1 font-normal font-sans text-sm hover:bg-accent",
+          "relative rounded-sm bg-card px-3 py-1 font-normal font-sans text-sm hover:bg-accent",
           className,
         )}
       >
         {tag.name}
+        {showPendingIndicator && <LinkPendingOverlay />}
       </NextLink>
     </ProjectTagHoverCard>
   );


### PR DESCRIPTION
## Goal

#470 made cross-route navigations feel instant (e.g. `/tags` → `/projects?tags=…` shows the loading shell right away).

Same-route filter changes on `/projects` (`?tags=a` → `?tags=b`, pagination, remove tag) still looked frozen: React keeps the mounted list visible during the transition, so the Suspense fallback never appears and nothing acknowledged the click.

## Fix

Use `useLinkStatus` to show a spinner on the clicked link (tag chips, Prev/Next) until the navigation completes.

## How to test

1. Open `/projects`, click a tag chip or Prev/Next — spinner on that control while the list updates.
2. From a project page, click a tag — loading shell still appears (no spinner needed).