### PR TITLE
Fix description/URL overrides on DB-driven home, list and search pages

### DIFF
--- a/apps/web/src/app/projects/project-adapter.ts
+++ b/apps/web/src/app/projects/project-adapter.ts
@@ -1,5 +1,9 @@
 import type { ProjectStatus } from "@repo/core/constants";
-import type { ProjectWithTrends } from "@repo/core/services/projects";
+import {
+  type ProjectWithTrends,
+  resolveProjectDescription,
+  resolveProjectURL,
+} from "@repo/core/services/projects";
 
 /**
  * `BestOfJS.Project` shape plus `activityScore`, which doesn't exist on the
@@ -30,7 +34,11 @@ export function toTrendsProject(
   return {
     slug: row.slug,
     name: row.name,
-    description: row.description,
+    description: resolveProjectDescription({
+      description: row.description,
+      overrideDescription: row.overrideDescription,
+      repoDescription: row.repo.description,
+    }),
     // `added_at` = Best of JS addition date (`projects.created_at`);
     // `created_at` = GitHub repo creation date (`repos.created_at`), matching
     // the pre-migration static API and the "Created" sort key.
@@ -57,7 +65,12 @@ export function toTrendsProject(
     npm: row.packageName ?? "",
     downloads: row.monthlyDownloads ?? 0,
     logo: row.logo ?? "",
-    url: row.url ?? "",
+    url:
+      resolveProjectURL({
+        overrideURL: row.overrideURL,
+        repoHomepage: row.repo.homepage,
+        url: row.url,
+      }) ?? "",
     status: row.status,
     tags: row.tags
       .map((code) => tagsByCode.get(code))

--- a/packages/core/src/services/projects/find-with-trends.ts
+++ b/packages/core/src/services/projects/find-with-trends.ts
@@ -202,7 +202,9 @@ export async function findProjectsWithTrends({
       slug: projects.slug,
       name: projects.name,
       description: projects.description,
+      overrideDescription: projects.overrideDescription,
       url: projects.url,
+      overrideURL: projects.overrideURL,
       createdAt: projects.createdAt,
       status: projects.status,
       logo: projects.logo,
@@ -216,6 +218,8 @@ export async function findProjectsWithTrends({
         last_commit: repos.last_commit,
         contributor_count: repos.contributor_count,
         created_at: repos.created_at,
+        description: repos.description,
+        homepage: repos.homepage,
       },
       stars: starsExpression,
       trends: {

--- a/packages/core/src/services/projects/project-helpers.ts
+++ b/packages/core/src/services/projects/project-helpers.ts
@@ -9,10 +9,11 @@ import type { OneYearSnapshots, ProjectDetails } from ".";
 
 export function getProjectDescription(project: ProjectDetails) {
   invariant(project.repo);
-  const repoDescription = project.repo.description;
-  return project.overrideDescription
-    ? project.description
-    : repoDescription || project.description;
+  return resolveProjectDescription({
+    description: project.description,
+    overrideDescription: project.overrideDescription,
+    repoDescription: project.repo.description,
+  });
 }
 
 export function getProjectRepositoryURL(project: ProjectDetails) {
@@ -21,10 +22,42 @@ export function getProjectRepositoryURL(project: ProjectDetails) {
 
 export function getProjectURL(project: ProjectDetails) {
   invariant(project.repo);
-  if (project.overrideURL) return project.url;
-  const homepage = project.repo.homepage;
+  return resolveProjectURL({
+    overrideURL: project.overrideURL,
+    repoHomepage: project.repo.homepage,
+    url: project.url,
+  });
+}
 
-  return homepage && isValidProjectURL(homepage) ? homepage : project.url;
+/**
+ * Shared by `getProjectDescription()` and any query (e.g.
+ * `findProjectsWithTrends()`) that needs the same override rule without
+ * loading the full `ProjectDetails` shape.
+ */
+export function resolveProjectDescription({
+  description,
+  overrideDescription,
+  repoDescription,
+}: {
+  description: string;
+  overrideDescription: boolean | null;
+  repoDescription: string | null;
+}) {
+  return overrideDescription ? description : repoDescription || description;
+}
+
+/** Shared by `getProjectURL()` and `findProjectsWithTrends()` — see `resolveProjectDescription()`. */
+export function resolveProjectURL({
+  overrideURL,
+  repoHomepage,
+  url,
+}: {
+  overrideURL: boolean | null;
+  repoHomepage: string | null;
+  url: string | null;
+}) {
+  if (overrideURL) return url;
+  return repoHomepage && isValidProjectURL(repoHomepage) ? repoHomepage : url;
 }
 
 export function getProjectTrends(snapshots: OneYearSnapshots[], date?: Date) {


### PR DESCRIPTION
## Goal

Home, list and search pages were recently migrated to be DB-driven (replacing the static API). That migration introduced a regression: project description and homepage URL always came from the `projects` table, ignoring the GitHub repo data and the admin override checkboxes.

- Restore the intended behavior: description/URL come from the GitHub repo (`repos.description` / `repos.homepage`) by default, unless overridden per-project via the "override description" / "override URL" checkboxes in the admin project form
- Extract the override logic into shared `resolveProjectDescription()` / `resolveProjectURL()` helpers, reused by the project detail page, the legacy static-API builder, and the new DB-backed query — single source of truth, no duplicated logic

## How to test

Check the homepage render the correct description and home page links for Node.js, React and VSCode projects.

## Screenshots

#### Before

<img width="1156" height="1069" alt="image" src="https://github.com/user-attachments/assets/b71d7914-8e0e-49c7-a0c2-83c15fa54e70" />

#### After

<img width="1088" height="926" alt="image" src="https://github.com/user-attachments/assets/9edb1079-84ac-4bc0-baa9-e55b9f24c06b" />
