### PR TITLE
Spike`noai` sub app

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -33,7 +33,7 @@
     "debug": "^4.3.7",
     "lucide-react": "0.428.0",
     "motion": "^12.23.16",
-    "nanoid": "^5.1.5",
+    "nanoid": "^5.1.16",
     "next": "catalog:",
     "next-themes": "^0.4.4",
     "nuqs": "^2.7.1",

--- a/apps/backend/src/tasks/check-trends-queries.task.ts
+++ b/apps/backend/src/tasks/check-trends-queries.task.ts
@@ -112,7 +112,7 @@ export const checkTrendsQueriesTask = createTask({
     const packageNames = parseList(flags.packages);
     // `--excludeTags rankings` is a shorthand for the exclusion the home page
     // and the /trends pages apply, so it can be checked without retyping it.
-    const excludeTagCodes =
+    const excludedTagCodes =
       flags.excludeTags === "rankings"
         ? TAGS_EXCLUDED_FROM_RANKINGS
         : parseList(flags.excludeTags);
@@ -122,7 +122,7 @@ export const checkTrendsQueriesTask = createTask({
       sort,
       query: search,
       tagCodes,
-      excludeTagCodes,
+      excludedTagCodes,
       packageNames,
       page,
       limit,
@@ -184,7 +184,7 @@ export const checkTrendsQueriesTask = createTask({
       ...checkScope(projects, effectiveScope),
       ...checkSortOrder(projects, sort),
       ...checkTagFilter(projects, tagCodes),
-      ...checkExcludedTagFilter(projects, excludeTagCodes),
+      ...checkExcludedTagFilter(projects, excludedTagCodes),
       ...checkStatusFilter(projects, status),
       ...checkPackageFilter(projects, packageNames, ownedPackages),
       ...(full.total >= floored.total
@@ -323,12 +323,12 @@ function checkTagFilter(projects: ProjectWithTrends[], tagCodes?: string[]) {
 
 function checkExcludedTagFilter(
   projects: ProjectWithTrends[],
-  excludeTagCodes?: string[],
+  excludedTagCodes?: string[],
 ) {
-  if (!excludeTagCodes || excludeTagCodes.length === 0) return [];
+  if (!excludedTagCodes || excludedTagCodes.length === 0) return [];
   return projects
     .filter((project) =>
-      excludeTagCodes.some((tagCode) => project.tags.includes(tagCode)),
+      excludedTagCodes.some((tagCode) => project.tags.includes(tagCode)),
     )
     .map(
       (project) =>

--- a/apps/legacy/package.json
+++ b/apps/legacy/package.json
@@ -41,7 +41,7 @@
     "@headlessui/react": "^1.4.0",
     "@vitejs/plugin-react": "^2.0.0",
     "cross-env": "^7.0.3",
-    "dompurify": "^3.4.12",
+    "dompurify": "^3.4.13",
     "framer-motion": "^4.1.17",
     "numeral": "^1.5.3",
     "qs": "^6.15.2",

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -2,6 +2,11 @@ import type { NextConfig } from "next";
 
 import { env } from "./src/env.mjs";
 
+// Which deployment is being built. Logged because every other symptom of a
+// wrong `BESTOFJS_APP` looks like a normal site: the No AI build serving AI
+// projects is indistinguishable from the main one at a glance.
+console.info(`Building Best of JS — app: "${env.BESTOFJS_APP}"`);
+
 const ONE_DAY = 60 * 60 * 24;
 
 const nextConfig: NextConfig = {

--- a/apps/web/src/app/(home)/hot-projects.ts
+++ b/apps/web/src/app/(home)/hot-projects.ts
@@ -8,6 +8,7 @@ import {
   type TrendsProject,
   toTrendsProject,
 } from "@/app/projects/project-adapter";
+import type { WebApp } from "@/config/apps";
 
 /** The four star-delta windows the home page's time range picker offers. */
 export type HotProjectsSortKey = "daily" | "weekly" | "monthly" | "yearly";
@@ -29,11 +30,17 @@ export type HotProjectsSortKey = "daily" | "weekly" | "monthly" | "yearly";
  */
 export async function getHotProjects(
   sort: HotProjectsSortKey,
+  app: WebApp,
   limit = 5,
 ): Promise<TrendsProject[]> {
   "use cache";
   cacheLife("daily");
-  cacheTag("daily", "home");
+  // `app` is a real function parameter (not a module-scope import) because
+  // Next's "use cache" excludes module-scope values from the cache key
+  // (github.com/vercel/next.js#74498) — only genuine arguments count, and
+  // `findProjectsWithTrends()` below applies this deployment's excluded tags
+  // inside `@/app/db`, which the compiler can't see into from here.
+  cacheTag("daily", "home", app);
 
   const [{ projects: rows }, allTags] = await Promise.all([
     findProjectsWithTrends({

--- a/apps/web/src/app/(home)/hot-projects.ts
+++ b/apps/web/src/app/(home)/hot-projects.ts
@@ -1,4 +1,4 @@
-import { cacheLife, cacheTag } from "next/cache";
+import { cacheLife } from "next/cache";
 
 import { TAGS_EXCLUDED_FROM_RANKINGS } from "@repo/core/constants";
 
@@ -9,6 +9,7 @@ import {
   toTrendsProject,
 } from "@/app/projects/project-adapter";
 import type { WebApp } from "@/config/apps";
+import { cacheTagForApp } from "@/server/cache";
 
 /** The four star-delta windows the home page's time range picker offers. */
 export type HotProjectsSortKey = "daily" | "weekly" | "monthly" | "yearly";
@@ -35,12 +36,7 @@ export async function getHotProjects(
 ): Promise<TrendsProject[]> {
   "use cache";
   cacheLife("daily");
-  // `app` is a real function parameter (not a module-scope import) because
-  // Next's "use cache" excludes module-scope values from the cache key
-  // (github.com/vercel/next.js#74498) — only genuine arguments count, and
-  // `findProjectsWithTrends()` below applies this deployment's excluded tags
-  // inside `@/app/db`, which the compiler can't see into from here.
-  cacheTag("daily", "home", app);
+  cacheTagForApp(app, "daily", "home");
 
   const [{ projects: rows }, allTags] = await Promise.all([
     findProjectsWithTrends({

--- a/apps/web/src/app/(home)/hot-projects.ts
+++ b/apps/web/src/app/(home)/hot-projects.ts
@@ -1,10 +1,8 @@
 import { cacheLife, cacheTag } from "next/cache";
 
-import { db } from "@repo/core";
 import { TAGS_EXCLUDED_FROM_RANKINGS } from "@repo/core/constants";
-import { findProjectsWithTrends } from "@repo/core/services/projects";
-import { findTags } from "@repo/core/services/tags";
 
+import { findProjectsWithTrends, findTags } from "@/app/db";
 import {
   buildTagsByCode,
   type TrendsProject,
@@ -26,7 +24,7 @@ export type HotProjectsSortKey = "daily" | "weekly" | "monthly" | "yearly";
  * be redundant — and would risk a top-5 hole from the `activity_score = -100`
  * sentinel a repo carries until its first GitHub commit-history fetch.
  *
- * `excludeTagCodes` reproduces the pre-migration static API's editorial
+ * `excludedTagCodes` reproduces the pre-migration static API's editorial
  * exclusion, which applied to the home page and the rankings only.
  */
 export async function getHotProjects(
@@ -39,8 +37,7 @@ export async function getHotProjects(
 
   const [{ projects: rows }, allTags] = await Promise.all([
     findProjectsWithTrends({
-      db,
-      excludeTagCodes: TAGS_EXCLUDED_FROM_RANKINGS,
+      excludedTagCodes: TAGS_EXCLUDED_FROM_RANKINGS,
       limit,
       scope: "all",
       sort,

--- a/apps/web/src/app/(home)/layout.tsx
+++ b/apps/web/src/app/(home)/layout.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from "react";
-import { cacheLife, cacheTag } from "next/cache";
+import { cacheLife } from "next/cache";
 
 import { db } from "@repo/core";
 import {
@@ -25,6 +25,7 @@ import { LatestMonthlyRankings } from "@/components/home/latest-monthly-rankings
 import { Separator } from "@/components/ui/separator";
 import { currentApp, type WebApp } from "@/config/apps";
 import { APP_REPO_FULL_NAME } from "@/config/site";
+import { cacheTagForApp } from "@/server/cache";
 
 export default async function TrendsLayout({
   children,
@@ -54,7 +55,7 @@ async function TrendsLayoutMain({ children }: React.PropsWithChildren) {
 async function renderTrendsLayoutMain(app: WebApp, children: React.ReactNode) {
   "use cache";
   cacheLife("daily");
-  cacheTag("daily", "home", app);
+  cacheTagForApp(app, "daily", "home");
 
   const {
     activeTotal,

--- a/apps/web/src/app/(home)/layout.tsx
+++ b/apps/web/src/app/(home)/layout.tsx
@@ -4,12 +4,11 @@ import { cacheLife, cacheTag } from "next/cache";
 
 import { db } from "@repo/core";
 import {
-  findProjectsWithTrends,
   getProjectsStats,
   getRepoStarsByFullName,
 } from "@repo/core/services/projects";
-import { findTags } from "@repo/core/services/tags";
 
+import { findProjectsWithTrends, findTags } from "@/app/db";
 import { ProjectListCardLoading } from "@/app/projects/loading-state";
 import {
   buildTagsByCode,
@@ -90,7 +89,6 @@ async function getData() {
   const [{ projects: newestRows }, allTags, stats, bestOfJSStars] =
     await Promise.all([
       findProjectsWithTrends({
-        db,
         limit: NUMBER_OF_NEWEST_PROJECTS,
         // "Recently Added" is a chronological feed of editorial admissions, not
         // a quality ranking — curation already happened when a human added the

--- a/apps/web/src/app/(home)/layout.tsx
+++ b/apps/web/src/app/(home)/layout.tsx
@@ -1,4 +1,3 @@
-"use cache"; // needed at the file level to avoid errors `Route "/" used `require('node:crypto').randomBytes(size)` before accessing either uncached data`
 import { Suspense } from "react";
 import { cacheLife, cacheTag } from "next/cache";
 
@@ -24,6 +23,7 @@ import {
 } from "@/components/home/home-sections";
 import { LatestMonthlyRankings } from "@/components/home/latest-monthly-rankings";
 import { Separator } from "@/components/ui/separator";
+import { currentApp, type WebApp } from "@/config/apps";
 import { APP_REPO_FULL_NAME } from "@/config/site";
 
 export default async function TrendsLayout({
@@ -41,6 +41,21 @@ export default async function TrendsLayout({
 }
 
 async function TrendsLayoutMain({ children }: React.PropsWithChildren) {
+  return renderTrendsLayoutMain(currentApp, children);
+}
+
+// A component rendered as JSX can't take extra arguments, so the cached
+// rendering is split into this inner function: `app` needs to be a real
+// parameter (not a module-scope import) since Next's "use cache" excludes
+// module-scope values from the cache key (github.com/vercel/next.js#74498).
+// This is also the sole cache boundary needed to satisfy PPR's requirement
+// that a cached function run before any dynamic API is accessed in this route
+// (see the old file-level `"use cache"` this replaced).
+async function renderTrendsLayoutMain(app: WebApp, children: React.ReactNode) {
+  "use cache";
+  cacheLife("daily");
+  cacheTag("daily", "home", app);
+
   const {
     activeTotal,
     bestOfJSStars,
@@ -83,9 +98,6 @@ const NUMBER_OF_NEWEST_PROJECTS = 5;
 const NUMBER_OF_POPULAR_TAGS = 10;
 
 async function getData() {
-  cacheLife("daily");
-  cacheTag("daily", "home");
-
   const [{ projects: newestRows }, allTags, stats, bestOfJSStars] =
     await Promise.all([
       findProjectsWithTrends({

--- a/apps/web/src/app/(home)/page.tsx
+++ b/apps/web/src/app/(home)/page.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from "next";
-import { cacheLife, cacheTag } from "next/cache";
+import { cacheLife } from "next/cache";
 
 import { HotProjectList } from "@/components/home/hot-project-list";
 import { currentApp, type WebApp } from "@/config/apps";
+import { cacheTagForApp } from "@/server/cache";
 
 import { getHotProjects } from "./hot-projects";
 
@@ -17,7 +18,7 @@ export default async function DailyTrendsPage() {
 async function renderDailyTrendsPage(app: WebApp) {
   "use cache";
   cacheLife("daily");
-  cacheTag("daily", "home", app);
+  cacheTagForApp(app, "daily", "home");
 
   const projects = await getHotProjects("daily", app);
   return <HotProjectList projects={projects} sortOptionKey="daily" />;

--- a/apps/web/src/app/(home)/page.tsx
+++ b/apps/web/src/app/(home)/page.tsx
@@ -1,17 +1,25 @@
-"use cache";
-
 import type { Metadata } from "next";
 import { cacheLife, cacheTag } from "next/cache";
 
 import { HotProjectList } from "@/components/home/hot-project-list";
+import { currentApp, type WebApp } from "@/config/apps";
 
 import { getHotProjects } from "./hot-projects";
 
 export default async function DailyTrendsPage() {
-  cacheLife("daily");
-  cacheTag("daily", "home");
+  return renderDailyTrendsPage(currentApp);
+}
 
-  const projects = await getHotProjects("daily");
+// A page component can't take extra arguments, so the cached rendering is
+// split into this inner function: `app` needs to be a real parameter (not a
+// module-scope import) since Next's "use cache" excludes module-scope values
+// from the cache key (github.com/vercel/next.js#74498).
+async function renderDailyTrendsPage(app: WebApp) {
+  "use cache";
+  cacheLife("daily");
+  cacheTag("daily", "home", app);
+
+  const projects = await getHotProjects("daily", app);
   return <HotProjectList projects={projects} sortOptionKey="daily" />;
 }
 

--- a/apps/web/src/app/(home)/trends/monthly/page.tsx
+++ b/apps/web/src/app/(home)/trends/monthly/page.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from "next";
-import { cacheLife, cacheTag } from "next/cache";
+import { cacheLife } from "next/cache";
 
 import { getHotProjects } from "@/app/(home)/hot-projects";
 import { HotProjectList } from "@/components/home/hot-project-list";
 import { currentApp, type WebApp } from "@/config/apps";
+import { cacheTagForApp } from "@/server/cache";
 
 export default async function MonthlyTrendsPage() {
   return renderMonthlyTrendsPage(currentApp);
@@ -15,7 +16,7 @@ export default async function MonthlyTrendsPage() {
 async function renderMonthlyTrendsPage(app: WebApp) {
   "use cache";
   cacheLife("daily");
-  cacheTag("daily", "home", app);
+  cacheTagForApp(app, "daily", "home");
 
   const projects = await getHotProjects("monthly", app);
   return <HotProjectList projects={projects} sortOptionKey="monthly" />;

--- a/apps/web/src/app/(home)/trends/monthly/page.tsx
+++ b/apps/web/src/app/(home)/trends/monthly/page.tsx
@@ -1,16 +1,23 @@
-"use cache";
-
 import type { Metadata } from "next";
 import { cacheLife, cacheTag } from "next/cache";
 
 import { getHotProjects } from "@/app/(home)/hot-projects";
 import { HotProjectList } from "@/components/home/hot-project-list";
+import { currentApp, type WebApp } from "@/config/apps";
 
 export default async function MonthlyTrendsPage() {
-  cacheLife("daily");
-  cacheTag("daily", "home");
+  return renderMonthlyTrendsPage(currentApp);
+}
 
-  const projects = await getHotProjects("monthly");
+// See `(home)/page.tsx` for why this is split: `app` must be a real
+// parameter, since Next's "use cache" excludes module-scope values from the
+// cache key (github.com/vercel/next.js#74498).
+async function renderMonthlyTrendsPage(app: WebApp) {
+  "use cache";
+  cacheLife("daily");
+  cacheTag("daily", "home", app);
+
+  const projects = await getHotProjects("monthly", app);
   return <HotProjectList projects={projects} sortOptionKey="monthly" />;
 }
 

--- a/apps/web/src/app/(home)/trends/weekly/page.tsx
+++ b/apps/web/src/app/(home)/trends/weekly/page.tsx
@@ -1,16 +1,23 @@
-"use cache";
-
 import type { Metadata } from "next";
 import { cacheLife, cacheTag } from "next/cache";
 
 import { getHotProjects } from "@/app/(home)/hot-projects";
 import { HotProjectList } from "@/components/home/hot-project-list";
+import { currentApp, type WebApp } from "@/config/apps";
 
 export default async function WeeklyTrendsPage() {
-  cacheLife("daily");
-  cacheTag("daily", "home");
+  return renderWeeklyTrendsPage(currentApp);
+}
 
-  const projects = await getHotProjects("weekly");
+// See `(home)/page.tsx` for why this is split: `app` must be a real
+// parameter, since Next's "use cache" excludes module-scope values from the
+// cache key (github.com/vercel/next.js#74498).
+async function renderWeeklyTrendsPage(app: WebApp) {
+  "use cache";
+  cacheLife("daily");
+  cacheTag("daily", "home", app);
+
+  const projects = await getHotProjects("weekly", app);
   return <HotProjectList projects={projects} sortOptionKey="weekly" />;
 }
 

--- a/apps/web/src/app/(home)/trends/weekly/page.tsx
+++ b/apps/web/src/app/(home)/trends/weekly/page.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from "next";
-import { cacheLife, cacheTag } from "next/cache";
+import { cacheLife } from "next/cache";
 
 import { getHotProjects } from "@/app/(home)/hot-projects";
 import { HotProjectList } from "@/components/home/hot-project-list";
 import { currentApp, type WebApp } from "@/config/apps";
+import { cacheTagForApp } from "@/server/cache";
 
 export default async function WeeklyTrendsPage() {
   return renderWeeklyTrendsPage(currentApp);
@@ -15,7 +16,7 @@ export default async function WeeklyTrendsPage() {
 async function renderWeeklyTrendsPage(app: WebApp) {
   "use cache";
   cacheLife("daily");
-  cacheTag("daily", "home", app);
+  cacheTagForApp(app, "daily", "home");
 
   const projects = await getHotProjects("weekly", app);
   return <HotProjectList projects={projects} sortOptionKey="weekly" />;

--- a/apps/web/src/app/(home)/trends/yearly/page.tsx
+++ b/apps/web/src/app/(home)/trends/yearly/page.tsx
@@ -1,16 +1,23 @@
-"use cache";
-
 import type { Metadata } from "next";
 import { cacheLife, cacheTag } from "next/cache";
 
 import { getHotProjects } from "@/app/(home)/hot-projects";
 import { HotProjectList } from "@/components/home/hot-project-list";
+import { currentApp, type WebApp } from "@/config/apps";
 
 export default async function YearlyTrendsPage() {
-  cacheLife("daily");
-  cacheTag("daily", "home");
+  return renderYearlyTrendsPage(currentApp);
+}
 
-  const projects = await getHotProjects("yearly");
+// See `(home)/page.tsx` for why this is split: `app` must be a real
+// parameter, since Next's "use cache" excludes module-scope values from the
+// cache key (github.com/vercel/next.js#74498).
+async function renderYearlyTrendsPage(app: WebApp) {
+  "use cache";
+  cacheLife("daily");
+  cacheTag("daily", "home", app);
+
+  const projects = await getHotProjects("yearly", app);
   return <HotProjectList projects={projects} sortOptionKey="yearly" />;
 }
 

--- a/apps/web/src/app/(home)/trends/yearly/page.tsx
+++ b/apps/web/src/app/(home)/trends/yearly/page.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from "next";
-import { cacheLife, cacheTag } from "next/cache";
+import { cacheLife } from "next/cache";
 
 import { getHotProjects } from "@/app/(home)/hot-projects";
 import { HotProjectList } from "@/components/home/hot-project-list";
 import { currentApp, type WebApp } from "@/config/apps";
+import { cacheTagForApp } from "@/server/cache";
 
 export default async function YearlyTrendsPage() {
   return renderYearlyTrendsPage(currentApp);
@@ -15,7 +16,7 @@ export default async function YearlyTrendsPage() {
 async function renderYearlyTrendsPage(app: WebApp) {
   "use cache";
   cacheLife("daily");
-  cacheTag("daily", "home", app);
+  cacheTagForApp(app, "daily", "home");
 
   const projects = await getHotProjects("yearly", app);
   return <HotProjectList projects={projects} sortOptionKey="yearly" />;

--- a/apps/web/src/app/api/og/projects/route.tsx
+++ b/apps/web/src/app/api/og/projects/route.tsx
@@ -26,6 +26,7 @@ import {
   getTrendsSortOptionByKey,
   type TrendsSortOption,
 } from "@/components/project-list/trends-sort-order-options";
+import { currentApp, type WebApp } from "@/config/apps";
 import { fromNow } from "@/helpers/from-now";
 import { formatNumber } from "@/helpers/numbers";
 import { getSearchParamsKeyValues } from "@/lib/url-search-params";
@@ -38,7 +39,10 @@ export async function GET(req: Request) {
   const { searchState } = getSearchStateFromURL(req.url);
   const { query, sort } = searchState;
   const sortOption = getTrendsSortOptionByKey(sort);
-  const { projects, selectedTags } = await fetchOgProjects(searchState);
+  const { projects, selectedTags } = await fetchOgProjects(
+    searchState,
+    currentApp,
+  );
 
   return generateImageResponse(
     <ImageLayout>
@@ -63,10 +67,18 @@ export async function GET(req: Request) {
   );
 }
 
-async function fetchOgProjects(searchState: TrendsProjectSearchState) {
+async function fetchOgProjects(
+  searchState: TrendsProjectSearchState,
+  app: WebApp,
+) {
   "use cache";
   cacheLife("hours");
-  cacheTag("projects");
+  // `app` is a real function parameter (not a module-scope import) because
+  // Next's "use cache" excludes module-scope values from the cache key
+  // (github.com/vercel/next.js#74498) — and `findProjectsWithTrends()` applies
+  // this deployment's excluded tags inside `@/app/db`, which the compiler
+  // can't see into from here.
+  cacheTag("projects", app);
 
   const NUMBER_OF_PROJECTS = 3;
   const { tags: tagCodes, query, sort, page } = searchState;

--- a/apps/web/src/app/api/og/projects/route.tsx
+++ b/apps/web/src/app/api/og/projects/route.tsx
@@ -1,8 +1,5 @@
 import { cacheLife, cacheTag } from "next/cache";
 
-import { db } from "@repo/core";
-import { findProjectsWithTrends } from "@repo/core/services/projects";
-import { findTags } from "@repo/core/services/tags";
 import type { TrendsSortKey } from "@repo/core/shared-schemas";
 
 import {
@@ -14,6 +11,7 @@ import {
   StarIcon,
   TagIcon,
 } from "@/app/api/og/og-utils";
+import { findProjectsWithTrends, findTags } from "@/app/db";
 import {
   buildTagsByCode,
   type TrendsProject,
@@ -75,7 +73,6 @@ async function fetchOgProjects(searchState: TrendsProjectSearchState) {
 
   const [{ projects: rows }, allTags] = await Promise.all([
     findProjectsWithTrends({
-      db,
       limit: NUMBER_OF_PROJECTS,
       page,
       query,

--- a/apps/web/src/app/api/og/projects/route.tsx
+++ b/apps/web/src/app/api/og/projects/route.tsx
@@ -1,4 +1,4 @@
-import { cacheLife, cacheTag } from "next/cache";
+import { cacheLife } from "next/cache";
 
 import type { TrendsSortKey } from "@repo/core/shared-schemas";
 
@@ -30,6 +30,7 @@ import { currentApp, type WebApp } from "@/config/apps";
 import { fromNow } from "@/helpers/from-now";
 import { formatNumber } from "@/helpers/numbers";
 import { getSearchParamsKeyValues } from "@/lib/url-search-params";
+import { cacheTagForApp } from "@/server/cache";
 
 import { ImageLayout } from "../og-image-layout";
 
@@ -73,12 +74,7 @@ async function fetchOgProjects(
 ) {
   "use cache";
   cacheLife("hours");
-  // `app` is a real function parameter (not a module-scope import) because
-  // Next's "use cache" excludes module-scope values from the cache key
-  // (github.com/vercel/next.js#74498) — and `findProjectsWithTrends()` applies
-  // this deployment's excluded tags inside `@/app/db`, which the compiler
-  // can't see into from here.
-  cacheTag("projects", app);
+  cacheTagForApp(app, "projects");
 
   const NUMBER_OF_PROJECTS = 3;
   const { tags: tagCodes, query, sort, page } = searchState;

--- a/apps/web/src/app/api/og/route.tsx
+++ b/apps/web/src/app/api/og/route.tsx
@@ -1,5 +1,6 @@
 import { getHotProjects } from "@/app/(home)/hot-projects";
 import type { TrendsProject } from "@/app/projects/project-adapter";
+import { currentApp } from "@/config/apps";
 
 import { ImageLayout } from "./og-image-layout";
 import {
@@ -16,7 +17,11 @@ const NUMBER_OF_PROJECTS = 3;
 export async function GET() {
   // Same helper the home page uses, tag exclusion included, so the page and its
   // own social preview cannot rank "hot projects" differently.
-  const projects = await getHotProjects("daily", NUMBER_OF_PROJECTS);
+  const projects = await getHotProjects(
+    "daily",
+    currentApp,
+    NUMBER_OF_PROJECTS,
+  );
 
   return generateImageResponse(
     <ImageLayout>

--- a/apps/web/src/app/api/tags/[slug]/route.tsx
+++ b/apps/web/src/app/api/tags/[slug]/route.tsx
@@ -1,12 +1,13 @@
 import { cacheLife, cacheTag } from "next/cache";
 
 import { findTagWithProjects } from "@/app/db";
+import { currentApp, type WebApp } from "@/config/apps";
 
 type Context = { params: Promise<{ slug: string }> };
 export async function GET(_req: Request, props: Context) {
   const { slug } = await props.params;
 
-  const tag = await getTagData(slug);
+  const tag = await getTagData(slug, currentApp);
   if (!tag) {
     return new Response(JSON.stringify({ error: `Tag not found: ${slug}` }), {
       status: 404,
@@ -27,10 +28,15 @@ export async function GET(_req: Request, props: Context) {
   });
 }
 
-async function getTagData(slug: string) {
+async function getTagData(slug: string, app: WebApp) {
   "use cache";
   cacheLife("days");
-  cacheTag("tags"); // same tag as /tags, so one revalidation clears both
+  // `app` is a real function parameter (not a module-scope import) because
+  // Next's "use cache" excludes module-scope values from the cache key
+  // (github.com/vercel/next.js#74498) — and `findTagWithProjects()` applies
+  // this deployment's excluded tags inside `@/app/db`, which the compiler
+  // can't see into from here.
+  cacheTag("tags", app); // same tag as /tags, so one revalidation clears both
 
   return await findTagWithProjects(slug);
 }

--- a/apps/web/src/app/api/tags/[slug]/route.tsx
+++ b/apps/web/src/app/api/tags/[slug]/route.tsx
@@ -1,6 +1,6 @@
 import { cacheLife, cacheTag } from "next/cache";
 
-import { findTagWithProjects } from "@repo/core/services/tags";
+import { findTagWithProjects } from "@/app/db";
 
 type Context = { params: Promise<{ slug: string }> };
 export async function GET(_req: Request, props: Context) {

--- a/apps/web/src/app/api/tags/[slug]/route.tsx
+++ b/apps/web/src/app/api/tags/[slug]/route.tsx
@@ -1,7 +1,8 @@
-import { cacheLife, cacheTag } from "next/cache";
+import { cacheLife } from "next/cache";
 
 import { findTagWithProjects } from "@/app/db";
 import { currentApp, type WebApp } from "@/config/apps";
+import { cacheTagForApp } from "@/server/cache";
 
 type Context = { params: Promise<{ slug: string }> };
 export async function GET(_req: Request, props: Context) {
@@ -31,12 +32,7 @@ export async function GET(_req: Request, props: Context) {
 async function getTagData(slug: string, app: WebApp) {
   "use cache";
   cacheLife("days");
-  // `app` is a real function parameter (not a module-scope import) because
-  // Next's "use cache" excludes module-scope values from the cache key
-  // (github.com/vercel/next.js#74498) — and `findTagWithProjects()` applies
-  // this deployment's excluded tags inside `@/app/db`, which the compiler
-  // can't see into from here.
-  cacheTag("tags", app); // same tag as /tags, so one revalidation clears both
+  cacheTagForApp(app, "tags"); // same tag as /tags, so one revalidation clears both
 
   return await findTagWithProjects(slug);
 }

--- a/apps/web/src/app/db.ts
+++ b/apps/web/src/app/db.ts
@@ -1,5 +1,102 @@
 import { db } from "@repo/core";
-import { ProjectService } from "@repo/core/services/projects";
+import {
+  type FindProjectsWithTrendsOptions,
+  findProjectsWithTrends as findProjectsWithTrendsQuery,
+  ProjectService,
+} from "@repo/core/services/projects";
+import {
+  type FindRelevantTagsOptions,
+  findRelevantTags as findRelevantTagsQuery,
+  findTags as findTagsQuery,
+  findTagsWithProjects as findTagsWithProjectsQuery,
+  findTagWithProjects as findTagWithProjectsQuery,
+} from "@repo/core/services/tags";
+
+import { excludedTagCodes } from "@/config/apps";
 
 /** Export a singleton to avoid creating too many connections */
 export const projectService = new ProjectService(db);
+
+/**
+ * The app's data façade: every listing query the pages use, pre-bound to `db`
+ * and to the tags this deployment hides (`@/config/apps`).
+ *
+ * Pages import from here rather than from `@repo/core/services/*` so that
+ * "which tags does this deployment exclude" is decided in exactly one place.
+ * Passing it per call site instead would fail silently — a page that forgot it
+ * looks completely normal, it just serves the projects the deployment exists to
+ * hide. Core stays deployment-agnostic: it takes `excludedTagCodes` as an
+ * ordinary query parameter, which the admin app will pass from its own UI.
+ */
+
+/**
+ * Editorial exclusions (`TAGS_EXCLUDED_FROM_RANKINGS`) and deployment
+ * exclusions are merged, never substituted — a caller passing its own list is
+ * narrowing the result further, not opting out of this deployment's identity.
+ */
+function mergeExcludedTags(callerTagCodes?: string[], optOut = false) {
+  const merged = [
+    ...(optOut ? [] : excludedTagCodes),
+    ...(callerTagCodes ?? []),
+  ];
+  return merged.length > 0 ? merged : undefined;
+}
+
+/**
+ * `showExcludedTags` is the `/projects` `?ai=1` opt-out — the one place a page
+ * may ask for this deployment's hidden tags back. It never disables the
+ * caller's own `excludedTagCodes` (the editorial ranking exclusion), only the
+ * deployment's.
+ */
+type AppQueryOptions = { showExcludedTags?: boolean };
+
+export function findProjectsWithTrends({
+  showExcludedTags,
+  ...options
+}: Omit<FindProjectsWithTrendsOptions, "db"> & AppQueryOptions) {
+  return findProjectsWithTrendsQuery({
+    ...options,
+    db,
+    excludedTagCodes: mergeExcludedTags(
+      options.excludedTagCodes,
+      showExcludedTags,
+    ),
+  });
+}
+
+export function findRelevantTags({
+  showExcludedTags,
+  ...options
+}: Omit<FindRelevantTagsOptions, "db"> & AppQueryOptions) {
+  return findRelevantTagsQuery({
+    ...options,
+    db,
+    excludedTagCodes: mergeExcludedTags(
+      options.excludedTagCodes,
+      showExcludedTags,
+    ),
+  });
+}
+
+export function findTags() {
+  return findTagsQuery({ excludedTagCodes: mergeExcludedTags() });
+}
+
+export function findTagsWithProjects(
+  options?: Parameters<typeof findTagsWithProjectsQuery>[0],
+) {
+  return findTagsWithProjectsQuery({
+    ...options,
+    excludedTagCodes: mergeExcludedTags(options?.excludedTagCodes),
+  });
+}
+
+export function findTagWithProjects(
+  code: string,
+  options?: Parameters<typeof findTagWithProjectsQuery>[1],
+) {
+  return findTagWithProjectsQuery(code, {
+    ...options,
+    excludedTagCodes: mergeExcludedTags(options?.excludedTagCodes),
+  });
+}

--- a/apps/web/src/app/featured/page.tsx
+++ b/apps/web/src/app/featured/page.tsx
@@ -1,4 +1,4 @@
-import { cacheLife, cacheTag } from "next/cache";
+import { cacheLife } from "next/cache";
 
 import { findProjectsWithTrends, findTags } from "@/app/db";
 import {
@@ -13,6 +13,7 @@ import { StarIcon } from "@/components/core";
 import { PageHeading } from "@/components/core/typography";
 import { TrendsProjectPaginatedList } from "@/components/project-list/trends-project-paginated-list";
 import { currentApp, type WebApp } from "@/config/apps";
+import { cacheTagForApp } from "@/server/cache";
 
 type PageProps = {
   searchParams: Promise<Record<string, string | string[]>>;
@@ -56,12 +57,7 @@ async function fetchFeaturedProjects(
 ) {
   "use cache";
   cacheLife("hours");
-  // `app` is a real function parameter (not a module-scope import) because
-  // Next's "use cache" excludes module-scope values from the cache key
-  // (github.com/vercel/next.js#74498) — and `findProjectsWithTrends()` applies
-  // this deployment's excluded tags inside `@/app/db`, which the compiler
-  // can't see into from here.
-  cacheTag("projects", app);
+  cacheTagForApp(app, "projects");
 
   const { sort, page, limit } = searchState;
 

--- a/apps/web/src/app/featured/page.tsx
+++ b/apps/web/src/app/featured/page.tsx
@@ -12,6 +12,7 @@ import {
 import { StarIcon } from "@/components/core";
 import { PageHeading } from "@/components/core/typography";
 import { TrendsProjectPaginatedList } from "@/components/project-list/trends-project-paginated-list";
+import { currentApp, type WebApp } from "@/config/apps";
 
 type PageProps = {
   searchParams: Promise<Record<string, string | string[]>>;
@@ -26,7 +27,10 @@ searchStateParser.path = "/featured";
 export default async function FeaturedProjectsPage(props: PageProps) {
   const searchParams = await props.searchParams;
   const { searchState, buildPageURL } = searchStateParser.parse(searchParams);
-  const { projects, total } = await fetchFeaturedProjects(searchState);
+  const { projects, total } = await fetchFeaturedProjects(
+    searchState,
+    currentApp,
+  );
 
   return (
     <>
@@ -46,10 +50,18 @@ export default async function FeaturedProjectsPage(props: PageProps) {
   );
 }
 
-async function fetchFeaturedProjects(searchState: TrendsProjectSearchState) {
+async function fetchFeaturedProjects(
+  searchState: TrendsProjectSearchState,
+  app: WebApp,
+) {
   "use cache";
   cacheLife("hours");
-  cacheTag("projects");
+  // `app` is a real function parameter (not a module-scope import) because
+  // Next's "use cache" excludes module-scope values from the cache key
+  // (github.com/vercel/next.js#74498) — and `findProjectsWithTrends()` applies
+  // this deployment's excluded tags inside `@/app/db`, which the compiler
+  // can't see into from here.
+  cacheTag("projects", app);
 
   const { sort, page, limit } = searchState;
 

--- a/apps/web/src/app/featured/page.tsx
+++ b/apps/web/src/app/featured/page.tsx
@@ -1,9 +1,6 @@
 import { cacheLife, cacheTag } from "next/cache";
 
-import { db } from "@repo/core";
-import { findProjectsWithTrends } from "@repo/core/services/projects";
-import { findTags } from "@repo/core/services/tags";
-
+import { findProjectsWithTrends, findTags } from "@/app/db";
 import {
   buildTagsByCode,
   toTrendsProject,
@@ -58,7 +55,6 @@ async function fetchFeaturedProjects(searchState: TrendsProjectSearchState) {
 
   const [{ projects: rows, total }, allTags] = await Promise.all([
     findProjectsWithTrends({
-      db,
       limit,
       page,
       // Hardcoded, not read from `searchState`: "featured" is an editorial

--- a/apps/web/src/app/projects/[slug]/page.tsx
+++ b/apps/web/src/app/projects/[slug]/page.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/app/(home)/hot-projects";
 import { projectService } from "@/app/db";
 import { Card, CardContent } from "@/components/ui/card";
+import { currentApp } from "@/config/apps";
 import { APP_CANONICAL_URL, APP_DISPLAY_NAME } from "@/config/site";
 
 import { ProjectDetailsNpmCard } from "./project-details-npm/project-details-npm";
@@ -101,7 +102,7 @@ const PRERENDERED_WINDOWS: HotProjectsSortKey[] = [
  */
 export async function generateStaticParams() {
   const lists = await Promise.all(
-    PRERENDERED_WINDOWS.map((sort) => getHotProjects(sort)),
+    PRERENDERED_WINDOWS.map((sort) => getHotProjects(sort, currentApp)),
   );
   const slugs = uniq(lists.flat().map((project) => project.slug));
   return slugs.map((slug) => ({ slug }));

--- a/apps/web/src/app/projects/[slug]/project-details-npm/dependencies-section.tsx
+++ b/apps/web/src/app/projects/[slug]/project-details-npm/dependencies-section.tsx
@@ -21,6 +21,7 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
+import { currentApp, type WebApp } from "@/config/apps";
 
 export async function DependenciesSection({
   project,
@@ -35,6 +36,7 @@ export async function DependenciesSection({
   const { projects, dependenciesNotOnBestOfJS } = await fetchDependencyProjects(
     project.slug,
     dependencies,
+    currentApp,
   );
 
   return (
@@ -94,10 +96,19 @@ export async function DependenciesSection({
  * bucket. `scope: "all"` because a deprecated dependency is still on Best of JS
  * and has a page to link to.
  */
-async function fetchDependencyProjects(slug: string, dependencies: string[]) {
+async function fetchDependencyProjects(
+  slug: string,
+  dependencies: string[],
+  app: WebApp,
+) {
   "use cache";
   cacheLife("days");
-  cacheTag("project-details", slug);
+  // `app` is a real function parameter (not a module-scope import) because
+  // Next's "use cache" excludes module-scope values from the cache key
+  // (github.com/vercel/next.js#74498) — and `findProjectsWithTrends()` applies
+  // this deployment's excluded tags inside `@/app/db`, which the compiler
+  // can't see into from here.
+  cacheTag("project-details", slug, app);
 
   const [{ projects: rows }, ownedPackages, allTags] = await Promise.all([
     findProjectsWithTrends({

--- a/apps/web/src/app/projects/[slug]/project-details-npm/dependencies-section.tsx
+++ b/apps/web/src/app/projects/[slug]/project-details-npm/dependencies-section.tsx
@@ -3,11 +3,10 @@ import { cacheLife, cacheTag } from "next/cache";
 import { db } from "@repo/core";
 import {
   findProjectSlugsByPackageNames,
-  findProjectsWithTrends,
   type ProjectDetails,
 } from "@repo/core/services/projects";
-import { findTags } from "@repo/core/services/tags";
 
+import { findProjectsWithTrends, findTags } from "@/app/db";
 import {
   buildTagsByCode,
   toTrendsProject,
@@ -102,7 +101,6 @@ async function fetchDependencyProjects(slug: string, dependencies: string[]) {
 
   const [{ projects: rows }, ownedPackages, allTags] = await Promise.all([
     findProjectsWithTrends({
-      db,
       limit: dependencies.length,
       packageNames: dependencies,
       scope: "all",

--- a/apps/web/src/app/projects/[slug]/project-details-npm/dependencies-section.tsx
+++ b/apps/web/src/app/projects/[slug]/project-details-npm/dependencies-section.tsx
@@ -1,4 +1,4 @@
-import { cacheLife, cacheTag } from "next/cache";
+import { cacheLife } from "next/cache";
 
 import { db } from "@repo/core";
 import {
@@ -22,6 +22,7 @@ import {
 } from "@/components/ui/collapsible";
 import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
 import { currentApp, type WebApp } from "@/config/apps";
+import { cacheTagForApp } from "@/server/cache";
 
 export async function DependenciesSection({
   project,
@@ -103,12 +104,7 @@ async function fetchDependencyProjects(
 ) {
   "use cache";
   cacheLife("days");
-  // `app` is a real function parameter (not a module-scope import) because
-  // Next's "use cache" excludes module-scope values from the cache key
-  // (github.com/vercel/next.js#74498) — and `findProjectsWithTrends()` applies
-  // this deployment's excluded tags inside `@/app/db`, which the compiler
-  // can't see into from here.
-  cacheTag("project-details", slug, app);
+  cacheTagForApp(app, "project-details", slug);
 
   const [{ projects: rows }, ownedPackages, allTags] = await Promise.all([
     findProjectsWithTrends({

--- a/apps/web/src/app/projects/page.tsx
+++ b/apps/web/src/app/projects/page.tsx
@@ -22,6 +22,7 @@ import { TrendsProjectScopePicker } from "@/components/project-list/trends-scope
 import { getTrendsSortOptionByKey } from "@/components/project-list/trends-sort-order-options";
 import { badgeVariants } from "@/components/ui/badge";
 import { buttonVariants } from "@/components/ui/button";
+import { currentApp, type WebApp } from "@/config/apps";
 import { APP_CANONICAL_URL, APP_DISPLAY_NAME } from "@/config/site";
 import { formatNumber } from "@/helpers/numbers";
 import { addCacheBustingParam } from "@/helpers/url";
@@ -52,7 +53,7 @@ const searchStateParser = new TrendsProjectSearchStateParser();
 export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const searchParams = await props.searchParams;
   const { searchState } = searchStateParser.parse(searchParams);
-  const data = await fetchPageData(searchState);
+  const data = await fetchPageData(searchState, currentApp);
 
   const title = getPageTitle(data, searchState);
   const description = getPageDescription(data, searchState);
@@ -148,8 +149,10 @@ async function ProjectsPageContent(props: PageProps) {
   const searchParams = await props.searchParams;
 
   const { searchState, buildPageURL } = searchStateParser.parse(searchParams);
-  const { projects, total, selectedTags, relevantTags } =
-    await fetchPageData(searchState);
+  const { projects, total, selectedTags, relevantTags } = await fetchPageData(
+    searchState,
+    currentApp,
+  );
 
   const { query } = searchState;
 
@@ -382,10 +385,16 @@ function CurrentTags({
 
 async function fetchPageData(
   searchState: TrendsProjectSearchState,
+  app: WebApp,
 ): Promise<ProjectsPageData> {
   "use cache";
   cacheLife("hours");
-  cacheTag("projects");
+  // `app` is a real function parameter (not a module-scope import) because
+  // Next's "use cache" excludes module-scope values from the cache key
+  // (github.com/vercel/next.js#74498) — and `findProjectsWithTrends()` /
+  // `findRelevantTags()` below apply this deployment's excluded tags inside
+  // `@/app/db`, which the compiler can't see into from here.
+  cacheTag("projects", app);
 
   const { ai, tags: tagCodes, sort, page, limit, query, scope } = searchState;
   // `?ai=1` asks this deployment for the tags it hides; on the main deployment

--- a/apps/web/src/app/projects/page.tsx
+++ b/apps/web/src/app/projects/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
-import { cacheLife, cacheTag } from "next/cache";
+import { cacheLife } from "next/cache";
 import NextLink from "next/link";
 
 import { resolveScope } from "@repo/core/services/projects";
@@ -27,6 +27,7 @@ import { APP_CANONICAL_URL, APP_DISPLAY_NAME } from "@/config/site";
 import { formatNumber } from "@/helpers/numbers";
 import { addCacheBustingParam } from "@/helpers/url";
 import { cn } from "@/lib/utils";
+import { cacheTagForApp } from "@/server/cache";
 
 import { ProjectListLoading } from "./loading-state";
 import {
@@ -389,12 +390,7 @@ async function fetchPageData(
 ): Promise<ProjectsPageData> {
   "use cache";
   cacheLife("hours");
-  // `app` is a real function parameter (not a module-scope import) because
-  // Next's "use cache" excludes module-scope values from the cache key
-  // (github.com/vercel/next.js#74498) — and `findProjectsWithTrends()` /
-  // `findRelevantTags()` below apply this deployment's excluded tags inside
-  // `@/app/db`, which the compiler can't see into from here.
-  cacheTag("projects", app);
+  cacheTagForApp(app, "projects");
 
   const { ai, tags: tagCodes, sort, page, limit, query, scope } = searchState;
   // `?ai=1` asks this deployment for the tags it hides; on the main deployment

--- a/apps/web/src/app/projects/page.tsx
+++ b/apps/web/src/app/projects/page.tsx
@@ -3,13 +3,9 @@ import type { Metadata } from "next";
 import { cacheLife, cacheTag } from "next/cache";
 import NextLink from "next/link";
 
-import { db } from "@repo/core";
-import {
-  findProjectsWithTrends,
-  resolveScope,
-} from "@repo/core/services/projects";
-import { findRelevantTags, findTags } from "@repo/core/services/tags";
+import { resolveScope } from "@repo/core/services/projects";
 
+import { findProjectsWithTrends, findRelevantTags, findTags } from "@/app/db";
 import {
   buildTagsByCode,
   type TrendsProject,
@@ -391,14 +387,25 @@ async function fetchPageData(
   cacheLife("hours");
   cacheTag("projects");
 
-  const { tags: tagCodes, sort, page, limit, query, scope } = searchState;
+  const { ai, tags: tagCodes, sort, page, limit, query, scope } = searchState;
+  // `?ai=1` asks this deployment for the tags it hides; on the main deployment
+  // there are none, so the flag is inert there.
+  const showExcludedTags = ai === "1";
 
   const [{ projects: rows, total }, allTags, relevantTags] = await Promise.all([
-    findProjectsWithTrends({ db, limit, page, query, scope, sort, tagCodes }),
+    findProjectsWithTrends({
+      limit,
+      page,
+      query,
+      scope,
+      showExcludedTags,
+      sort,
+      tagCodes,
+    }),
     findTags(),
     // Same `scope` as the listing: a suggested tag whose projects are all
     // filtered out would lead to an empty page.
-    findRelevantTags({ db, tagCodes, query, scope }),
+    findRelevantTags({ tagCodes, query, scope, showExcludedTags }),
   ]);
 
   const tagsByCode = buildTagsByCode(allTags);

--- a/apps/web/src/app/projects/project-adapter.ts
+++ b/apps/web/src/app/projects/project-adapter.ts
@@ -1,5 +1,9 @@
 import type { ProjectStatus } from "@repo/core/constants";
-import type { ProjectWithTrends } from "@repo/core/services/projects";
+import {
+  type ProjectWithTrends,
+  resolveProjectDescription,
+  resolveProjectURL,
+} from "@repo/core/services/projects";
 
 /**
  * `BestOfJS.Project` shape plus `activityScore`, which doesn't exist on the
@@ -30,7 +34,11 @@ export function toTrendsProject(
   return {
     slug: row.slug,
     name: row.name,
-    description: row.description,
+    description: resolveProjectDescription({
+      description: row.description,
+      overrideDescription: row.overrideDescription,
+      repoDescription: row.repo.description,
+    }),
     // `added_at` = Best of JS addition date (`projects.created_at`);
     // `created_at` = GitHub repo creation date (`repos.created_at`), matching
     // the pre-migration static API and the "Created" sort key.
@@ -57,7 +65,12 @@ export function toTrendsProject(
     npm: row.packageName ?? "",
     downloads: row.monthlyDownloads ?? 0,
     logo: row.logo ?? "",
-    url: row.url ?? "",
+    url:
+      resolveProjectURL({
+        overrideURL: row.overrideURL,
+        repoHomepage: row.repo.homepage,
+        url: row.url,
+      }) ?? "",
     status: row.status,
     tags: row.tags
       .map((code) => tagsByCode.get(code))

--- a/apps/web/src/app/projects/trends-project-search-state.ts
+++ b/apps/web/src/app/projects/trends-project-search-state.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import { trendsSortKeySchema } from "@repo/core/shared-schemas";
 
+import { showExcludedTagsByDefault } from "@/config/apps";
 import {
   limitSchema,
   type PageSearchStateUpdater,
@@ -9,6 +10,14 @@ import {
   paginationSchema,
   SearchStateParser,
 } from "@/lib/page-search-state";
+
+/**
+ * `"1"` / `"0"` rather than `true` / `false`: the value reads as a switch in the
+ * URL, and keeping it a string means the state round-trips through the URL
+ * builder unchanged.
+ */
+const aiSchema = z.enum(["0", "1"]);
+const defaultAi = showExcludedTagsByDefault ? "1" : "0";
 
 export const trendsProjectSearchStateSchema = paginationSchema.extend({
   tags: z
@@ -28,6 +37,10 @@ export const trendsProjectSearchStateSchema = paginationSchema.extend({
   // Defaults to the filtered view: a bare /projects URL hides the projects the
   // UI would badge as a warning, and `?scope=all` opts into the full catalog.
   scope: z.enum(["all", "active"]).catch("active").default("active"),
+  // Same shape as `scope`: a filter whose default the deployment sets and the
+  // URL opts out of. This is the whole mechanism — no deployment-specific code
+  // path, just a different default value.
+  ai: aiSchema.catch(defaultAi).default(defaultAi),
 });
 
 export type TrendsProjectSearchState = z.infer<
@@ -53,9 +66,15 @@ export class TrendsProjectSearchStateParser extends SearchStateParser<
    * `{ sort: "newest" }` was a no-op.
    */
   constructor(options: Partial<TrendsProjectSearchState> = {}) {
-    const { limit = 30, scope = "active", sort = "most-stars" } = options;
+    const {
+      ai = defaultAi,
+      limit = 30,
+      scope = "active",
+      sort = "most-stars",
+    } = options;
 
     const extendedSchema = trendsProjectSearchStateSchema.extend({
+      ai: aiSchema.catch(ai).default(ai),
       limit: limitSchema.default(limit),
       scope: z.enum(["all", "active"]).catch(scope).default(scope),
       sort: trendsSortKeySchema.catch(sort).default(sort),

--- a/apps/web/src/app/rankings/monthly/[year]/[month]/page.tsx
+++ b/apps/web/src/app/rankings/monthly/[year]/[month]/page.tsx
@@ -12,6 +12,7 @@ import { PageHeading } from "@/components/core/typography";
 import { ProjectTable } from "@/components/project-list/project-table";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Card, CardHeader } from "@/components/ui/card";
+import { currentApp, type WebApp } from "@/config/apps";
 import { APP_CANONICAL_URL, APP_DISPLAY_NAME } from "@/config/site";
 import { cn } from "@/lib/utils";
 import { api } from "@/server/api";
@@ -26,12 +27,21 @@ type PageProps = {
   }>;
 };
 
-// All monthly rankings are historical snapshots that never change
-// Cache them forever, tagged by their specific month for targeted revalidation
-async function getCachedMonthlyRankings(date: MonthlyDate, limit: number) {
+// All monthly rankings are historical snapshots that never change, so cache
+// forever, tagged by their specific month for targeted revalidation. `app` is
+// a real function parameter (not a module-scope import) because Next's
+// "use cache" excludes module-scope values from the cache key
+// (github.com/vercel/next.js#74498) — the Data Cache persists across
+// deployments, and `getMonthlyRankings()` depends on this deployment's
+// excluded tags by way of a call several modules deep.
+async function getCachedMonthlyRankings(
+  date: MonthlyDate,
+  limit: number,
+  app: WebApp,
+) {
   "use cache";
   cacheLife("forever"); // Historical data is frozen forever
-  cacheTag("monthly", `${date.year}-${date.month}`);
+  cacheTag("monthly", `${date.year}-${date.month}`, app);
   return api.rankings.getMonthlyRankings({ date, limit });
 }
 
@@ -39,7 +49,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const params = await props.params;
   const date = parsePageParams(params);
 
-  const { projects } = await getCachedMonthlyRankings(date, 10);
+  const { projects } = await getCachedMonthlyRankings(date, 10, currentApp);
   const projectNames = projects.map((project) => project.name).join(", ");
 
   const title = `Rankings ${formatMonthlyDate(date)}`;
@@ -65,6 +75,7 @@ export default async function MonthlyRankingPage(props: PageProps) {
   const { isFirst, isLatest, projects } = await getCachedMonthlyRankings(
     date,
     50,
+    currentApp,
   );
 
   return (

--- a/apps/web/src/app/rankings/monthly/[year]/[month]/page.tsx
+++ b/apps/web/src/app/rankings/monthly/[year]/[month]/page.tsx
@@ -1,6 +1,6 @@
 import { CalendarIcon } from "lucide-react";
 import type { Metadata } from "next";
-import { cacheLife, cacheTag } from "next/cache";
+import { cacheLife } from "next/cache";
 import Link from "next/link";
 
 import {
@@ -17,6 +17,7 @@ import { APP_CANONICAL_URL, APP_DISPLAY_NAME } from "@/config/site";
 import { cn } from "@/lib/utils";
 import { api } from "@/server/api";
 import type { MonthlyDate } from "@/server/api-rankings";
+import { cacheTagForApp } from "@/server/cache";
 
 import { formatMonthlyDate } from "../../monthly-rankings-utils";
 
@@ -41,7 +42,7 @@ async function getCachedMonthlyRankings(
 ) {
   "use cache";
   cacheLife("forever"); // Historical data is frozen forever
-  cacheTag("monthly", `${date.year}-${date.month}`, app);
+  cacheTagForApp(app, "monthly", `${date.year}-${date.month}`);
   return api.rankings.getMonthlyRankings({ date, limit });
 }
 

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,7 +1,6 @@
 import type { MetadataRoute } from "next";
 
-import { findTags } from "@repo/core/services/tags";
-
+import { findTags } from "@/app/db";
 import { APP_CANONICAL_URL } from "@/config/site";
 
 const NUMBER_OF_POPULAR_TAGS = 10;

--- a/apps/web/src/app/tags/page.tsx
+++ b/apps/web/src/app/tags/page.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from "next";
-import { cacheLife, cacheTag } from "next/cache";
+import { cacheLife } from "next/cache";
 
 import { findTagsWithProjects } from "@/app/db";
 import { currentApp, type WebApp } from "@/config/apps";
+import { cacheTagForApp } from "@/server/cache";
 
 import { TagsDataTable } from "./tags-data-table";
 import { TagsPageShell } from "./tags-page-shell";
@@ -22,7 +23,7 @@ export default async function TagsPage() {
 async function renderTagsPage(app: WebApp) {
   "use cache";
   cacheLife("hours"); // Time-based: after 1h, next request serves cached then revalidates in background; later users get fresh data.
-  cacheTag("tags", app); // On-demand: ?api/revalidate?tag=<tag>
+  cacheTagForApp(app, "tags"); // On-demand: ?api/revalidate?tag=<tag>
 
   const tags = await findTagsWithProjects();
 

--- a/apps/web/src/app/tags/page.tsx
+++ b/apps/web/src/app/tags/page.tsx
@@ -2,7 +2,7 @@
 import type { Metadata } from "next";
 import { cacheLife, cacheTag } from "next/cache";
 
-import { findTagsWithProjects } from "@repo/core/services/tags";
+import { findTagsWithProjects } from "@/app/db";
 
 import { TagsDataTable } from "./tags-data-table";
 import { TagsPageShell } from "./tags-page-shell";

--- a/apps/web/src/app/tags/page.tsx
+++ b/apps/web/src/app/tags/page.tsx
@@ -1,8 +1,8 @@
-"use cache";
 import type { Metadata } from "next";
 import { cacheLife, cacheTag } from "next/cache";
 
 import { findTagsWithProjects } from "@/app/db";
+import { currentApp, type WebApp } from "@/config/apps";
 
 import { TagsDataTable } from "./tags-data-table";
 import { TagsPageShell } from "./tags-page-shell";
@@ -12,8 +12,17 @@ export const metadata: Metadata = {
 };
 
 export default async function TagsPage() {
+  return renderTagsPage(currentApp);
+}
+
+// A page component can't take extra arguments, so the cached rendering is
+// split into this inner function: `app` needs to be a real parameter (not a
+// module-scope import) since Next's "use cache" excludes module-scope values
+// from the cache key (github.com/vercel/next.js#74498).
+async function renderTagsPage(app: WebApp) {
+  "use cache";
   cacheLife("hours"); // Time-based: after 1h, next request serves cached then revalidates in background; later users get fresh data.
-  cacheTag("tags"); // On-demand: ?api/revalidate?tag=<tag>
+  cacheTag("tags", app); // On-demand: ?api/revalidate?tag=<tag>
 
   const tags = await findTagsWithProjects();
 

--- a/apps/web/src/components/header/app-badge.tsx
+++ b/apps/web/src/components/header/app-badge.tsx
@@ -1,0 +1,17 @@
+import { Badge } from "@/components/ui/badge";
+import { appBadgeLabel } from "@/config/apps";
+
+/**
+ * Renders nothing on the main deployment, where `appBadgeLabel` is `null` — the
+ * one piece of UI that differs between deployments, and it differs by data
+ * rather than by a branch on the app's identity.
+ */
+export function AppBadge() {
+  if (!appBadgeLabel) return null;
+
+  return (
+    <Badge variant="secondary" className="uppercase">
+      {appBadgeLabel}
+    </Badge>
+  );
+}

--- a/apps/web/src/components/header/app-badge.tsx
+++ b/apps/web/src/components/header/app-badge.tsx
@@ -1,17 +1,30 @@
-import { Badge } from "@/components/ui/badge";
 import { appBadgeLabel } from "@/config/apps";
+import { cn } from "@/lib/utils";
 
 /**
  * Renders nothing on the main deployment, where `appBadgeLabel` is `null` — the
  * one piece of UI that differs between deployments, and it differs by data
  * rather than by a branch on the app's identity.
+ *
+ * Positioned by its parent (`MainNavContent`), which hangs it off the top-right
+ * corner of the logo like an edition mark. Neutral sand rather than the logo's
+ * own orange: next to the letters, a matching fill reads as part of the
+ * wordmark instead of as a label attached to it. Sand 3/11 keeps it a surface
+ * sitting just off the page background rather than an inverted chip, which at
+ * this size shouts louder than a permanent, unchanging marker should.
  */
 export function AppBadge() {
   if (!appBadgeLabel) return null;
 
   return (
-    <Badge variant="secondary" className="uppercase">
+    <span
+      className={cn(
+        "-top-0.5 -right-8 -z-10 pointer-events-none absolute rounded-full",
+        "border border-(--sand-6) bg-(--sand-3) px-1.5 py-px",
+        "font-sans font-semibold text-(--sand-11) text-[10px] uppercase tracking-wide",
+      )}
+    >
       {appBadgeLabel}
-    </Badge>
+    </span>
   );
 }

--- a/apps/web/src/components/header/desktop-nav.tsx
+++ b/apps/web/src/components/header/desktop-nav.tsx
@@ -22,33 +22,52 @@ import { ChevronDownIcon } from "../core";
 import { BestOfJSLogo } from "../svg-logos";
 import { MobileMenuButton } from "./mobile-nav";
 
-export function MainNav() {
+export function MainNav({ badge }: { badge?: React.ReactNode }) {
   const pathname = usePathname();
-  return <MainNavContent pathname={pathname} />;
+  return <MainNavContent pathname={pathname} badge={badge} />;
 }
 
-export function MainNavFallback() {
-  return <MainNavContent />;
+export function MainNavFallback({ badge }: { badge?: React.ReactNode }) {
+  return <MainNavContent badge={badge} />;
 }
 
-function MainNavContent({ pathname }: { pathname?: string }) {
+function MainNavContent({
+  pathname,
+  badge,
+}: {
+  pathname?: string;
+  badge?: React.ReactNode;
+}) {
   return (
     <>
       <div className="mr-4 lg:hidden">
         <MobileMenuButton />
       </div>
       <div className="flex gap-6 lg:gap-8">
-        <Link
-          href="/"
-          className="flex items-center space-x-2"
-          aria-label="Best of JS"
-        >
-          <BestOfJSLogo
-            width={130}
-            height={37.15}
-            className="h-[37.15px] w-[130px] text-(--logo-color)"
-          />
-        </Link>
+        {/*
+        `relative` so the deployment badge can hang off the logo's top-right
+        corner, `z-0` so the badge's negative z-index stays trapped in this
+        wrapper: without it the badge would slide behind the header's own
+        background — the header is `sticky z-40`, so it paints as one layer —
+        and disappear entirely instead of tucking under the logo.
+
+        The badge sits outside the `<Link>` on purpose: the link's `aria-label`
+        would hide any text nested inside it from screen readers.
+        */}
+        <div className="relative z-0 flex items-center">
+          <Link
+            href="/"
+            className="flex items-center space-x-2"
+            aria-label="Best of JS"
+          >
+            <BestOfJSLogo
+              width={130}
+              height={37.15}
+              className="h-[37.15px] w-[130px] text-(--logo-color)"
+            />
+          </Link>
+          {badge}
+        </div>
         <div className="hidden gap-2 lg:flex">
           <nav className="flex items-center gap-2">
             {mainNavItems?.map(

--- a/apps/web/src/components/header/site-header.tsx
+++ b/apps/web/src/components/header/site-header.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import Link from "next/link";
 
 import { DiscordIcon, GitHubIcon } from "@/components/core/icons";
+import { AppBadge } from "@/components/header/app-badge";
 import { MainNav, MainNavFallback } from "@/components/header/desktop-nav";
 import { ClientSearchRoot } from "@/components/search-palette/search-root";
 import { ThemeToggle } from "@/components/theme-toggle";
@@ -15,6 +16,7 @@ export function SiteHeader() {
         <Suspense fallback={<MainNavFallback />}>
           <MainNav />
         </Suspense>
+        <AppBadge />
         <div className="flex flex-1 items-center justify-end space-x-4">
           {/*
           Suspense block needed to avoid the "deopted into client-side rendering"

--- a/apps/web/src/components/header/site-header.tsx
+++ b/apps/web/src/components/header/site-header.tsx
@@ -13,10 +13,16 @@ export function SiteHeader() {
   return (
     <header className="sticky top-0 z-40 w-full border-b bg-background">
       <div className="container flex h-16 items-center space-x-4 sm:justify-between sm:space-x-0">
-        <Suspense fallback={<MainNavFallback />}>
-          <MainNav />
+        {/*
+        The badge is passed down rather than rendered here: it is positioned
+        against the logo, which lives inside `MainNav`. `MainNav` is a client
+        component and cannot read the server-only `BESTOFJS_APP` itself, so the
+        server renders the badge and hands it over as a slot. Both the nav and
+        its fallback get it, so it does not blink in during hydration.
+        */}
+        <Suspense fallback={<MainNavFallback badge={<AppBadge />} />}>
+          <MainNav badge={<AppBadge />} />
         </Suspense>
-        <AppBadge />
         <div className="flex flex-1 items-center justify-end space-x-4">
           {/*
           Suspense block needed to avoid the "deopted into client-side rendering"

--- a/apps/web/src/components/home/ai-tooling-info.tsx
+++ b/apps/web/src/components/home/ai-tooling-info.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { InfoIcon } from "lucide-react";
+
+import { linkVariants } from "@/components/ui/link";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+/**
+ * A popover rather than a tooltip: a tooltip never opens on touch devices, and
+ * this is the only pointer to the No AI deployment a first-time visitor gets.
+ * The trigger is a real button so it is reachable by keyboard too.
+ *
+ * The pointer lives behind an icon instead of an extra sentence because the
+ * intro paragraph has a hard two-line budget on desktop — a third line costs
+ * more above-the-fold space than the link is worth.
+ *
+ * The host arrives as a prop rather than being read from `@/config/apps`: that
+ * module derives `currentApp` from a server-only env var at import time, so a
+ * client component pulling *any* symbol out of it crashes the browser bundle.
+ */
+export function AiToolingInfo({ host }: { host: string }) {
+  return (
+    <Popover>
+      <PopoverTrigger
+        aria-label="About AI projects on Best of JS"
+        className="ml-1 inline-flex align-middle text-muted-foreground hover:text-foreground"
+      >
+        <InfoIcon className="size-4" />
+      </PopoverTrigger>
+      <PopoverContent align="start" className="font-sans text-sm">
+        Prefer a version without AI projects? Visit{" "}
+        <a href={`https://${host}`} className={linkVariants()}>
+          {host}
+        </a>
+        .
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/home/home-intro-section.tsx
+++ b/apps/web/src/components/home/home-intro-section.tsx
@@ -1,3 +1,7 @@
+import { linkVariants } from "@/components/ui/link";
+import { currentApp, hostByApp, type WebApp, webApps } from "@/config/apps";
+
+import { AiToolingInfo } from "./ai-tooling-info";
 import { TypeWriter } from "./typewriter";
 
 export function HomeIntroSection() {
@@ -13,17 +17,57 @@ export function HomeIntroSection() {
     "Deno",
     "CSS-in-JS",
   ];
+  const Intro = introByApp[currentApp];
   return (
     <div className="flex flex-col items-start gap-2">
       <h1 className="font-serif text-3xl leading-tight tracking-tighter md:text-4xl">
         <TypeWriter topics={topics} sleepTime={100} loop />
       </h1>
       <p className="font-serif text-lg text-muted-foreground">
-        A place to find the best open source projects related to the web
-        platform:
-        <br />
-        JS, HTML, CSS, but also TypeScript, Node.js, Deno, Bun...
+        <Intro />
       </p>
     </div>
+  );
+}
+
+/**
+ * The intro is the one piece of copy that cannot be a per-app string: the two
+ * deployments say structurally different things, one with a popover and one
+ * with a link. A lookup table keeps that difference declarative — still no
+ * `if (isNoAI)` — while leaving the markup where markup belongs rather than in
+ * `config/apps`.
+ */
+const introByApp: Record<WebApp, () => React.ReactNode> = {
+  [webApps.MAIN]: MainIntro,
+  [webApps.NOAI]: NoAiIntro,
+};
+
+function MainIntro() {
+  return (
+    <>
+      A place to find the best open source projects related to the web platform:
+      <br />
+      JS, HTML, CSS, but also TypeScript, Node.js, Deno, Bun, AI tooling...
+      <AiToolingInfo host={hostByApp[webApps.NOAI]} />
+    </>
+  );
+}
+
+/**
+ * Shorter than the main one, and it does not re-explain Best of JS: someone on
+ * this subdomain arrived on purpose. It still names the parent site, because
+ * search traffic can land here cold with no idea what it is a version *of*.
+ */
+function NoAiIntro() {
+  return (
+    <>
+      The <strong className="font-semibold">No AI</strong> version of{" "}
+      <a href={`https://${hostByApp[webApps.MAIN]}`} className={linkVariants()}>
+        Best of JS
+      </a>
+      :
+      <br />
+      the best open source projects of the web platform, minus AI tooling.
+    </>
   );
 }

--- a/apps/web/src/components/home/latest-monthly-rankings.tsx
+++ b/apps/web/src/components/home/latest-monthly-rankings.tsx
@@ -1,5 +1,5 @@
 import { CalendarIcon } from "lucide-react";
-import { cacheLife, cacheTag } from "next/cache";
+import { cacheLife } from "next/cache";
 import NextLink from "next/link";
 
 import { formatMonthlyDate } from "@/app/rankings/monthly/monthly-rankings-utils";
@@ -11,6 +11,7 @@ import { Card, CardHeader } from "@/components/ui/card";
 import { currentApp, type WebApp } from "@/config/apps";
 import { cn } from "@/lib/utils";
 import { api } from "@/server/api";
+import { cacheTagForApp } from "@/server/cache";
 
 export async function LatestMonthlyRankings() {
   return renderLatestMonthlyRankings(currentApp);
@@ -23,7 +24,7 @@ export async function LatestMonthlyRankings() {
 async function renderLatestMonthlyRankings(app: WebApp) {
   "use cache";
   cacheLife("monthly"); // Revalidate every 30 days for latest rankings
-  cacheTag("monthly", "latest", app);
+  cacheTagForApp(app, "monthly", "latest");
   const { year, month, projects } = await api.rankings.getMonthlyRankings({
     limit: 5,
   });

--- a/apps/web/src/components/home/latest-monthly-rankings.tsx
+++ b/apps/web/src/components/home/latest-monthly-rankings.tsx
@@ -8,13 +8,22 @@ import { SectionHeading } from "@/components/core/section";
 import { ProjectTable } from "@/components/project-list/project-table";
 import { buttonVariants } from "@/components/ui/button";
 import { Card, CardHeader } from "@/components/ui/card";
+import { currentApp, type WebApp } from "@/config/apps";
 import { cn } from "@/lib/utils";
 import { api } from "@/server/api";
 
 export async function LatestMonthlyRankings() {
+  return renderLatestMonthlyRankings(currentApp);
+}
+
+// A component rendered as JSX can't take extra arguments, so the cached
+// rendering is split into this inner function: `app` needs to be a real
+// parameter (not a module-scope import) since Next's "use cache" excludes
+// module-scope values from the cache key (github.com/vercel/next.js#74498).
+async function renderLatestMonthlyRankings(app: WebApp) {
   "use cache";
   cacheLife("monthly"); // Revalidate every 30 days for latest rankings
-  cacheTag("monthly", "latest");
+  cacheTag("monthly", "latest", app);
   const { year, month, projects } = await api.rankings.getMonthlyRankings({
     limit: 5,
   });

--- a/apps/web/src/config/apps.ts
+++ b/apps/web/src/config/apps.ts
@@ -1,0 +1,63 @@
+import { env } from "@/env.mjs";
+
+/**
+ * Best of JS runs as several deployments of *this same code*, differing only in
+ * which tags they hide. `BESTOFJS_APP` picks one; there is deliberately no
+ * conditional keyed on the app anywhere else in the codebase, so
+ * `git diff` between deployment branches stays empty.
+ */
+export const webApps = {
+  MAIN: "main",
+  NOAI: "noai",
+} as const;
+
+export type WebApp = (typeof webApps)[keyof typeof webApps];
+
+/**
+ * A list rather than a single tag code so the exclusion can be widened later
+ * (`llm`, `mcp`, ...) without touching anything but this table.
+ */
+export const excludedTagsByApp: Record<WebApp, string[]> = {
+  [webApps.MAIN]: [],
+  [webApps.NOAI]: ["ai"],
+};
+
+/**
+ * Marks which deployment you are on, in the header, on every page. Most of the
+ * site — project pages, `/tags`, `/hall-of-fame` — renders identically on both,
+ * so without a persistent marker there is no way to tell them apart. `null` on
+ * the main deployment: it is the unmarked default.
+ */
+export const badgeLabelByApp: Record<WebApp, string | null> = {
+  [webApps.MAIN]: null,
+  [webApps.NOAI]: "No AI",
+};
+
+export const hostByApp: Record<WebApp, string> = {
+  [webApps.MAIN]: "bestofjs.org",
+  [webApps.NOAI]: "noai.bestofjs.org",
+};
+
+export const currentApp: WebApp = env.BESTOFJS_APP;
+
+/**
+ * The tags this deployment hides. Read it through the `@/app/db` façade rather
+ * than here: passing it by hand at a query call site is the one mistake that
+ * fails silently — the page looks completely normal, it just quietly serves the
+ * projects this deployment exists to hide.
+ */
+export const excludedTagCodes = excludedTagsByApp[currentApp];
+
+export const isMainApp = currentApp === webApps.MAIN;
+
+export const appBadgeLabel = badgeLabelByApp[currentApp];
+
+/**
+ * The default value of the `/projects` `?ai=1|0` parameter: the *only*
+ * difference between deployments on that page. The control itself behaves
+ * identically on both — the No AI deployment does show AI projects when the URL
+ * explicitly asks for them. Suppressing that would mean hiding the parameter on
+ * one deployment and deciding what a hand-typed `?ai=1` does there, which is
+ * exactly the app-specific branching this design avoids.
+ */
+export const showExcludedTagsByDefault = excludedTagCodes.length === 0;

--- a/apps/web/src/env.mjs
+++ b/apps/web/src/env.mjs
@@ -18,6 +18,13 @@ export const env = createEnv({
       .string()
       .url()
       .default("https://bestofjs-rankings.vercel.app"),
+    /**
+     * Which deployment of the app this is — see `@/config/apps`. A `z.enum`
+     * rather than `z.string()` on purpose: a typo in the Vercel dashboard
+     * (`no-ai`) would otherwise fall back to `main` and silently serve AI
+     * projects on the No AI site, which looks entirely normal from the outside.
+     */
+    BESTOFJS_APP: z.enum(["main", "noai"]).default("main"),
   },
   client: {
     /** Show time spent in search palette filter functions */

--- a/apps/web/src/server/api-rankings.ts
+++ b/apps/web/src/server/api-rankings.ts
@@ -17,6 +17,12 @@ export type MonthlyDate = {
 
 export function createRankingsAPI(
   projectsAPI: ReturnType<typeof createProjectsAPI>,
+  /**
+   * Whether this deployment hides some tags — only used to keep the
+   * "project not found" log meaningful. The filtering itself happens once, in
+   * `createAPI()`'s `getData()`.
+   */
+  hasExcludedTags = false,
 ) {
   return {
     async getMonthlyRankings({
@@ -38,28 +44,36 @@ export function createRankingsAPI(
         res.json(),
       )) as RankingsData;
       const { isFirst, isLatest, month, year } = data;
-      const projects = data.trending.slice(0, limit);
-      const fullNames = projects.map((project) => project.full_name);
+      // The whole archived ranking is resolved before `limit` is applied, so a
+      // deployment that hides some tags still renders a *full* page rather than
+      // a truncated one: the lookup below drops the hidden projects, and the
+      // slice then takes the top `limit` of what is left. The archive holds ~100
+      // entries and the collection is already in memory, so this costs nothing.
+      const entries = data.trending;
+      const fullNames = entries.map((project) => project.full_name);
 
       const { projects: foundProjects } = await projectsAPI.findProjects({
         criteria: { full_name: { $in: fullNames } },
-        limit,
+        limit: entries.length,
       });
 
-      const sortedProjects = projects
+      const sortedProjects = entries
         .map(({ full_name, delta }) => {
           // we use `findLast` to lookup data because the oldest projects have a higher priority. TODO don't lookup by full_name, use a unique key
           const project = foundProjects.findLast(
             (project) => project.full_name === full_name,
           );
           if (!project) {
-            console.log("Not found", full_name);
+            // Expected, not an anomaly, on a deployment that hides tags: the
+            // archived entry was resolved against a filtered collection.
+            if (!hasExcludedTags) console.log("Not found", full_name);
 
             return;
           }
           return { ...project, score: delta };
         })
-        .filter(Boolean);
+        .filter(Boolean)
+        .slice(0, limit);
       return {
         isFirst,
         isLatest,

--- a/apps/web/src/server/cache.ts
+++ b/apps/web/src/server/cache.ts
@@ -1,0 +1,26 @@
+import { cacheTag as nextCacheTag } from "next/cache";
+
+import type { WebApp } from "@/config/apps";
+
+/**
+ * `cacheTag`, with the deployment's `app` appended. Use this — not
+ * `next/cache`'s `cacheTag` — at any `"use cache"` site whose result depends
+ * on this deployment's excluded tags (i.e. anything that reads through
+ * `@/app/db` or the static-JSON collection in `@/server/api`).
+ *
+ * Why `app` must be a real function parameter of the cached function, not a
+ * module-scope import: Next's `"use cache"` excludes module-scope values from
+ * the cache key (github.com/vercel/next.js#74498). This wrapper makes the
+ * common mistake — forgetting to key by deployment — a compile error rather
+ * than a silent one: a cached function that omits `app` from its signature
+ * has no `app` in scope to pass here.
+ *
+ * Note: this guards the tag, not the parameter. A cached function that closes
+ * over the module-scope `currentApp` instead of taking `app` as an argument
+ * still compiles — and still re-introduces the bug, since `currentApp` is
+ * excluded from the key. The page-split pattern (`renderX(currentApp)` →
+ * `renderXInner(app, …)`) is what keeps `app` a parameter; keep it.
+ */
+export function cacheTagForApp(app: WebApp, ...tags: string[]) {
+  return nextCacheTag(...tags, app);
+}

--- a/apps/web/src/server/create-api.tsx
+++ b/apps/web/src/server/create-api.tsx
@@ -1,3 +1,5 @@
+import { excludedTagCodes } from "@/config/apps";
+
 import { createProjectsAPI } from "./api-projects";
 import { createRankingsAPI } from "./api-rankings";
 import { createTagsAPI } from "./api-tags";
@@ -11,7 +13,19 @@ import {
 
 export function createAPI(fetchProjectData: () => Promise<RawData>) {
   async function getData() {
-    const { projects, tags: rawTags, date } = await fetchProjectData();
+    const {
+      projects: allProjects,
+      tags: allTags,
+      date,
+    } = await fetchProjectData();
+
+    // The single place this deployment's tag exclusion is applied to the static
+    // JSON collection: every consumer of `getData()` (the search palette index,
+    // the monthly rankings lookup) reads the filtered set, so none of them can
+    // forget. Filtering before `getTagsByKey()` also means the tag counters are
+    // computed on the filtered collection rather than corrected afterwards.
+    const { projects, rawTags } = excludeTags(allProjects, allTags);
+
     const tagsByKey = getTagsByKey(rawTags, projects);
     const projectsBySlug: Data["projectsBySlug"] = {};
     projects.forEach((project) => {
@@ -36,11 +50,31 @@ export function createAPI(fetchProjectData: () => Promise<RawData>) {
   const tagsAPI = createTagsAPI(context);
 
   // Dependent APIs
-  const rankingAPI = createRankingsAPI(projectsAPI);
+  const rankingAPI = createRankingsAPI(
+    projectsAPI,
+    excludedTagCodes.length > 0,
+  );
 
   return {
     projects: projectsAPI,
     tags: tagsAPI,
     rankings: rankingAPI,
+  };
+}
+
+/**
+ * Drops both the excluded tags and every project carrying one. Returns the
+ * inputs unchanged on the main deployment, where the list is empty.
+ */
+function excludeTags(
+  projects: BestOfJS.RawProject[],
+  tags: BestOfJS.RawTag[],
+): { projects: BestOfJS.RawProject[]; rawTags: BestOfJS.RawTag[] } {
+  if (excludedTagCodes.length === 0) return { projects, rawTags: tags };
+  return {
+    projects: projects.filter(
+      (project) => !project.tags.some((tag) => excludedTagCodes.includes(tag)),
+    ),
+    rawTags: tags.filter((tag) => !excludedTagCodes.includes(tag.code)),
   };
 }

--- a/apps/web/src/server/featured-projects.ts
+++ b/apps/web/src/server/featured-projects.ts
@@ -1,6 +1,8 @@
 import { db } from "@repo/core";
 import { findFeaturedProjects } from "@repo/core/services/projects";
 
+import { excludedTagCodes } from "@/config/apps";
+
 export type { FeaturedProject } from "@repo/core/services/projects";
 
 // TODO: Revisit this wrapper once listings are fully DB-driven
@@ -13,5 +15,21 @@ export async function findRandomFeaturedProjects({
   skip?: number;
   limit?: number;
 } = {}) {
-  return findFeaturedProjects(db, { skip, limit });
+  if (excludedTagCodes.length === 0) {
+    return findFeaturedProjects(db, { skip, limit });
+  }
+
+  // Featured projects come from a precomputed daily slug list, so the tags are
+  // only known once the rows are fetched — the exclusion cannot be pushed into
+  // the query. Over-fetch, then filter, then cut back to `limit`, so the
+  // carousel still shows a full set instead of a short one.
+  const { projects, total } = await findFeaturedProjects(db, {
+    skip,
+    limit: limit * 2,
+  });
+  const kept = projects.filter(
+    (project) =>
+      !project.tags.some((tag) => excludedTagCodes.includes(tag.code)),
+  );
+  return { projects: kept.slice(0, limit), total };
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,7 @@
     "es-toolkit": "^1.39.10",
     "is-absolute-url": "^4.0.1",
     "luxon": "^3.7.1",
-    "nanoid": "^5.1.5",
+    "nanoid": "^5.1.16",
     "slugify": "^1.6.6",
     "tiny-invariant": "^1.3.3",
     "zod": "catalog:"

--- a/packages/core/src/services/projects/find-with-trends.ts
+++ b/packages/core/src/services/projects/find-with-trends.ts
@@ -111,7 +111,7 @@ export interface FindProjectsWithTrendsOptions {
    * libraries. The `/projects` listing deliberately does not — see
    * `docs/architecture/web-app.md`.
    */
-  excludeTagCodes?: string[];
+  excludedTagCodes?: string[];
   limit?: number;
   /**
    * Keep only projects owning ANY of these npm package names, primary or
@@ -161,7 +161,7 @@ export type ProjectWithTrends = Awaited<
  */
 export async function findProjectsWithTrends({
   db,
-  excludeTagCodes,
+  excludedTagCodes,
   limit = 30,
   packageNames,
   page = 1,
@@ -185,8 +185,8 @@ export async function findProjectsWithTrends({
     tagCodes && tagCodes.length > 0
       ? getWhereClauseSearchByTag(db, tagCodes)
       : undefined,
-    excludeTagCodes && excludeTagCodes.length > 0
-      ? getWhereClauseExcludeTags(db, excludeTagCodes)
+    excludedTagCodes && excludedTagCodes.length > 0
+      ? getWhereClauseExcludeTags(db, excludedTagCodes)
       : undefined,
   );
 

--- a/packages/core/src/services/projects/find-with-trends.ts
+++ b/packages/core/src/services/projects/find-with-trends.ts
@@ -202,7 +202,9 @@ export async function findProjectsWithTrends({
       slug: projects.slug,
       name: projects.name,
       description: projects.description,
+      overrideDescription: projects.overrideDescription,
       url: projects.url,
+      overrideURL: projects.overrideURL,
       createdAt: projects.createdAt,
       status: projects.status,
       logo: projects.logo,
@@ -216,6 +218,8 @@ export async function findProjectsWithTrends({
         last_commit: repos.last_commit,
         contributor_count: repos.contributor_count,
         created_at: repos.created_at,
+        description: repos.description,
+        homepage: repos.homepage,
       },
       stars: starsExpression,
       trends: {

--- a/packages/core/src/services/projects/find.ts
+++ b/packages/core/src/services/projects/find.ts
@@ -155,15 +155,22 @@ export function getWhereClauseSearchByTag(db: DB, tagCodes: string[]) {
  * empty the result set.
  */
 export function getWhereClauseExcludeTags(db: DB, tagCodes: string[]) {
-  return notInArray(
-    projects.id,
-    db
-      .select({ id: projectsToTags.projectId })
-      .from(projectsToTags)
-      .innerJoin(tags, eq(projectsToTags.tagId, tags.id))
-      .where(inArray(tags.code, tagCodes))
-      .groupBy(projectsToTags.projectId),
-  );
+  return notInArray(projects.id, selectProjectIdsHavingAnyTag(db, tagCodes));
+}
+
+/**
+ * The sub-query behind `getWhereClauseExcludeTags()`, exported on its own so
+ * queries that filter `projects_to_tags` rather than `projects` — the tag
+ * counts in `services/tags` — exclude by exactly the same definition of
+ * "carries one of these tags" instead of restating it.
+ */
+export function selectProjectIdsHavingAnyTag(db: DB, tagCodes: string[]) {
+  return db
+    .select({ id: projectsToTags.projectId })
+    .from(projectsToTags)
+    .innerJoin(tags, eq(projectsToTags.tagId, tags.id))
+    .where(inArray(tags.code, tagCodes))
+    .groupBy(projectsToTags.projectId);
 }
 
 /**

--- a/packages/core/src/services/projects/project-helpers.ts
+++ b/packages/core/src/services/projects/project-helpers.ts
@@ -9,10 +9,11 @@ import type { OneYearSnapshots, ProjectDetails } from ".";
 
 export function getProjectDescription(project: ProjectDetails) {
   invariant(project.repo);
-  const repoDescription = project.repo.description;
-  return project.overrideDescription
-    ? project.description
-    : repoDescription || project.description;
+  return resolveProjectDescription({
+    description: project.description,
+    overrideDescription: project.overrideDescription,
+    repoDescription: project.repo.description,
+  });
 }
 
 export function getProjectRepositoryURL(project: ProjectDetails) {
@@ -21,10 +22,42 @@ export function getProjectRepositoryURL(project: ProjectDetails) {
 
 export function getProjectURL(project: ProjectDetails) {
   invariant(project.repo);
-  if (project.overrideURL) return project.url;
-  const homepage = project.repo.homepage;
+  return resolveProjectURL({
+    overrideURL: project.overrideURL,
+    repoHomepage: project.repo.homepage,
+    url: project.url,
+  });
+}
 
-  return homepage && isValidProjectURL(homepage) ? homepage : project.url;
+/**
+ * Shared by `getProjectDescription()` and any query (e.g.
+ * `findProjectsWithTrends()`) that needs the same override rule without
+ * loading the full `ProjectDetails` shape.
+ */
+export function resolveProjectDescription({
+  description,
+  overrideDescription,
+  repoDescription,
+}: {
+  description: string;
+  overrideDescription: boolean | null;
+  repoDescription: string | null;
+}) {
+  return overrideDescription ? description : repoDescription || description;
+}
+
+/** Shared by `getProjectURL()` and `findProjectsWithTrends()` — see `resolveProjectDescription()`. */
+export function resolveProjectURL({
+  overrideURL,
+  repoHomepage,
+  url,
+}: {
+  overrideURL: boolean | null;
+  repoHomepage: string | null;
+  url: string | null;
+}) {
+  if (overrideURL) return url;
+  return repoHomepage && isValidProjectURL(repoHomepage) ? repoHomepage : url;
 }
 
 export function getProjectTrends(snapshots: OneYearSnapshots[], date?: Date) {

--- a/packages/core/src/services/tags/find-relevant.ts
+++ b/packages/core/src/services/tags/find-relevant.ts
@@ -3,6 +3,7 @@ import { and, count, desc, eq, gte, notInArray } from "drizzle-orm";
 import type { DB } from "../../index";
 import * as schema from "../../schema";
 import {
+  getWhereClauseExcludeTags,
   getWhereClauseSearchByTag,
   getWhereClauseSearchByText,
 } from "../projects/find";
@@ -17,6 +18,12 @@ const { projects, projectTrends, projectsToTags, repoTrends, repos, tags } =
 
 export interface FindRelevantTagsOptions {
   db: DB;
+  /**
+   * Hide these tags, and every project carrying them, from the suggestions.
+   * Must match what the listing excludes — a suggestion the listing filters out
+   * is the same dead end the `scope` note below describes.
+   */
+  excludedTagCodes?: string[];
   /** Already-selected tag codes: scope to projects having ALL of them, exclude them from the output */
   tagCodes?: string[];
   /** Text search on project name/description and repo owner/name, same scoping as findProjectsWithTrends() */
@@ -44,14 +51,20 @@ export interface RelevantTag {
  */
 export async function findRelevantTags({
   db,
+  excludedTagCodes,
   tagCodes,
   query,
   relevanceFloor = false,
   scope = "active",
   limit = 20,
 }: FindRelevantTagsOptions): Promise<RelevantTag[]> {
+  const hasExcludedTags = excludedTagCodes && excludedTagCodes.length > 0;
   const where = and(
     relevanceFloor ? gte(projectTrends.relevanceScore, 0) : undefined,
+    hasExcludedTags ? notInArray(tags.code, excludedTagCodes) : undefined,
+    hasExcludedTags
+      ? getWhereClauseExcludeTags(db, excludedTagCodes)
+      : undefined,
     // Same predicate and the same query-wins rule as the listing, imported
     // rather than restated so the two cannot drift.
     resolveScope(scope, query) === "active"

--- a/packages/core/src/services/tags/find.ts
+++ b/packages/core/src/services/tags/find.ts
@@ -11,8 +11,42 @@ import {
 
 import { db } from "../../index";
 import * as schema from "../../schema";
+import { selectProjectIdsHavingAnyTag } from "../projects/find";
 
-export async function findTags() {
+/**
+ * Drop the excluded tags themselves from a tag listing, and stop projects
+ * carrying them from counting towards the tags they share with other projects.
+ *
+ * Both halves are needed: without the first, a deployment excluding `ai` still
+ * offers an `ai` chip leading to an empty page; without the second, a tag like
+ * `react` advertises a count the listing then fails to deliver.
+ */
+function getExcludedTagsFilters(excludedTagCodes: string[] | undefined) {
+  if (!excludedTagCodes || excludedTagCodes.length === 0) {
+    return { tagFilter: undefined, projectFilter: undefined };
+  }
+  return {
+    tagFilter: notInArray(schema.tags.code, excludedTagCodes),
+    projectFilter: notInArray(
+      schema.projectsToTags.projectId,
+      selectProjectIdsHavingAnyTag(db, excludedTagCodes),
+    ),
+  };
+}
+
+export interface ExcludedTagsOption {
+  /**
+   * Hide these tags, and every project carrying them, from the result. Set per
+   * deployment by the web app — see `apps/web/src/config/apps.ts`.
+   */
+  excludedTagCodes?: string[];
+}
+
+export async function findTags(options?: ExcludedTagsOption) {
+  const { tagFilter, projectFilter } = getExcludedTagsFilters(
+    options?.excludedTagCodes,
+  );
+
   const tags = await db
     .select({
       name: schema.tags.name,
@@ -24,8 +58,12 @@ export async function findTags() {
     .from(schema.tags)
     .leftJoin(
       schema.projectsToTags,
-      eq(schema.projectsToTags.tagId, schema.tags.id),
+      // ANDed into the JOIN, not the WHERE: a tag whose every project is
+      // excluded must still appear with a count of 0 rather than vanish
+      // (`count()` on the LEFT-joined column yields 0, which is the truth).
+      and(eq(schema.projectsToTags.tagId, schema.tags.id), projectFilter),
     )
+    .where(tagFilter)
     .groupBy(() => [
       schema.tags.name,
       schema.tags.code,
@@ -53,15 +91,18 @@ export type TagProject = {
  * Fetch all tags with counts and their top projects per tag (by stars). N is configurable via options (default 5).
  * Single query using subqueries: tags with count, ranked projects (ROW_NUMBER), top N per tag, then group in JS.
  */
-export async function findTagsWithProjects(options?: {
-  /** Restrict to these tag codes. Omit for every tag (the /tags page). */
-  codes?: string[];
-  /** Max number of top (by stars) projects to return per tag. Default 5. */
-  topProjectsPerTag?: number;
-}): Promise<TagWithProjectsItem[]> {
-  const { codes, topProjectsPerTag = 5 } = options ?? {};
+export async function findTagsWithProjects(
+  options?: ExcludedTagsOption & {
+    /** Restrict to these tag codes. Omit for every tag (the /tags page). */
+    codes?: string[];
+    /** Max number of top (by stars) projects to return per tag. Default 5. */
+    topProjectsPerTag?: number;
+  },
+): Promise<TagWithProjectsItem[]> {
+  const { codes, excludedTagCodes, topProjectsPerTag = 5 } = options ?? {};
   const codeFilter =
     codes && codes.length > 0 ? inArray(schema.tags.code, codes) : undefined;
+  const { tagFilter, projectFilter } = getExcludedTagsFilters(excludedTagCodes);
 
   // Sub-query 1: Tags with project count (same logic as findTags()). Used in main query FROM.
   const tagsWithCount = db
@@ -75,9 +116,9 @@ export async function findTagsWithProjects(options?: {
     .from(schema.tags)
     .leftJoin(
       schema.projectsToTags,
-      eq(schema.projectsToTags.tagId, schema.tags.id),
+      and(eq(schema.projectsToTags.tagId, schema.tags.id), projectFilter),
     )
-    .where(codeFilter)
+    .where(and(codeFilter, tagFilter))
     .groupBy(() => [
       schema.tags.name,
       schema.tags.code,
@@ -109,7 +150,14 @@ export async function findTagsWithProjects(options?: {
       eq(schema.projects.id, schema.projectsToTags.projectId),
     )
     .innerJoin(schema.repos, eq(schema.repos.id, schema.projects.repoId))
-    .where(and(notInArray(schema.projects.status, ["deprecated"]), codeFilter))
+    .where(
+      and(
+        notInArray(schema.projects.status, ["deprecated"]),
+        codeFilter,
+        tagFilter,
+        projectFilter,
+      ),
+    )
     .as("ranked");
 
   // Sub-query 3: From sub-query 2, keep only rows with rn <= topProjectsPerTag (top N projects per tag). Used in main query LEFT JOIN.
@@ -185,7 +233,7 @@ export async function findTagsWithProjects(options?: {
  */
 export async function findTagWithProjects(
   code: string,
-  options?: { topProjectsPerTag?: number },
+  options?: ExcludedTagsOption & { topProjectsPerTag?: number },
 ): Promise<TagWithProjectsItem | null> {
   const [tag] = await findTagsWithProjects({ ...options, codes: [code] });
   return tag ?? null;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,8 +132,8 @@ importers:
         specifier: ^12.23.16
         version: 12.23.22(@emotion/is-prop-valid@1.2.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       nanoid:
-        specifier: ^5.1.5
-        version: 5.1.5
+        specifier: ^5.1.16
+        version: 5.1.16
       next:
         specifier: 'catalog:'
         version: 16.3.0(@babel/core@7.28.5)(@playwright/test@1.47.2)(@types/node@24.12.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -299,8 +299,8 @@ importers:
         specifier: ^7.0.3
         version: 7.0.3
       dompurify:
-        specifier: ^3.4.12
-        version: 3.4.12
+        specifier: ^3.4.13
+        version: 3.4.13
       framer-motion:
         specifier: ^4.1.17
         version: 4.1.17(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -659,8 +659,8 @@ importers:
         specifier: ^3.7.1
         version: 3.7.1
       nanoid:
-        specifier: ^5.1.5
-        version: 5.1.5
+        specifier: ^5.1.16
+        version: 5.1.16
       slugify:
         specifier: ^1.6.6
         version: 1.6.6
@@ -5114,8 +5114,8 @@ packages:
     resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -6866,13 +6866,13 @@ packages:
       react: '*'
       react-dom: '*'
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@5.1.5:
-    resolution: {integrity: sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==}
+  nanoid@5.1.16:
+    resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -13432,7 +13432,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -15465,9 +15465,9 @@ snapshots:
       stacktrace-js: 2.0.2
       stylis: 4.3.0
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
-  nanoid@5.1.5: {}
+  nanoid@5.1.16: {}
 
   natural-compare-lite@1.4.0: {}
 
@@ -15888,25 +15888,25 @@ snapshots:
 
   postcss@8.5.10:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.5.16:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,13 @@
     "build": {
       "dependsOn": ["^build"],
       "outputs": [".next/**", "!.next/cache/**", "public/data/**", "build/**"],
-      "env": ["POSTGRES_URL", "GITHUB_ACCESS_TOKEN", "STAGE", "NODE_ENV"]
+      "env": [
+        "BESTOFJS_APP",
+        "POSTGRES_URL",
+        "GITHUB_ACCESS_TOKEN",
+        "STAGE",
+        "NODE_ENV"
+      ]
     },
     "lint": {
       "dependsOn": ["^lint"]


### PR DESCRIPTION
## Goal

Spike for #459: a "No AI" version of Best of JS, running as a **second deployment of the same code** rather than a second app or a `/no-ai` route prefix.

The bet being tested: the whole site can be filtered — home, `/projects`, `/tags`, rankings, search palette — with no app-specific code path, and without the complexity getting out of hand.

Three principles:

- **Deployment identity, not a feature flag.** One env var (`BESTOFJS_APP`) picks the app; a per-app table maps it to the tags that app hides. Nothing else in the codebase branches on which app it is.
- **The domain layer stays app-agnostic.** `@repo/core` gains "exclude these tags" as an ordinary query capability, reusable by anyone — the admin app could expose include/exclude filters on top of the same parameter. It never learns that a `noai` deployment exists.
- **Bound in exactly one place.** The web app has a single data façade that pre-binds the deployment's excluded tags to every listing query. Passing it per call site was the alternative, and it fails silently: a page that forgets looks completely normal, it just serves the projects the deployment exists to hide.

Whether the complexity is acceptable is a judgement to make on the diff, not against a metric agreed upfront.

## Required setup — to review this PR

This PR does nothing on its own — the deployment has to declare which app it is. This section only makes the `noai` branch preview render as the variant, so the spike can be reviewed. Running it for real on its own domain is a separate, post-merge job: see the [Manual setup comment](https://github.com/bestofjs/bestofjs/pull/483#issuecomment-5650130017).

- Set `BESTOFJS_APP=noai` from the Vercel dashboard of the existing `bestofjs` project, scoped to the **Preview** environment / the `noai` branch.
- The value must match a key of the app registry introduced here (`main` | `noai`). It is the same string the registry uses to look up the excluded tags, the badge label and the host.
- Unset defaults to `main`, so production and local dev are untouched by this PR. Until it is set, the Vercel preview for this branch renders as the **main** app: an unchanged-looking preview is the expected first result, not a failure.
- A value outside the registry (`no-ai`, `noAI`, ...) fails env validation and the build stops. Deliberate: a silent fallback to `main` would serve AI projects on the No AI site while looking completely normal.

## Main changes

- Core query layer gains an `excludedTagCodes` parameter, covering project listings, tag listings, tag counts and related-tag suggestions.
- Tag counts stay truthful: a project carrying a hidden tag stops counting towards the other tags it shares, so a tag can no longer advertise a count the listing fails to deliver.
- Web app data façade binds the deployment's excluded tags to every listing query. Editorial exclusions (`TAGS_EXCLUDED_FROM_RANKINGS`) and deployment exclusions merge — one never replaces the other.
- The static-JSON collection is filtered once where it is loaded, which covers the ⌘K search palette and the monthly rankings lookup together.
- Monthly rankings stay full-length rather than truncated: the archived ranking is resolved and filtered before the row limit is applied.
- `/projects` gains an `?ai=1|0` parameter, modelled on the existing `scope` filter — a filter whose default the deployment sets and the URL opts out of. The control behaves identically on both deployments; only the default differs.
- Project detail pages are unchanged on both deployments. The deployment changes what gets *surfaced*, not what exists — which is also what makes the `?ai=1` opt-out coherent.
- A "No AI" badge in the header marks which deployment you are on. Most of the site renders identically on both, so without it there is no way to tell.

## How to test

Locally, `BESTOFJS_APP` defaults to `main` — the app behaves exactly as today. To exercise the spike, set `BESTOFJS_APP=noai` (`.env` or inline) and run `pnpm -F web dev`:

- Header shows the `No AI` badge on every page.
- `/` — Hot Projects, Recently Added, Featured and Popular Tags contain no AI-tagged projects.
- `/projects` — no AI projects; `?ai=1` brings them back; related tag suggestions contain no hidden tags.
- `/tags` — `ai` is absent, and the counts of the remaining tags are lower than on the main deployment.
- ⌘K palette — searching `ai`, `openai`, `n8n` returns no hidden projects.
- `/rankings/monthly/2026/07` (any month) — no AI projects, and still a full page of results rather than a short one.
- `/projects/n8n` (or any AI project) — still renders. This is intended.

Then `BESTOFJS_APP=main` and confirm every page above is identical to `develop`.

## Out of scope

Deliberately left out of the spike, all listed in #459:

- UI copy, explanations and cross-links between the two versions.
- `robots` / `sitemap` / canonical URL per deployment. `APP_CANONICAL_URL` is hardcoded, which is the real blocker before pointing DNS at this — not indexing rules.
- Hall of Fame and the global project count.
- Widening the excluded tags beyond `ai` (`skills`, `mcp`, ...), which depends on the separate tagging pass.

## Screenshots

<img width="1197" height="1009" alt="image" src="https://github.com/user-attachments/assets/001a7873-3ab6-4675-8338-c528f65de2d1" />


